### PR TITLE
[All-Feat] github action을 이용하여 slack 연동

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -2,7 +2,7 @@ name: PR Slack Notification
 
 on:
     pull_request:
-        types: [review_requested]
+        types: [opened, review_requested]
 
 jobs:
     notify_slack:
@@ -54,3 +54,5 @@ jobs:
                   )
 
                   curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
+            - name: Debug Event
+              run: cat $GITHUB_EVENT_PATH

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,0 +1,56 @@
+name: PR Slack Notification
+
+on:
+    pull_request:
+        types: [review_requested]
+
+jobs:
+    notify_slack:
+        name: Send PR Notification to Reviewers
+        runs-on: ubuntu-latest
+        steps:
+            - name: Load Slack User Mapping
+              id: load_mapping
+              env:
+                  SLACK_USER_MAPPING: ${{ secrets.SLACK_USER_MAPPING }}
+              run: |
+                  declare -A USER_MAP
+                  while IFS="," read -r key value; do
+                    USER_MAP[$key]=$(echo $value | tr -d '"')
+                  done < <(echo "$SLACK_USER_MAPPING" | jq -r 'to_entries | map("\(.key),\(.value)") | .[]')
+
+                  REVIEWERS=$(jq -r '.pull_request.requested_reviewers | map(.login) | join(", ")' $GITHUB_EVENT_PATH)
+                  MENTION_LIST=""
+
+                  for reviewer in ${REVIEWERS//,/ }; do
+                    if [[ -n "${USER_MAP[$reviewer]}" ]]; then
+                      MENTION_LIST+="<@${USER_MAP[$reviewer]}> "
+                    fi
+                  done
+
+                  echo "mention_list=$MENTION_LIST" >> $GITHUB_ENV
+
+            - name: Send Slack Notification
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+                  PR_TITLE: ${{ github.event.pull_request.title }}
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  PR_CREATOR: ${{ github.event.pull_request.user.login }}
+                  PR_REVIEWERS: ${{ env.mention_list }}
+              run: |
+                  if [ -z "$PR_REVIEWERS" ]; then
+                    echo "No reviewers, skipping Slack notification."
+                    exit 0
+                  fi
+
+                  PAYLOAD=$(jq -n \
+                    --arg prCreator "$PR_CREATOR" \
+                    --arg prTitle "$PR_TITLE" \
+                    --arg prUrl "$PR_URL" \
+                    --arg prReviewers "$PR_REVIEWERS" \
+                    '{
+                      text: "📢 *PR 리뷰 요청*\n👤 *작성자*: \($prCreator)\n🔗 *PR*: <\($prUrl)|\($prTitle)>\n🔍 *리뷰어*: \($prReviewers)"
+                    }'
+                  )
+
+                  curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -54,5 +54,3 @@ jobs:
                   )
 
                   curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
-            - name: Debug Event
-              run: cat $GITHUB_EVENT_PATH


### PR DESCRIPTION
github에서 PR을 생성하거나 리뷰어를 할당할 때마다, slack에 해당 리뷰어가 멘션됩니다.

<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #39 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- github 연동을 위해 slack app 생성
- slack app에서 webhook url 생성
- github secret에 slack webhook url 추가
- github secret에 `github id` - `slack id` 매핑 추가
- github action을 동작시킬 `slack-notification.yml` 작성

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
https://ek12mv2.tistory.com/486 해당 포스팅과 GPT o1의 도움을 받아 작성했습니당
깃허브 액션을 로컬 환경에서 돌려보기가 힘들어서, 잘못된 동작이 있다면 차차 고쳐나가야 할 것 같습니다,,