### PR TITLE
[FE-Feat] 캘린더 드래그 또는 클릭으로 시간 선택 구현

### DIFF
--- a/frontend/src/components/Calendar/Core/SelectedWeek.tsx
+++ b/frontend/src/components/Calendar/Core/SelectedWeek.tsx
@@ -7,7 +7,7 @@ import { weekStyle } from './index.css';
 import { WeekCell } from './WeekCell';
 
 export const SelectedWeek = () => {
-  const { selected, dates, handleChangeWeek } = useCalendarContext();
+  const { selected, dates } = useCalendarContext();
   const today = new Date();
 
   return (
@@ -22,7 +22,6 @@ export const SelectedWeek = () => {
           day={day}
           isToday={isSameDate(dates[i], today)}
           key={day}
-          onClickHandler={() => handleChangeWeek(dates[i])}
           selected={isSameDate(dates[i], selected)}
         />)}
     </div>

--- a/frontend/src/components/Calendar/Core/TimeControlButton.tsx
+++ b/frontend/src/components/Calendar/Core/TimeControlButton.tsx
@@ -15,7 +15,7 @@ export const TimeControlButton = ({ type }: { type: 'prev' | 'next' | 'today' })
           className={timeControlButtonStyle({ order: 'first' })}
           onClick={handleClickPrevWeek}
         >
-          <ChevronLeft fill={vars.color.Ref.Netural[600]} />
+          <ChevronLeft clickable fill={vars.color.Ref.Netural[600]} />
         </button>
       );
     case 'next':
@@ -25,7 +25,7 @@ export const TimeControlButton = ({ type }: { type: 'prev' | 'next' | 'today' })
           className={timeControlButtonStyle({ order: 'last' })} 
           onClick={handleClickNextWeek}
         >
-          <ChevronRight fill={vars.color.Ref.Netural[600]} />
+          <ChevronRight clickable fill={vars.color.Ref.Netural[600]} />
         </button>
       );
     case 'today':

--- a/frontend/src/components/Calendar/Core/WeekCell.tsx
+++ b/frontend/src/components/Calendar/Core/WeekCell.tsx
@@ -1,5 +1,3 @@
-import type { MouseEvent } from 'react';
-
 import type { WEEKDAY } from '@/constants/date';
 
 import { Text } from '../../Text';
@@ -10,7 +8,6 @@ interface WeekCellProps {
   date: Date;
   isToday: boolean;
   selected: boolean;
-  onClickHandler?: (event: MouseEvent<HTMLDivElement>) => void;
 }
 
 export const WeekCell = ({ day, date, isToday, selected }: WeekCellProps) => {

--- a/frontend/src/components/Calendar/Core/WeekCell.tsx
+++ b/frontend/src/components/Calendar/Core/WeekCell.tsx
@@ -10,10 +10,10 @@ interface WeekCellProps {
   date: Date;
   isToday: boolean;
   selected: boolean;
-  onClickHandler: (event: MouseEvent<HTMLDivElement>) => void;
+  onClickHandler?: (event: MouseEvent<HTMLDivElement>) => void;
 }
 
-export const WeekCell = ({ day, date, isToday, selected, onClickHandler }: WeekCellProps) => {
+export const WeekCell = ({ day, date, isToday, selected }: WeekCellProps) => {
   const dayStyleName = (day: WEEKDAY) => {
     switch (day) {
       case 'SUN':
@@ -31,7 +31,6 @@ export const WeekCell = ({ day, date, isToday, selected, onClickHandler }: WeekC
         day: dayStyleName(day), 
         state: selected ? 'selected' : 'default', 
       })}
-      onClick={onClickHandler}
     >
       <Text typo='b3M'>{day}</Text>
       <div className={weekCellBoxStyle({ day: isToday ? 'today' : dayStyleName(day) })}>

--- a/frontend/src/components/Calendar/Core/WeekCell.tsx
+++ b/frontend/src/components/Calendar/Core/WeekCell.tsx
@@ -31,6 +31,7 @@ export const WeekCell = ({ day, date, isToday, selected }: WeekCellProps) => {
         day: dayStyleName(day), 
         state: selected ? 'selected' : 'default', 
       })}
+      key={selected ? Date.now() : ''}
     >
       <Text typo='b3M'>{day}</Text>
       <div className={weekCellBoxStyle({ day: isToday ? 'today' : dayStyleName(day) })}>

--- a/frontend/src/components/Calendar/Core/index.css.ts
+++ b/frontend/src/components/Calendar/Core/index.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
+import { fadeHighlightProps } from '@/theme/animation.css';
+
 import { vars } from '../../../theme/index.css';
 
 export const containerStyle = style({
@@ -64,8 +66,6 @@ export const weekCellStyle = recipe({
     justifyContent: 'center',
     alignItems: 'center',
     gap: vars.spacing[100],
-
-    cursor: 'pointer',
   },
   variants: {
     day: {
@@ -82,6 +82,7 @@ export const weekCellStyle = recipe({
     state: {
       selected: {
         backgroundColor: vars.color.Ref.Primary[50],
+        ...fadeHighlightProps,
       },
       default: {
         backgroundColor: vars.color.Ref.Netural.White,

--- a/frontend/src/components/Calendar/Header/CalendarHeader.tsx
+++ b/frontend/src/components/Calendar/Header/CalendarHeader.tsx
@@ -1,4 +1,4 @@
-import { isSameDate, isWeekend } from '@/utils/date';
+import { isSameDate } from '@/utils/date';
 
 import { useCalendarContext } from '../context/CalendarContext';
 import { CalendarCell } from '../Table/CalendarCell';

--- a/frontend/src/components/Calendar/Header/CalendarHeader.tsx
+++ b/frontend/src/components/Calendar/Header/CalendarHeader.tsx
@@ -13,7 +13,7 @@ export const CalendarHeader = () => {
       <SideCell time='all' />
       {dates.map((date) => 
         <CalendarCell
-          holiday={isWeekend(date)}
+          date={date}
           key={date.getTime()}
           selected={isSameDate(selected, date)}
           time='all'

--- a/frontend/src/components/Calendar/Table/CalendarCell.tsx
+++ b/frontend/src/components/Calendar/Table/CalendarCell.tsx
@@ -1,6 +1,9 @@
 
-import type { Time } from '../../../constants/date';
-import { cellStyle } from './index.css';
+import { Flex } from '@/components/Flex';
+import type { Time } from '@/constants/date';
+import { MINUTES } from '@/constants/date';
+
+import { cellDetailStyle, cellStyle } from './index.css';
 
 interface CalendarCellProps {
   holiday?: boolean;
@@ -26,6 +29,15 @@ export const CalendarCell = ({ holiday = false, time, selected }: CalendarCellPr
       role='gridcell'
       tabIndex={0}
     >
+      {(time === 'empty' || time === 'all') ? null : (
+        <Flex direction='column' height='100%'>
+          {MINUTES.map(({ startTime, endTime }) => (
+            <div
+              className={cellDetailStyle}
+              key={`${startTime}-${endTime}`}
+            />
+          ))}
+        </Flex>)}
     </div>
   );
 };

--- a/frontend/src/components/Calendar/Table/CalendarCell.tsx
+++ b/frontend/src/components/Calendar/Table/CalendarCell.tsx
@@ -1,17 +1,18 @@
 
 import { Flex } from '@/components/Flex';
-import type { Time } from '@/constants/date';
-import { MINUTES } from '@/constants/date';
+import { MINUTES, type Time } from '@/constants/date';
+import { isWeekend } from '@/utils/date';
 
-import { cellDetailStyle, cellStyle } from './index.css';
+import { CalendarDetailCell } from './CalendarDetailCell';
+import { cellStyle } from './index.css';
 
 interface CalendarCellProps {
-  holiday?: boolean;
+  date: Date;
   time: Time;
   selected: boolean;
 }
 
-export const CalendarCell = ({ holiday = false, time, selected }: CalendarCellProps) => {
+export const CalendarCell = ({ date, time, selected }: CalendarCellProps) => {
   const formatTimeToStyle = (time: Time) => {
     if (time === 'empty') return 'empty';
     if (time === 'all') return 'all';
@@ -22,7 +23,7 @@ export const CalendarCell = ({ holiday = false, time, selected }: CalendarCellPr
     <div 
       aria-selected={selected}
       className={cellStyle({ 
-        day: holiday ? 'holiday' : 'default', 
+        day: isWeekend(date) ? 'holiday' : 'default', 
         time: formatTimeToStyle(time),
         state: selected ? 'selected' : 'default',
       })}
@@ -31,13 +32,14 @@ export const CalendarCell = ({ holiday = false, time, selected }: CalendarCellPr
     >
       {(time === 'empty' || time === 'all') ? null : (
         <Flex direction='column' height='100%'>
-          {MINUTES.map(({ startTime, endTime }) => (
-            <div
-              className={cellDetailStyle}
-              key={`${startTime}-${endTime}`}
-            />
-          ))}
-        </Flex>)}
+          {MINUTES.map((minute) => {
+            const newDate = new Date(date);
+            newDate.setHours(time);
+            newDate.setMinutes(minute);
+            return <CalendarDetailCell date={newDate} key={newDate.getTime()} />;
+          })}
+        </Flex>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/Calendar/Table/CalendarDay.tsx
+++ b/frontend/src/components/Calendar/Table/CalendarDay.tsx
@@ -5,29 +5,30 @@ import { CalendarCell } from './CalendarCell';
 import { dayStyle } from './index.css';
 
 interface CalendarDayProps {
-  holiday?: boolean;
+  date: Date;
   selected: boolean;
 }
 
-export const CalendarDay = memo(({ holiday = false, selected }: CalendarDayProps) => (
+export const CalendarDay = memo(({ date, selected }: CalendarDayProps) => (
   <div className={dayStyle}>
     <CalendarCell
-      holiday={holiday}
+      date={date}
       selected={selected}
       time='all'
     />
     <CalendarCell
-      holiday={holiday}
+      date={date}
       selected={selected}
       time='empty'
     />
-    {TIMES.map((time) => 
+    {TIMES.map((time) => (
       <CalendarCell
-        holiday={holiday}
+        date={date}
         key={time}
         selected={selected}
         time={time}
-      />,
+      />
+    ),
     )}
   </div>
 ));

--- a/frontend/src/components/Calendar/Table/CalendarDetailCell.tsx
+++ b/frontend/src/components/Calendar/Table/CalendarDetailCell.tsx
@@ -5,17 +5,26 @@ import { cellDetailStyle } from './index.css';
 
 export const CalendarDetailCell = ({ date }: { date: Date }) => {
   const { 
-    selectedStartTime, 
-    selectedEndTime, 
+    selectedStartTime,
+    selectedEndTime,
+    doneStartTime,
+    doneEndTime,
     handleMouseDown,
     handleMouseEnter,
     handleMouseUp,
   } = useTimeTableContext();
   const selected = isDateInRange(date, selectedStartTime, selectedEndTime);
+  const done = isDateInRange(date, doneStartTime, doneEndTime);
+
+  const stateStyle = (() => {
+    if (done) return 'done';
+    if (selected) return 'selected';
+    return 'default';
+  })();
 
   return (
     <div
-      className={cellDetailStyle({ state: selected ? 'selected' : 'default' })}
+      className={cellDetailStyle({ state: stateStyle })}
       key={date.getTime()}
       onMouseDown={()=>handleMouseDown(date)}
       onMouseEnter={()=>handleMouseEnter(date)}

--- a/frontend/src/components/Calendar/Table/CalendarDetailCell.tsx
+++ b/frontend/src/components/Calendar/Table/CalendarDetailCell.tsx
@@ -1,0 +1,29 @@
+import { isDateInRange } from '@/utils/date';
+
+import { useTimeTableContext } from '../context/TimeTableContext';
+import { cellDetailStyle } from './index.css';
+
+export const CalendarDetailCell = ({ date }: { date: Date }) => {
+  const { 
+    selectedStartTime, 
+    selectedEndTime, 
+    handleSelectStartTime, 
+    handleSelectEndTime, 
+  } = useTimeTableContext();
+
+  const selected = isDateInRange(date, selectedStartTime, selectedEndTime);
+  const handleSelectTime = () => {
+    // eslint-disable-next-line no-console
+    console.log(date);
+    handleSelectStartTime(date);
+    handleSelectEndTime(date);
+  };
+
+  return (
+    <div
+      className={cellDetailStyle({ state: selected ? 'selected' : 'default' })}
+      key={date.getTime()}
+      onClick={handleSelectTime}
+    />
+  );
+};

--- a/frontend/src/components/Calendar/Table/CalendarDetailCell.tsx
+++ b/frontend/src/components/Calendar/Table/CalendarDetailCell.tsx
@@ -7,23 +7,19 @@ export const CalendarDetailCell = ({ date }: { date: Date }) => {
   const { 
     selectedStartTime, 
     selectedEndTime, 
-    handleSelectStartTime, 
-    handleSelectEndTime, 
+    handleMouseDown,
+    handleMouseEnter,
+    handleMouseUp,
   } = useTimeTableContext();
-
   const selected = isDateInRange(date, selectedStartTime, selectedEndTime);
-  const handleSelectTime = () => {
-    // eslint-disable-next-line no-console
-    console.log(date);
-    handleSelectStartTime(date);
-    handleSelectEndTime(date);
-  };
 
   return (
     <div
       className={cellDetailStyle({ state: selected ? 'selected' : 'default' })}
       key={date.getTime()}
-      onClick={handleSelectTime}
+      onMouseDown={()=>handleMouseDown(date)}
+      onMouseEnter={()=>handleMouseEnter(date)}
+      onMouseUp={handleMouseUp}
     />
   );
 };

--- a/frontend/src/components/Calendar/Table/CalendarDetailCell.tsx
+++ b/frontend/src/components/Calendar/Table/CalendarDetailCell.tsx
@@ -12,6 +12,7 @@ export const CalendarDetailCell = ({ date }: { date: Date }) => {
     handleMouseDown,
     handleMouseEnter,
     handleMouseUp,
+    handleClick,
   } = useTimeTableContext();
   const selected = isDateInRange(date, selectedStartTime, selectedEndTime);
   const done = isDateInRange(date, doneStartTime, doneEndTime);
@@ -26,6 +27,7 @@ export const CalendarDetailCell = ({ date }: { date: Date }) => {
     <div
       className={cellDetailStyle({ state: stateStyle })}
       key={date.getTime()}
+      onClick={()=>handleClick(date)}
       onMouseDown={()=>handleMouseDown(date)}
       onMouseEnter={()=>handleMouseEnter(date)}
       onMouseUp={handleMouseUp}

--- a/frontend/src/components/Calendar/Table/index.css.ts
+++ b/frontend/src/components/Calendar/Table/index.css.ts
@@ -77,6 +77,9 @@ export const cellDetailStyle = recipe({
         backgroundColor: vars.color.Ref.Primary[50],
         boxShadow: `inset 0 0 0 0.5px ${vars.color.Ref.Primary[100]}`,
       },
+      done: {
+        backgroundColor: vars.color.Ref.Primary[50],
+      },
       default: {},
     },
   },

--- a/frontend/src/components/Calendar/Table/index.css.ts
+++ b/frontend/src/components/Calendar/Table/index.css.ts
@@ -63,6 +63,12 @@ export const cellStyle = recipe({
     },
   },
 });
+
+export const cellDetailStyle = style({
+  width: '100%',
+  flexGrow: 1,
+  // borderBottom: '1px solid #E5E5E5',
+});
   
 export const sideCellStyle = recipe({
   base: {

--- a/frontend/src/components/Calendar/Table/index.css.ts
+++ b/frontend/src/components/Calendar/Table/index.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
+import { fadeHighlightProps } from '@/theme/animation.css';
+
 import { vars } from '../../../theme/index.css';
 
 export const containerStyle = style({
@@ -31,6 +33,7 @@ export const sideStyle = style({
 export const cellStyle = recipe({
   base: {
     width: '100%',
+    boxShadow: `inset 0 0 0 0.5px ${vars.color.Ref.Netural[200]}`,
   },
   variants: {
     day: {
@@ -55,19 +58,28 @@ export const cellStyle = recipe({
     state: {
       selected: {
         backgroundColor: vars.color.Ref.Primary[50],
-        boxShadow: `inset 0 0 0 0.5px ${vars.color.Ref.Primary[100]}`,
+        ...fadeHighlightProps,
       },
-      default: {
-        boxShadow: `inset 0 0 0 0.5px ${vars.color.Ref.Netural[200]}`,
-      },
+      default: {},
     },
   },
 });
 
-export const cellDetailStyle = style({
-  width: '100%',
-  flexGrow: 1,
-  // borderBottom: '1px solid #E5E5E5',
+export const cellDetailStyle = recipe({
+  base: {
+    width: '100%',
+    flexGrow: 1,
+    cursor: 'pointer',
+  },
+  variants: {
+    state: {
+      selected: {
+        backgroundColor: vars.color.Ref.Primary[50],
+        boxShadow: `inset 0 0 0 0.5px ${vars.color.Ref.Primary[100]}`,
+      },
+      default: {},
+    },
+  },
 });
   
 export const sideCellStyle = recipe({

--- a/frontend/src/components/Calendar/Table/index.tsx
+++ b/frontend/src/components/Calendar/Table/index.tsx
@@ -15,7 +15,7 @@ export const CalendarTable = () => {
         <CalendarSide />
         {dates.map((date) => 
           <CalendarDay
-            holiday={isWeekend(date)}
+            date={date}
             key={date.getTime()}
             selected={isSameDate(selected, date)}
           />)}

--- a/frontend/src/components/Calendar/Table/index.tsx
+++ b/frontend/src/components/Calendar/Table/index.tsx
@@ -1,5 +1,5 @@
 
-import { isSameDate, isWeekend } from '@/utils/date';
+import { isSameDate } from '@/utils/date';
 
 import { useCalendarContext } from '../context/CalendarContext';
 import { CalendarDay } from './CalendarDay';

--- a/frontend/src/components/Calendar/Table/index.tsx
+++ b/frontend/src/components/Calendar/Table/index.tsx
@@ -1,17 +1,21 @@
 
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { isSameDate } from '@/utils/date';
 
 import { useCalendarContext } from '../context/CalendarContext';
+import { useTimeTableContext } from '../context/TimeTableContext';
 import { CalendarDay } from './CalendarDay';
 import { CalendarSide } from './CalendarSide';
 import { containerStyle, contentsStyle } from './index.css';
 
 export const CalendarTable = () => {
   const { selected, dates } = useCalendarContext();
+  const { reset } = useTimeTableContext();
+  const calendarTableRef = useClickOutside<HTMLDivElement>(reset);
 
   return(
     <div className={containerStyle}>
-      <div className={contentsStyle}>
+      <div className={contentsStyle} ref={calendarTableRef}>
         <CalendarSide />
         {dates.map((date) => 
           <CalendarDay

--- a/frontend/src/components/Calendar/context/TimeTableContext.ts
+++ b/frontend/src/components/Calendar/context/TimeTableContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+import { useSafeContext } from '@/hooks/useSafeContext';
+import type { TimeInfo } from '@/hooks/useSelectTime';
+
+export const TimeTableContext = createContext<TimeInfo | null>(null);
+
+export const useTimeTableContext = (): TimeInfo => useSafeContext(TimeTableContext);

--- a/frontend/src/components/Calendar/context/TimeTableProvider.tsx
+++ b/frontend/src/components/Calendar/context/TimeTableProvider.tsx
@@ -1,0 +1,14 @@
+import type { PropsWithChildren } from 'react';
+
+import { useSelectTime } from '@/hooks/useSelectTime';
+
+import { TimeTableContext } from './TimeTableContext';
+
+export const TimeTableProvider = ({ children }: PropsWithChildren) => {
+  const times = useSelectTime();
+  return (
+    <TimeTableContext.Provider value={times}>
+      {children}
+    </TimeTableContext.Provider>
+  );
+};

--- a/frontend/src/components/Calendar/index.tsx
+++ b/frontend/src/components/Calendar/index.tsx
@@ -1,4 +1,5 @@
 import { CalendarProvider } from './context/CalendarProvider';
+import { TimeTableProvider } from './context/TimeTableProvider';
 import { Core } from './Core';
 import { CalendarHeader } from './Header/CalendarHeader';
 import { wrapperStyle } from './index.css';
@@ -7,9 +8,11 @@ import { CalendarTable } from './Table';
 export const Calendar = () => (
   <CalendarProvider>
     <Core />
-    <div className={wrapperStyle}>
-      <CalendarHeader />
-      <CalendarTable />
-    </div>
+    <TimeTableProvider>
+      <div className={wrapperStyle}>
+        <CalendarHeader />
+        <CalendarTable />
+      </div>
+    </TimeTableProvider>
   </CalendarProvider>
 );

--- a/frontend/src/components/Notification/GlobalNotification.tsx
+++ b/frontend/src/components/Notification/GlobalNotification.tsx
@@ -1,7 +1,7 @@
 import { createPortal } from 'react-dom';
 
 import type { NotificationWithId } from '@/hooks/useNotification';
-import { fadeInAndOut } from '@/theme/animation.css';
+import { fadeInAndOutStyle } from '@/theme/animation.css';
 
 import { Notification } from '.';
 import { notificationsStyle } from './index.css';
@@ -14,7 +14,7 @@ export const GlobalNotification = ({ notifications }: { notifications: Notificat
       {notifications
         .map((noti) => 
           <Notification
-            className={fadeInAndOut}
+            className={fadeInAndOutStyle}
             key={noti.id}
             {...noti}
           />)}

--- a/frontend/src/constants/date.ts
+++ b/frontend/src/constants/date.ts
@@ -16,3 +16,10 @@ export const WEEK_MAP: Record<string, string> = Object.freeze({
   4: '넷째주',
   5: '다섯째주',
 });
+
+export const MINUTES = Object.freeze(
+  new Array(4).fill(0)
+    .map((_, i) => ({
+      startTime: i * 15,
+      endTime: i * 15 + 15,
+    })));

--- a/frontend/src/constants/date.ts
+++ b/frontend/src/constants/date.ts
@@ -2,7 +2,7 @@ export type Time = number | 'all' | 'empty';
 
 export type WEEKDAY = 'SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT';
 
-export const TIMES: readonly Time[] = Object.freeze(
+export const TIMES: readonly number[] = Object.freeze(
   new Array(24).fill(0)
     .map((_, i) => i));
 
@@ -19,7 +19,4 @@ export const WEEK_MAP: Record<string, string> = Object.freeze({
 
 export const MINUTES = Object.freeze(
   new Array(4).fill(0)
-    .map((_, i) => ({
-      startTime: i * 15,
-      endTime: i * 15 + 15,
-    })));
+    .map((_, i) => i * 15));

--- a/frontend/src/hooks/useClickOutside.ts
+++ b/frontend/src/hooks/useClickOutside.ts
@@ -20,7 +20,7 @@ export const useClickOutside = <T extends HTMLElement>(
     return () => {
       document.removeEventListener('click', handleClickOutside, true);
     };
-  }, [notClickableRef, onClickOutside]);
+  }, [onClickOutside]);
 
   return notClickableRef;
 };

--- a/frontend/src/hooks/useClickOutside.ts
+++ b/frontend/src/hooks/useClickOutside.ts
@@ -1,0 +1,26 @@
+import type { RefObject } from 'react';
+import { useEffect, useRef } from 'react';
+
+export const useClickOutside = <T extends HTMLElement>(
+  onClickOutside: (event: MouseEvent) => void,
+) => {
+  const notClickableRef: RefObject<T | null> = useRef<T>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as Node;
+      const isOutside =
+        notClickableRef.current && !notClickableRef.current.contains(target);
+      if (!isOutside) return;
+
+      onClickOutside(e);
+    };
+
+    document.addEventListener('click', handleClickOutside, true);
+    return () => {
+      document.removeEventListener('click', handleClickOutside, true);
+    };
+  }, [notClickableRef, onClickOutside]);
+
+  return notClickableRef;
+};

--- a/frontend/src/hooks/useSelectTime.ts
+++ b/frontend/src/hooks/useSelectTime.ts
@@ -14,39 +14,39 @@ type State = {
 };
 
 type Action = {
-  type: 'SELECT_START' | 'SELECT_PROGRESS' | 'SELECT_END';
+  type: 'SELECT_START' | 'SELECT_PROGRESS' | 'SELECT_END' | 'SELECT_CANCEL';
   date?: Date;
 };
+
+const resetSelectedTime = () => ({
+  startTime: null,
+  endTime: null,
+});
+
+const resetDoneTime = () => ({
+  startTime: null,
+  endTime: null,
+});
 
 const selectReducer = (state: State, action: Action) => {
   switch (action.type) {
     case 'SELECT_START':
       if (!action.date) return state;
-      return {
-        ...state,
-        selectedTime: {
-          startTime: action.date,
-          endTime: null,
-        },
-        isSelecting: true,
+      return { 
+        ...state, selectedTime: { startTime: action.date, endTime: null }, isSelecting: true,
       };
+
     case 'SELECT_PROGRESS':
       if (!state.isSelecting || !action.date) return state;
-      return {
-        ...state,
-        selectedTime: {
-          ...state.selectedTime,
-          endTime: action.date,
-        },
+      return { 
+        ...state, selectedTime: { ...state.selectedTime, endTime: action.date }, 
       };
+
     case 'SELECT_END': {
       const { startDate, endDate }
          = sortDate(state.selectedTime.startTime, state.selectedTime.endTime);
       return {
-        selectedTime: {
-          startTime: null,
-          endTime: null,
-        },
+        selectedTime: resetSelectedTime(),
         doneTime: {
           startTime: action.date || startDate,
           endTime: action.date || endDate,
@@ -54,6 +54,14 @@ const selectReducer = (state: State, action: Action) => {
         isSelecting: false,
       };
     }
+
+    case 'SELECT_CANCEL':
+      return {
+        selectedTime: resetSelectedTime(),
+        doneTime: resetDoneTime(),
+        isSelecting: false,
+      };
+
     default:
       return state;
   }
@@ -68,6 +76,7 @@ export interface TimeInfo {
   handleMouseEnter: (date: Date) => void;
   handleMouseUp: () => void;
   handleClick: (date: Date) => void;
+  reset: () => void;
 }
 
 export const useSelectTime = (): TimeInfo => {
@@ -86,5 +95,6 @@ export const useSelectTime = (): TimeInfo => {
     handleMouseEnter: (date: Date) => dispatch({ type: 'SELECT_PROGRESS', date }),
     handleMouseUp: () => dispatch({ type: 'SELECT_END' }),
     handleClick: (date: Date) => dispatch({ type: 'SELECT_END', date }),
+    reset: () => dispatch({ type: 'SELECT_CANCEL' }),
   };
 };

--- a/frontend/src/hooks/useSelectTime.ts
+++ b/frontend/src/hooks/useSelectTime.ts
@@ -1,35 +1,69 @@
-import { useState } from 'react';
+import { useReducer } from 'react';
 
 export interface TimeRange {
   startTime: Date | null;
   endTime: Date | null;
 }
 
+type State = {
+  selectedTime: TimeRange;
+  isSelecting: boolean;
+};
+
+type Action = {
+  type: 'SELECT_START' | 'SELECT_PROGRESS' | 'SELECT_END';
+  date?: Date;
+};
+
+const selectReducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'SELECT_START':
+      if (!action.date) return state;
+      return {
+        selectedTime: {
+          startTime: action.date,
+          endTime: null,
+        },
+        isSelecting: true,
+      };
+    case 'SELECT_PROGRESS':
+      if (!state.isSelecting || !action.date) return state;
+      return {
+        ...state,
+        selectedTime: {
+          ...state.selectedTime,
+          endTime: action.date,
+        },
+      };
+    case 'SELECT_END':
+      return {
+        ...state,
+        isSelecting: false,
+      };
+    default:
+      return state;
+  }
+};
+
 export interface TimeInfo {
   selectedStartTime: Date | null;
   selectedEndTime: Date | null;
-  handleSelectStartTime: (date: Date) => void;
-  handleSelectEndTime: (date: Date) => void;
+  handleMouseDown: (date: Date) => void;
+  handleMouseEnter: (date: Date) => void;
+  handleMouseUp: () => void;
 }
 
 export const useSelectTime = (): TimeInfo => {
-  const [selectedTime, setSelectedTime] = useState<TimeRange>({
-    startTime: null,
-    endTime: null,
-  });
-
-  const handleSelectStartTime = (date: Date) => {
-    setSelectedTime((prev) => ({ ...prev, startTime: date }));
-  };
-
-  const handleSelectEndTime = (date: Date) => {
-    setSelectedTime((prev) => ({ ...prev, endTime: date }));
-  };
+  const [state, dispatch] = useReducer(selectReducer, 
+    { selectedTime: { startTime: null, endTime: null }, 
+      isSelecting: false },
+  );
 
   return {
-    selectedStartTime: selectedTime.startTime,
-    selectedEndTime: selectedTime.endTime,
-    handleSelectStartTime,
-    handleSelectEndTime,
+    selectedStartTime: state.selectedTime.startTime,
+    selectedEndTime: state.selectedTime.endTime,
+    handleMouseDown: (date: Date) => dispatch({ type: 'SELECT_START', date }),
+    handleMouseEnter: (date: Date) => dispatch({ type: 'SELECT_PROGRESS', date }),
+    handleMouseUp: () => dispatch({ type: 'SELECT_END' }),
   };
 };

--- a/frontend/src/hooks/useSelectTime.ts
+++ b/frontend/src/hooks/useSelectTime.ts
@@ -9,6 +9,7 @@ export interface TimeRange {
 
 type State = {
   selectedTime: TimeRange;
+  doneTime: TimeRange;
   isSelecting: boolean;
 };
 
@@ -19,17 +20,17 @@ type Action = {
 
 const selectReducer = (state: State, action: Action) => {
   switch (action.type) {
-    case 'SELECT_START': {
+    case 'SELECT_START':
       if (!action.date) return state;
       return {
+        ...state,
         selectedTime: {
           startTime: action.date,
           endTime: null,
         },
         isSelecting: true,
       };
-    }
-    case 'SELECT_PROGRESS': {
+    case 'SELECT_PROGRESS':
       if (!state.isSelecting || !action.date) return state;
       return {
         ...state,
@@ -38,12 +39,15 @@ const selectReducer = (state: State, action: Action) => {
           endTime: action.date,
         },
       };
-    }
     case 'SELECT_END': {
       const { startDate, endDate }
          = sortDate(state.selectedTime.startTime, state.selectedTime.endTime);
       return {
         selectedTime: {
+          startTime: null,
+          endTime: null,
+        },
+        doneTime: {
           startTime: startDate,
           endTime: endDate,
         },
@@ -58,6 +62,8 @@ const selectReducer = (state: State, action: Action) => {
 export interface TimeInfo {
   selectedStartTime: Date | null;
   selectedEndTime: Date | null;
+  doneStartTime: Date | null;
+  doneEndTime: Date | null;
   handleMouseDown: (date: Date) => void;
   handleMouseEnter: (date: Date) => void;
   handleMouseUp: () => void;
@@ -66,12 +72,15 @@ export interface TimeInfo {
 export const useSelectTime = (): TimeInfo => {
   const [state, dispatch] = useReducer(selectReducer, 
     { selectedTime: { startTime: null, endTime: null }, 
+      doneTime: { startTime: null, endTime: null },
       isSelecting: false },
   );
 
   return {
     selectedStartTime: state.selectedTime.startTime,
     selectedEndTime: state.selectedTime.endTime,
+    doneStartTime: state.doneTime.startTime,
+    doneEndTime: state.doneTime.endTime,
     handleMouseDown: (date: Date) => dispatch({ type: 'SELECT_START', date }),
     handleMouseEnter: (date: Date) => dispatch({ type: 'SELECT_PROGRESS', date }),
     handleMouseUp: () => dispatch({ type: 'SELECT_END' }),

--- a/frontend/src/hooks/useSelectTime.ts
+++ b/frontend/src/hooks/useSelectTime.ts
@@ -48,8 +48,8 @@ const selectReducer = (state: State, action: Action) => {
           endTime: null,
         },
         doneTime: {
-          startTime: startDate,
-          endTime: endDate,
+          startTime: action.date || startDate,
+          endTime: action.date || endDate,
         },
         isSelecting: false,
       };
@@ -67,6 +67,7 @@ export interface TimeInfo {
   handleMouseDown: (date: Date) => void;
   handleMouseEnter: (date: Date) => void;
   handleMouseUp: () => void;
+  handleClick: (date: Date) => void;
 }
 
 export const useSelectTime = (): TimeInfo => {
@@ -84,5 +85,6 @@ export const useSelectTime = (): TimeInfo => {
     handleMouseDown: (date: Date) => dispatch({ type: 'SELECT_START', date }),
     handleMouseEnter: (date: Date) => dispatch({ type: 'SELECT_PROGRESS', date }),
     handleMouseUp: () => dispatch({ type: 'SELECT_END' }),
+    handleClick: (date: Date) => dispatch({ type: 'SELECT_END', date }),
   };
 };

--- a/frontend/src/hooks/useSelectTime.ts
+++ b/frontend/src/hooks/useSelectTime.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+export interface TimeRange {
+  startTime: Date | null;
+  endTime: Date | null;
+}
+
+export interface TimeInfo {
+  selectedStartTime: Date | null;
+  selectedEndTime: Date | null;
+  handleSelectStartTime: (date: Date) => void;
+  handleSelectEndTime: (date: Date) => void;
+}
+
+export const useSelectTime = (): TimeInfo => {
+  const [selectedTime, setSelectedTime] = useState<TimeRange>({
+    startTime: null,
+    endTime: null,
+  });
+
+  const handleSelectStartTime = (date: Date) => {
+    setSelectedTime((prev) => ({ ...prev, startTime: date }));
+  };
+
+  const handleSelectEndTime = (date: Date) => {
+    setSelectedTime((prev) => ({ ...prev, endTime: date }));
+  };
+
+  return {
+    selectedStartTime: selectedTime.startTime,
+    selectedEndTime: selectedTime.endTime,
+    handleSelectStartTime,
+    handleSelectEndTime,
+  };
+};

--- a/frontend/src/hooks/useSelectTime.ts
+++ b/frontend/src/hooks/useSelectTime.ts
@@ -1,5 +1,7 @@
 import { useReducer } from 'react';
 
+import { sortDate } from '@/utils/date';
+
 export interface TimeRange {
   startTime: Date | null;
   endTime: Date | null;
@@ -17,7 +19,7 @@ type Action = {
 
 const selectReducer = (state: State, action: Action) => {
   switch (action.type) {
-    case 'SELECT_START':
+    case 'SELECT_START': {
       if (!action.date) return state;
       return {
         selectedTime: {
@@ -26,7 +28,8 @@ const selectReducer = (state: State, action: Action) => {
         },
         isSelecting: true,
       };
-    case 'SELECT_PROGRESS':
+    }
+    case 'SELECT_PROGRESS': {
       if (!state.isSelecting || !action.date) return state;
       return {
         ...state,
@@ -35,11 +38,18 @@ const selectReducer = (state: State, action: Action) => {
           endTime: action.date,
         },
       };
-    case 'SELECT_END':
+    }
+    case 'SELECT_END': {
+      const { startDate, endDate }
+         = sortDate(state.selectedTime.startTime, state.selectedTime.endTime);
       return {
-        ...state,
+        selectedTime: {
+          startTime: startDate,
+          endTime: endDate,
+        },
         isSelecting: false,
       };
+    }
     default:
       return state;
   }

--- a/frontend/src/theme/animation.css.ts
+++ b/frontend/src/theme/animation.css.ts
@@ -1,4 +1,7 @@
+import type { CSSProperties } from '@vanilla-extract/css';
 import { keyframes, style } from '@vanilla-extract/css';
+
+import { vars } from './index.css';
 
 // TODO: 토큰 매직넘버 제거
 
@@ -24,6 +27,27 @@ const disappear = keyframes({
   },
 });
 
-export const fadeInAndOut = style({
+export const fadeInAndOutStyle = style({
   animation: `${appear} 0.3s ease-out, ${disappear} 0.3s ease-in 2.7s`,
 });
+
+export const fadeHighlight = keyframes({
+  '0%': { backgroundColor: vars.color.Ref.Netural.White },
+  '5%': { 
+    backgroundColor: vars.color.Ref.Primary[50],         
+    boxShadow: `inset 0 0 0 0.5px ${vars.color.Ref.Primary[100]}`, 
+  },
+  '50%': { 
+    backgroundColor: vars.color.Ref.Primary[50],
+    boxShadow: `inset 0 0 0 0.5px ${vars.color.Ref.Primary[100]}`,
+  },
+  '100%': { 
+    backgroundColor: vars.color.Ref.Netural.White,
+  },
+});
+
+export const fadeHighlightProps: CSSProperties = {
+  animationName: fadeHighlight,
+  animationDuration: '2s',
+  animationFillMode: 'forwards',
+};

--- a/frontend/src/utils/date/date.ts
+++ b/frontend/src/utils/date/date.ts
@@ -106,6 +106,22 @@ export const isWeekend = (date: Date): boolean => {
 };
 
 /**
+ * 두 날짜 객체를 비교하여 시작 날짜와 종료 날짜를 반환합니다.
+ * @param date1 - 비교할 날짜1
+ * @param date2 - 비교할 날짜2
+ * @returns - 시작 날짜와 종료 날짜
+ */
+export const sortDate = (date1: Date | null, date2: Date | null): {
+  startDate: Date | null;
+  endDate: Date | null;
+} => {
+  if (!date1 || !date2) return { startDate: date1, endDate: date2 };
+  const [startDate, endDate] 
+    = [date1, date2].sort((a, b) => a.getTime() - b.getTime());
+  return { startDate, endDate };
+};
+
+/**
  * 
  * @param target - 비교할 날짜
  * @param startDate - 시작 날짜
@@ -119,9 +135,12 @@ export const isDateInRange = (
 ): boolean => {
   if (!startDate || !endDate) return false;
 
+  const { startDate: start, endDate: end } = sortDate(startDate, endDate);
+  if (!start || !end) return false;
+
   const targetTime = target.getTime();
-  const startTime = startDate.getTime();
-  const endTime = endDate.getTime();
+  const startTime = start.getTime();
+  const endTime = end.getTime();
 
   return targetTime >= startTime && targetTime <= endTime;
 };

--- a/frontend/src/utils/date/date.ts
+++ b/frontend/src/utils/date/date.ts
@@ -115,7 +115,12 @@ export const sortDate = (date1: Date | null, date2: Date | null): {
   startDate: Date | null;
   endDate: Date | null;
 } => {
-  if (!date1 || !date2) return { startDate: date1, endDate: date2 };
+  if (!date1 || !date2) {
+    return { 
+      startDate: date1 || date2, 
+      endDate: date1 || date2, 
+    };
+  }
   const [startDate, endDate] 
     = [date1, date2].sort((a, b) => a.getTime() - b.getTime());
   return { startDate, endDate };

--- a/frontend/src/utils/date/date.ts
+++ b/frontend/src/utils/date/date.ts
@@ -104,3 +104,24 @@ export const isWeekend = (date: Date): boolean => {
   
   return date.getDay() === SUNDAY || date.getDay() === SATURDAY;
 };
+
+/**
+ * 
+ * @param target - 비교할 날짜
+ * @param startDate - 시작 날짜
+ * @param endDate - 종료 날짜
+ * @returns - 날짜가 범위 내에 있는지 여부
+ */
+export const isDateInRange = (
+  target: Date,
+  startDate: Date | null,
+  endDate: Date | null,
+): boolean => {
+  if (!startDate || !endDate) return false;
+
+  const targetTime = target.getTime();
+  const startTime = startDate.getTime();
+  const endTime = endDate.getTime();
+
+  return targetTime >= startTime && targetTime <= endTime;
+};


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- close #61 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 기/디 피드백: 캘린더 헤더에서의 직접 선택을 막고, 선택된 날짜는 하이라이팅 되었다가 애니메이션으로 사라지도록 합니다. (선택된 값은 계속 유지됨)
- 선택 시간의 시작과 끝의 `Date` 객체를 상태로 들고 있도록 합니다.
  - 드래그 시 15분 단위로 셀 선택 구현
  - 클릭 시 15분짜리 셀 선택 구현
  - 캘린더 외부 클릭 시 선택 해제 구현

아래 UI (새 일정 표시 및 시간범위 렌더링) 제외하고 구현했습니다.
<img width="381" alt="image" src="https://github.com/user-attachments/assets/3e037aef-e65d-42b6-ac7a-7aa9e5a8d6e7" />


## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `CalendarDetailCell` component for enhanced time cell interactivity.
  - Added a `TimeTableProvider` for improved context management within the calendar.

- **Bug Fixes**
  - Removed outdated week change functionality, simplifying week navigation.

- **Style**
  - Updated animations and visual highlights across calendar cells and notifications for a smoother, more refined experience.
  
- **Refactor**
  - Streamlined date handling and interaction logic across calendar components, including revised selection behavior and improved click-outside detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->