### PR TITLE
[BE-Feat] Redis 사용 세팅

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -47,9 +47,15 @@ dependencies {
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// test-containers
+	testImplementation "org.testcontainers:testcontainers:1.20.4"
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/endolphin/backend/global/config/RedisConfig.java
+++ b/backend/src/main/java/endolphin/backend/global/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package endolphin.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    /**
+     * RedisTemplate for binary data (byte[]) storage. 키는 String, 값은 byte[]로 다룹니다.
+     */
+    @Bean
+    @Primary
+    public RedisTemplate<String, byte[]> redisByteTemplate(
+        RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(RedisSerializer.byteArray());
+        template.setHashValueSerializer(RedisSerializer.byteArray());
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
+++ b/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
@@ -1,0 +1,85 @@
+package endolphin.backend.global.redis;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DiscussionBitmapService {
+
+    private final RedisTemplate<String, byte[]> redisTemplate;
+
+    /**
+     * Redis 키 생성: "{discussionId}:{minuteKey}"
+     */
+    private String buildRedisKey(Long discussionId, long minuteKey) {
+        return discussionId + ":" + minuteKey;
+    }
+
+    /**
+     * LocalDateTime을 분 단위의 long 값(에포크 기준 분 값)으로 변환.
+     */
+    private long convertToMinuteKey(LocalDateTime dateTime) {
+        return dateTime.toEpochSecond(ZoneOffset.UTC) / 60;
+    }
+
+    /**
+     * 해당 논의 및 시각(분)에 대해 16비트(2바이트) 크기의 비트맵을 초기화하여 Redis에 저장합니다.
+     *
+     * @param discussionId 논의 식별자
+     * @param dateTime     초기화할 기준 시각 (분 단위로 변환됨)
+     */
+    public void initializeBitmap(Long discussionId, LocalDateTime dateTime) {
+        int byteSize = 2;
+        long minuteKey = convertToMinuteKey(dateTime);
+        String redisKey = buildRedisKey(discussionId, minuteKey);
+        byte[] initialData = new byte[byteSize];
+        redisTemplate.opsForValue().set(redisKey, initialData);
+    }
+
+    /**
+     * 해당 논의의 특정 시각(분) 비트맵 데이터에서, 지정 오프셋의 비트를 수정합니다.
+     *
+     * @param discussionId 논의 식별자
+     * @param dateTime     수정할 시각 (분 단위로 변환됨)
+     * @param bitOffset    수정할 비트의 오프셋 (0부터 시작, 최대 15까지 사용 가능)
+     * @param value        설정할 비트 값 (true/false)
+     * @return 이전 비트 값 (true/false)
+     */
+    public Boolean setBitValue(Long discussionId, LocalDateTime dateTime, long bitOffset,
+        boolean value) {
+        long minuteKey = convertToMinuteKey(dateTime);
+        String redisKey = buildRedisKey(discussionId, minuteKey);
+        return redisTemplate.opsForValue().setBit(redisKey, bitOffset, value);
+    }
+
+    /**
+     * 해당 논의의 특정 시각(분) 비트맵 데이터에서, 지정 오프셋의 비트 값을 조회합니다.
+     *
+     * @param discussionId 논의 식별자
+     * @param dateTime     조회할 시각 (분 단위로 변환됨)
+     * @param bitOffset    조회할 비트 오프셋 (0부터 시작)
+     * @return 조회된 비트 값 (true/false)
+     */
+    public Boolean getBitValue(Long discussionId, LocalDateTime dateTime, long bitOffset) {
+        long minuteKey = convertToMinuteKey(dateTime);
+        String redisKey = buildRedisKey(discussionId, minuteKey);
+        return redisTemplate.opsForValue().getBit(redisKey, bitOffset);
+    }
+
+    /**
+     * 해당 논의의 특정 시각(분) 비트맵 데이터 전체를 조회합니다.
+     *
+     * @param discussionId 논의 식별자
+     * @param dateTime     조회할 시각 (분 단위로 변환됨)
+     * @return byte[] 형태의 전체 비트맵 데이터 (없으면 null)
+     */
+    public byte[] getBitmapData(Long discussionId, LocalDateTime dateTime) {
+        long minuteKey = convertToMinuteKey(dateTime);
+        String redisKey = buildRedisKey(discussionId, minuteKey);
+        return redisTemplate.opsForValue().get(redisKey);
+    }
+}

--- a/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
+++ b/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
@@ -23,7 +23,7 @@ public class DiscussionBitmapService {
      * LocalDateTime을 분 단위의 long 값(에포크 기준 분 값)으로 변환.
      */
     private long convertToMinuteKey(LocalDateTime dateTime) {
-        return dateTime.toEpochSecond(ZoneOffset.UTC) / 60;
+        return dateTime.toEpochSecond(ZoneOffset.ofHours(9)) / 60;
     }
 
     /**

--- a/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
+++ b/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
@@ -3,6 +3,7 @@ package endolphin.backend.global.redis;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -33,11 +34,16 @@ public class DiscussionBitmapService {
      * @param dateTime     초기화할 기준 시각 (분 단위로 변환됨)
      */
     public void initializeBitmap(Long discussionId, LocalDateTime dateTime) {
-        int byteSize = 2;
-        long minuteKey = convertToMinuteKey(dateTime);
-        String redisKey = buildRedisKey(discussionId, minuteKey);
-        byte[] initialData = new byte[byteSize];
-        redisTemplate.opsForValue().set(redisKey, initialData);
+        try {
+            int byteSize = 2;
+            long minuteKey = convertToMinuteKey(dateTime);
+            String redisKey = buildRedisKey(discussionId, minuteKey);
+            byte[] initialData = new byte[byteSize];
+            redisTemplate.opsForValue().set(redisKey, initialData);
+        } catch (RedisSystemException e) {
+            //TODO: 예외 처리
+            throw e;
+        }
     }
 
     /**

--- a/backend/src/test/java/endolphin/backend/global/redis/DiscussionBitmapServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/redis/DiscussionBitmapServiceTest.java
@@ -1,0 +1,45 @@
+package endolphin.backend.global.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+@SpringBootTest
+public class DiscussionBitmapServiceTest {
+
+    @Autowired
+    private DiscussionBitmapService bitmapService;
+
+
+    @DisplayName("비트맵 초기화 및 비트 연산 테스트")
+    @Test
+    public void testInitializeAndBitOperations() {
+        Long discussionId = 100L;
+        LocalDateTime dateTime = LocalDateTime.now();
+
+        // 1. 초기화: 해당 논의 및 시각에 대해 16비트 크기의 비트맵을 생성하여 Redis에 저장
+        bitmapService.initializeBitmap(discussionId, dateTime);
+
+        // 2. 오프셋 5의 비트를 true로 설정
+        Boolean previousValue = bitmapService.setBitValue(discussionId, dateTime, 5, true);
+        // 초기화된 비트맵은 모두 0이므로 이전 값은 false여야 함
+        assertThat(previousValue).isFalse();
+
+        // 3. 수정된 비트 조회: 오프셋 5의 비트 값이 true인지 확인
+        Boolean bitValue = bitmapService.getBitValue(discussionId, dateTime, 5);
+        assertThat(bitValue).isTrue();
+
+        // 4. 전체 비트맵 데이터 조회 및 검증
+        byte[] bitmapData = bitmapService.getBitmapData(discussionId, dateTime);
+        int byteIndex = 5 / 8;          // 0
+        int bitPosition = 5 % 8;        // 5
+        // big-endian 순서로 확인: (7 - bitPosition)
+        boolean extractedBit = ((bitmapData[byteIndex] >> (7 - bitPosition)) & 1) == 1;
+        assertThat(extractedBit).isTrue();
+    }
+}

--- a/backend/src/test/java/endolphin/backend/global/redis/DiscussionBitmapServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/redis/DiscussionBitmapServiceTest.java
@@ -41,5 +41,13 @@ public class DiscussionBitmapServiceTest {
         // big-endian 순서로 확인: (7 - bitPosition)
         boolean extractedBit = ((bitmapData[byteIndex] >> (7 - bitPosition)) & 1) == 1;
         assertThat(extractedBit).isTrue();
+
+        // 5. SCAN을 이용하여 해당 discussionId의 모든 비트맵 키 삭제
+        bitmapService.deleteDiscussionBitmapsUsingScan(discussionId);
+
+        // 6. 삭제 후 데이터 검증: 비트맵 데이터가 없어야 함
+        byte[] afterDelete = bitmapService.getBitmapData(discussionId, dateTime);
+        assertThat(afterDelete).as("deleteDiscussionBitmapsUsingScan should remove the bitmap")
+            .isNull();
     }
 }

--- a/backend/src/test/java/endolphin/backend/global/redis/RedisTemplateTest.java
+++ b/backend/src/test/java/endolphin/backend/global/redis/RedisTemplateTest.java
@@ -1,0 +1,31 @@
+package endolphin.backend.global.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@SpringBootTest
+public class RedisTemplateTest {
+
+    @Autowired
+    private RedisTemplate<String, byte[]> redisTemplate;
+
+    @DisplayName("작성한 Redis template 테스트")
+    @Test
+    public void testSetAndGetByteArray() {
+        String key = "test:bytearray";
+        byte[] expected = new byte[] {10, 20, 30, 40, 50};
+
+        // 값 저장
+        redisTemplate.opsForValue().set(key, expected);
+
+        // 값 조회
+        byte[] actual = redisTemplate.opsForValue().get(key);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/endolphin/backend/global/redis/RedisTestContainer.java
+++ b/backend/src/test/java/endolphin/backend/global/redis/RedisTestContainer.java
@@ -1,0 +1,28 @@
+package endolphin.backend.global.redis;
+
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@DisplayName("Redis Test Containers")
+@Profile("dev")
+@Configuration
+public class RedisTestContainer {
+
+    private static final String REDIS_DOCKER_IMAGE = "redis:6-alpine";
+
+    static {
+        GenericContainer<?> REDIS_CONTAINER =
+            new GenericContainer<>(DockerImageName.parse(REDIS_DOCKER_IMAGE))
+                .withExposedPorts(6379)
+                .withReuse(true);
+
+        REDIS_CONTAINER.start();
+
+        System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
+        System.setProperty("spring.data.redis.port",
+            REDIS_CONTAINER.getMappedPort(6379).toString());
+    }
+}


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #86 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- RedisTempate 작성
- DiscussionBitmapService에서 {discussionId}:{minuteKey} : byte[2] 형태로 데이터 저장 로직 구현
- dev환경 테스트용 redis testContainer 설정
- 데이터 저장, 조회, 변경 테스트 코드 작성
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated support for Redis to enhance backend operations and provide efficient management of discussion-related data.

- **Tests**
  - Added automated tests for the `DiscussionBitmapService` and `RedisTemplate` to verify the correctness and reliability of the new data handling capabilities.

- **Chores**
  - Updated project dependencies, including Redis and Testcontainers, to ensure robust integration and smoother development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->