### PR TITLE
[All-Fix] git hook의 로컬 검증 코드 실행 기준을 변경

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -14,8 +14,7 @@ frontend_files=$(echo "$files" | grep -E "^frontend/.*\.(js|ts|jsx|tsx)$" | sed 
 backend_files=$(echo "$files" | grep -E "^backend/.*\.(java|yml)$" | sed 's|^backend/||')
 
 # 현재 브랜치 이름 get
-current_branch_name=$(git rev-parse --abbrev-ref HEAD)
-
+current_branch=$(git rev-parse --abbrev-ref HEAD)
 # 브랜치에서 fe|be 부분만 추출
 part=$(echo "$current_branch" | cut -d'/' -f2)
 
@@ -24,7 +23,6 @@ part=$(echo "$current_branch" | cut -d'/' -f2)
 if [ "$part" = "fe" ]; then
   # eslint 실행을 위해 frontend 폴더로 이동
   cd frontend
-
   echo "[pre-commit] ⏳ Checking lint for staged files..."
   # Lint fix 실행
 if ! pnpm exec eslint --fix $frontend_files; then
@@ -39,7 +37,6 @@ fi
   echo "[pre-commit] ✅ Lint passed. Proceeding with commit."
   echo ""
 fi
-
 
 
 #################### 백엔드 스크립트 ####################

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -13,10 +13,15 @@ frontend_files=$(echo "$files" | grep -E "^frontend/.*\.(js|ts|jsx|tsx)$" | sed 
 # !!! 확장자 수정해 주세요(문법 검사할 파일들) !!!
 backend_files=$(echo "$files" | grep -E "^backend/.*\.(java|yml)$" | sed 's|^backend/||')
 
+# 현재 브랜치 이름 get
+current_branch_name=$(git rev-parse --abbrev-ref HEAD)
+
+# 브랜치에서 fe|be 부분만 추출
+part=$(echo "$current_branch" | cut -d'/' -f2)
 
 #################### 프론트엔드 스크립트 ####################
 
-if [ -n "$frontend_files" ]; then
+if [ "$part" = "fe" ]; then
   # eslint 실행을 위해 frontend 폴더로 이동
   cd frontend
 
@@ -39,7 +44,7 @@ fi
 
 #################### 백엔드 스크립트 ####################
 
-if [ -n "$backend_files" ]; then
+if [ "$part" = "be" ]; then
   cd backend
 
   # Do something

--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -24,7 +24,7 @@ frontend_files=$(echo "$files" | grep -E "^frontend/" | sed 's|^frontend/||')
 backend_files=$(echo "$files" | grep -E "^backend/" | sed 's|^backend/||')
 
 # 정규식 - 브랜치 네이밍 검사
-branch_name_regex="^(feature|refactor|hotfix)/(fe|be)/[a-z0-9-]+$"
+branch_name_regex="^(feature|refactor|bugfix)/(fe|be)/[a-z0-9-]+$"
 
 echo "[pre-push] ⏳ Validating changes before pushing to $remote_name ... ($remote_url)"
 

--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -28,10 +28,8 @@ branch_name_regex="^(feature|refactor|hotfix)/(fe|be)/[a-z0-9-]+$"
 
 echo "[pre-push] ⏳ Validating changes before pushing to $remote_name ... ($remote_url)"
 
-# 브랜치 네이밍 검사
-current_branch_name=$(git rev-parse --abbrev-ref HEAD)
-if ! echo "$current_branch_name" | grep -Eq "$branch_name_regex"; then
-  echo "[pre-push] ❌ Invalid branch name: $current_branch_name"
+if ! echo "$current_branch" | grep -Eq "$branch_name_regex"; then
+  echo "[pre-push] ❌ Invalid branch name: $current_branch"
   echo "[pre-push] Branch name must match the following pattern: "
   echo "[pre-push] <tag>/<fe|be>/..."
   exit 1

--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -29,18 +29,21 @@ branch_name_regex="^(feature|refactor|hotfix)/(fe|be)/[a-z0-9-]+$"
 echo "[pre-push] ⏳ Validating changes before pushing to $remote_name ... ($remote_url)"
 
 # 브랜치 네이밍 검사
-branch_name=$(git rev-parse --abbrev-ref HEAD)
-if ! echo "$branch_name" | grep -Eq "$branch_name_regex"; then
-  echo "[pre-push] ❌ Invalid branch name: $branch_name"
+current_branch_name=$(git rev-parse --abbrev-ref HEAD)
+if ! echo "$current_branch_name" | grep -Eq "$branch_name_regex"; then
+  echo "[pre-push] ❌ Invalid branch name: $current_branch_name"
   echo "[pre-push] Branch name must match the following pattern: "
   echo "[pre-push] <tag>/<fe|be>/..."
   exit 1
 fi
 
+# 브랜치에서 fe|be 부분만 추출
+part=$(echo "$current_branch" | cut -d'/' -f2)
+
 
 #################### 프론트엔드 스크립트 ####################
 
-if [ -n "$frontend_files" ]; then
+if [ "$part" = "fe" ]; then
   # pnpm 실행을 위해 frontend 폴더로 이동
   cd frontend
 
@@ -65,9 +68,7 @@ fi
 
 #################### 백엔드 스크립트 ####################
 
-#################### 백엔드 스크립트 ####################
-
-if [ -n "$backend_files" ]; then
+if [ "$part" = "be" ]; then
   cd backend
 
   echo "[pre-push] ⏳ Running backend build with Spring Profile '$SPRING_PROFILE'..."


### PR DESCRIPTION
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
git hook의 로컬 검증 코드 실행 조건을 변경했습니다. 이전에는 작업자의 환경(fe, be)과 상관없이 변경된 파일이 있으면 해당 파일들에 대해 모두 검증을 수행하도록 했는데, 생각해보니 fe, be 환경이 달라서 서로의 로컬 테스트를 돌릴 수가 없네요. 굳이 다른 파트의 테스트를 돌릴 필요도 없었던 것 같구요..

따라서 로컬 검증 코드 실행 기준을 브랜치 네이밍으로 변경했습니다.
브랜치 이름을 파싱해서 파트명(fe | be)을 추출합니다. 이후 해당 파트의 로컬 검증 코드만을 수행합니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
브랜치 네임을 `hotfix` -> `bugfix` 로 수정하여 다시 PR 오픈합니다