### PR TITLE
[ALL-Feat] PR open 시 리뷰 요청 알림의 중복 전송을 방지

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -48,12 +48,15 @@ jobs:
         run: |
           if [ "${{ steps.read_old.outputs.old_reviewers }}" = "${{ steps.prepare_new.outputs.new_reviewers }}" ]; then
             echo "⚠️ Same reviewer set -> skip notification"
+            echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
           fi
           echo "✅ New/different reviewer set -> proceed"
+          echo "skip=false" >> $GITHUB_OUTPUT
 
       # 5) github - slack 아이디 매핑을 Load
       - name: Load Slack User Mapping
+        if: ${{ steps.check_diff.outputs.skip == 'false' }}
         id: load_mapping
         env:
           SLACK_USER_MAPPING: ${{ secrets.SLACK_USER_MAPPING }}
@@ -76,6 +79,7 @@ jobs:
 
       # 6) Slack 알림 전송
       - name: Send Slack Notification
+        if: ${{ steps.check_diff.outputs.skip == 'false' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -102,13 +106,13 @@ jobs:
 
       # 7) 새 reviewer list를 임시 파일로 생성 및 캐시에 업데이트
       - name: Save new reviewer list
-        if: always()
+        if: ${{ steps.check_diff.outputs.skip == 'false' }}
         run: |
           mkdir -p .reviewer-state
           echo "${{ steps.prepare_new.outputs.new_reviewers }}" > .reviewer-state/old_reviewers.txt
 
       - name: Save cache
-        if: always()
+        if: ${{ steps.check_diff.outputs.skip == 'false' }}
         uses: actions/cache@v3
         with:
           path: ./.reviewer-state

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, review_requested]
 
 concurrency:
-  group: slack-notification
+  group: slack-notification-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,60 +1,60 @@
 name: PR Slack Notification
 
 on:
-    pull_request:
-        types: [opened, review_requested]
-        
+  pull_request:
+    types: [opened, review_requested]
+
 concurrency:
-    group: slack-notification
-    cancel-in-progress: false
+  group: slack-notification
+  cancel-in-progress: false
 
 jobs:
-    notify_slack:
-        name: Send PR Notification to Reviewers
-        runs-on: ubuntu-latest
-        steps:
-            - name: Load Slack User Mapping
-              id: load_mapping
-              env:
-                  SLACK_USER_MAPPING: ${{ secrets.SLACK_USER_MAPPING }}
-              run: |
-                  declare -A USER_MAP
-                  while IFS="," read -r key value; do
-                    USER_MAP[$key]=$(echo $value | tr -d '"')
-                  done < <(echo "$SLACK_USER_MAPPING" | jq -r 'to_entries | map("\(.key),\(.value)") | .[]')
+  notify_slack:
+    name: Send PR Notification to Reviewers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load Slack User Mapping
+        id: load_mapping
+        env:
+          SLACK_USER_MAPPING: ${{ secrets.SLACK_USER_MAPPING }}
+        run: |
+          declare -A USER_MAP
+          while IFS="," read -r key value; do
+            USER_MAP[$key]=$(echo $value | tr -d '"')
+          done < <(echo "$SLACK_USER_MAPPING" | jq -r 'to_entries | map("\(.key),\(.value)") | .[]')
 
-                  REVIEWERS=$(jq -r '.pull_request.requested_reviewers | map(.login) | join(", ")' $GITHUB_EVENT_PATH)
-                  MENTION_LIST=""
+          REVIEWERS=$(jq -r '.pull_request.requested_reviewers | map(.login) | join(", ")' $GITHUB_EVENT_PATH)
+          MENTION_LIST=""
 
-                  for reviewer in ${REVIEWERS//,/ }; do
-                    if [[ -n "${USER_MAP[$reviewer]}" ]]; then
-                      MENTION_LIST+="<@${USER_MAP[$reviewer]}> "
-                    fi
-                  done
+          for reviewer in ${REVIEWERS//,/ }; do
+            if [[ -n "${USER_MAP[$reviewer]}" ]]; then
+              MENTION_LIST+="<@${USER_MAP[$reviewer]}> "
+            fi
+          done
 
-                  echo "mention_list=$MENTION_LIST" >> $GITHUB_ENV
+          echo "mention_list=$MENTION_LIST" >> $GITHUB_ENV
 
-            - name: Send Slack Notification
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-                  PR_TITLE: ${{ github.event.pull_request.title }}
-                  PR_URL: ${{ github.event.pull_request.html_url }}
-                  PR_CREATOR: ${{ github.event.pull_request.user.login }}
-                  PR_REVIEWERS: ${{ env.mention_list }}
-              run: |
-                  if [ -z "$PR_REVIEWERS" ]; then
-                    echo "No reviewers, skipping Slack notification."
-                    exit 0
-                  fi
+      - name: Send Slack Notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_CREATOR: ${{ github.event.pull_request.user.login }}
+          PR_REVIEWERS: ${{ env.mention_list }}
+        run: |
+          if [ -z "$PR_REVIEWERS" ]; then
+            echo "No reviewers, skipping Slack notification."
+            exit 0
+          fi
 
-                  PAYLOAD=$(jq -n \
-                    --arg prCreator "$PR_CREATOR" \
-                    --arg prTitle "$PR_TITLE" \
-                    --arg prUrl "$PR_URL" \
-                    --arg prReviewers "$PR_REVIEWERS" \
-                    '{
-                      text: "📢 *PR 리뷰 요청*\n👤 *작성자*: \($prCreator)\n🔗 *PR*: <\($prUrl)|\($prTitle)>\n🔍 *리뷰어*: \($prReviewers)"
-                    }'
-                  )
+          PAYLOAD=$(jq -n \
+            --arg prCreator "$PR_CREATOR" \
+            --arg prTitle "$PR_TITLE" \
+            --arg prUrl "$PR_URL" \
+            --arg prReviewers "$PR_REVIEWERS" \
+            '{
+              text: "📢 *PR 리뷰 요청*\n👤 *작성자*: \($prCreator)\n🔗 *PR*: <\($prUrl)|\($prTitle)>\n🔍 *리뷰어*: \($prReviewers)"
+            }'
+          )
 
-                  curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
+          curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: slack-notification-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   notify_slack:

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -3,6 +3,10 @@ name: PR Slack Notification
 on:
     pull_request:
         types: [opened, review_requested]
+        
+concurrency:
+    group: slack-notification
+    cancel-in-progress: false
 
 jobs:
     notify_slack:

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -13,6 +13,46 @@ jobs:
     name: Send PR Notification to Reviewers
     runs-on: ubuntu-latest
     steps:
+      # 1) 캐시에서 reviewer list 복원
+      - name: Restore reviewer cache
+        id: cache_restore
+        uses: actions/cache@v3
+        with:
+          path: ./.reviewer-state  # 캐시 저장 경로
+          key: pr-reviewers-${{ github.event.pull_request.number }}
+
+      # 2) 이전 reviewer list를 Load
+      - name: Read old reviewer list
+        id: read_old
+        run: |
+          mkdir -p .reviewer-state
+          if [ -f .reviewer-state/old_reviewers.txt ]; then
+            OLD_REVIEWERS=$(cat .reviewer-state/old_reviewers.txt)
+          else
+            OLD_REVIEWERS=""
+          fi
+          echo "old_reviewers=$OLD_REVIEWERS" >> $GITHUB_OUTPUT
+
+      # 3) 새로운 reviewer list 생성
+      - name: Prepare new reviewer list
+        id: prepare_new
+        run: |
+          # "requested_reviewers": [{ "login": "kwon204" }, ...]
+          NEW_REVIEWERS=$(jq -r '.pull_request.requested_reviewers | map(.login) | sort | join(",")' $GITHUB_EVENT_PATH)
+          echo "new_reviewers=$NEW_REVIEWERS"
+          echo "new_reviewers=$NEW_REVIEWERS" >> $GITHUB_OUTPUT
+
+      # 4) reviewer list의 중복 여부 판별
+      - name: Check if same as old
+        id: check_diff
+        run: |
+          if [ "${{ steps.read_old.outputs.old_reviewers }}" = "${{ steps.prepare_new.outputs.new_reviewers }}" ]; then
+            echo "⚠️ Same reviewer set -> skip notification"
+            exit 0
+          fi
+          echo "✅ New/different reviewer set -> proceed"
+
+      # 5) github - slack 아이디 매핑을 Load
       - name: Load Slack User Mapping
         id: load_mapping
         env:
@@ -34,6 +74,7 @@ jobs:
 
           echo "mention_list=$MENTION_LIST" >> $GITHUB_ENV
 
+      # 6) Slack 알림 전송
       - name: Send Slack Notification
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -58,3 +99,17 @@ jobs:
           )
 
           curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
+
+      # 7) 새 reviewer list를 임시 파일로 생성 및 캐시에 업데이트
+      - name: Save new reviewer list
+        if: always()
+        run: |
+          mkdir -p .reviewer-state
+          echo "${{ steps.prepare_new.outputs.new_reviewers }}" > .reviewer-state/old_reviewers.txt
+
+      - name: Save cache
+        if: always()
+        uses: actions/cache@v3
+        with:
+          path: ./.reviewer-state
+          key: pr-reviewers-${{ github.event.pull_request.number }}

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -46,10 +46,10 @@ jobs:
       - name: Check if same as old
         id: check_diff
         run: |
-        echo "Comparing reviewers..."
-        echo "Old: [$OLD_REVIEWERS]"
-        echo "New: [$NEW_REVIEWERS]"
-        echo "compare: $OLD_REVIEWERS = $NEW_REVIEWERS"
+          echo "Comparing reviewers..."
+          echo "Old: [$OLD_REVIEWERS]"
+          echo "New: [$NEW_REVIEWERS]"
+          echo "compare: $OLD_REVIEWERS = $NEW_REVIEWERS"
           if [ "${{ steps.read_old.outputs.old_reviewers }}" = "${{ steps.prepare_new.outputs.new_reviewers }}" ]; then
             echo "⚠️ Same reviewer set -> skip notification"
             echo "skip=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -46,6 +46,10 @@ jobs:
       - name: Check if same as old
         id: check_diff
         run: |
+        echo "Comparing reviewers..."
+        echo "Old: [$OLD_REVIEWERS]"
+        echo "New: [$NEW_REVIEWERS]"
+        echo "compare: $OLD_REVIEWERS = $NEW_REVIEWERS"
           if [ "${{ steps.read_old.outputs.old_reviewers }}" = "${{ steps.prepare_new.outputs.new_reviewers }}" ]; then
             echo "⚠️ Same reviewer set -> skip notification"
             echo "skip=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: slack-notification-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   notify_slack:
@@ -46,10 +46,6 @@ jobs:
       - name: Check if same as old
         id: check_diff
         run: |
-          echo "Comparing reviewers..."
-          echo "Old: [$OLD_REVIEWERS]"
-          echo "New: [$NEW_REVIEWERS]"
-          echo "compare: $OLD_REVIEWERS = $NEW_REVIEWERS"
           if [ "${{ steps.read_old.outputs.old_reviewers }}" = "${{ steps.prepare_new.outputs.new_reviewers }}" ]; then
             echo "⚠️ Same reviewer set -> skip notification"
             echo "skip=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
action cache를 사용해 특정 pr에 등록된 리뷰어 리스트를 캐싱하고, 이 리스트의 내용이 업데이트될 때만(diff가 생길 때만) 알림을 전송하도록 합니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
조금 전 알게 된 사실인데 action cache는 캐시를 업데이트하거나 삭제하는 기능을 제공하지 않는다고 하네요.. 일단 한 번에 여러 action workflow가 생성되면 가장 최근의 것만 실행하도록 해서 중복 문제를 임시로 해결해 놨고, 캐시 부분은 나중에 제대로 손봐야 할 것 같습니다.