### PR TITLE
[FE-Feat] Input 컴포넌트의 border 적용 위치를 동적으로 선택 가능하도록 구현

### DIFF
--- a/frontend/src/components/Input/Core/HelperText.tsx
+++ b/frontend/src/components/Input/Core/HelperText.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from 'react';
 
-import { Text } from '../Text';
+import { Text } from '../../Text';
 import { helperTextStyle } from './helperText.css';
 
 interface HelperTextProps extends PropsWithChildren {

--- a/frontend/src/components/Input/Core/InputField.tsx
+++ b/frontend/src/components/Input/Core/InputField.tsx
@@ -4,6 +4,7 @@ import { useRef } from 'react';
 import { ChevronDown } from '@/components/Icon';
 import { useSafeContext } from '@/hooks/useSafeContext';
 import { vars } from '@/theme/index.css';
+import clsx from '@/utils/clsx';
 
 import { interactableBorderStyle } from '../index.css';
 import { InputContext } from '../InputContext';
@@ -27,10 +28,9 @@ const InputField = ({ placeholder, onClick, ...inputProps }: InputFieldProps) =>
 
   return (
     <div 
-      className={`
-        ${inputFieldContainerStyle({ type })}
-        ${borderPlacement === 'inputField' && interactableBorderStyle({ isValid })}
-      `} 
+      className={clsx(
+        inputFieldContainerStyle({ type }), 
+        borderPlacement === 'inputField' && interactableBorderStyle({ isValid }) )} 
       onClick={handleContainerClick}
     >
       <input

--- a/frontend/src/components/Input/Core/InputField.tsx
+++ b/frontend/src/components/Input/Core/InputField.tsx
@@ -30,7 +30,8 @@ const InputField = ({ placeholder, onClick, ...inputProps }: InputFieldProps) =>
     <div 
       className={clsx(
         inputFieldContainerStyle({ type }), 
-        borderPlacement === 'inputField' && interactableBorderStyle({ isValid }) )} 
+        borderPlacement === 'inputField' && interactableBorderStyle({ isValid }),
+      )} 
       onClick={handleContainerClick}
     >
       <input

--- a/frontend/src/components/Input/Core/InputField.tsx
+++ b/frontend/src/components/Input/Core/InputField.tsx
@@ -1,10 +1,12 @@
 import type { InputHTMLAttributes } from 'react';
 import { useRef } from 'react';
 
-import { useSafeContext } from '../../hooks/useSafeContext';
-import { vars } from '../../theme/index.css';
-import { ChevronDown } from '../Icon';
-import { InputContext } from './InputContext';
+import { ChevronDown } from '@/components/Icon';
+import { useSafeContext } from '@/hooks/useSafeContext';
+import { vars } from '@/theme/index.css';
+
+import { interactableBorderStyle } from '../index.css';
+import { InputContext } from '../InputContext';
 import { inputFieldContainerStyle, inputFieldStyle, selectIconStyle } from './inputField.css';
 
 interface InputFieldProps extends Omit<
@@ -15,7 +17,7 @@ interface InputFieldProps extends Omit<
 }
 
 const InputField = ({ placeholder, onClick, ...inputProps }: InputFieldProps) => {
-  const { isValid, type } = useSafeContext(InputContext);
+  const { isValid, type, borderPlacement } = useSafeContext(InputContext);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleContainerClick = () => {
@@ -24,7 +26,13 @@ const InputField = ({ placeholder, onClick, ...inputProps }: InputFieldProps) =>
   };
 
   return (
-    <div className={inputFieldContainerStyle({ isValid, type })} onClick={handleContainerClick}>
+    <div 
+      className={`
+        ${inputFieldContainerStyle({ type })}
+        ${borderPlacement === 'inputField' && interactableBorderStyle({ isValid })}
+      `} 
+      onClick={handleContainerClick}
+    >
       <input
         className={inputFieldStyle}
         placeholder={placeholder}

--- a/frontend/src/components/Input/Core/Label.tsx
+++ b/frontend/src/components/Input/Core/Label.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from 'react';
 
-import { Text } from '../Text';
+import { Text } from '../../Text';
 import { labelContainerStyle, requiredMarkerStyle } from './label.css';
 
 interface LabelProps extends PropsWithChildren {

--- a/frontend/src/components/Input/Core/helperText.css.ts
+++ b/frontend/src/components/Input/Core/helperText.css.ts
@@ -1,6 +1,6 @@
 import { recipe } from '@vanilla-extract/recipes';
 
-import { vars } from '../../theme/index.css';
+import { vars } from '@/theme/index.css';
 
 export const helperTextStyle = recipe({
   base: {},

--- a/frontend/src/components/Input/Core/inputField.css.ts
+++ b/frontend/src/components/Input/Core/inputField.css.ts
@@ -1,43 +1,27 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import { font } from '../../theme/font';
-import { vars } from '../../theme/index.css';
+import { font } from '@/theme/font';
+import { vars } from '@/theme/index.css';
 
 export const inputFieldContainerStyle = recipe({
   base: {
     flex: 1,
+    height: '100%',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    borderRadius: vars.radius[200],
-    border: `1px solid ${vars.color.Ref.Netural[300]}`,
-    borderWidth: 1.5,
     backgroundColor: vars.color.Ref.Netural.White,
-    padding: vars.spacing[400],
-    height: 40, 
+    padding: `0 ${vars.spacing[400]}`,
+    borderRadius: vars.radius[200],
+    borderWidth: 1.5,
+    boxSizing: 'border-box',
   },
   variants: {
-    isValid: {
-      true: {
-        ':hover': {
-          borderColor: vars.color.Ref.Primary[200],
-        },
-        ':focus-within': {
-          borderColor: vars.color.Ref.Primary[500],
-        },
-      },
-      false: {
-        borderColor: vars.color.Ref.Red[500],
-      },
-    },
     type: {
       text: { cursor: 'text' },
       select: { cursor: 'pointer' },
     },
-  },
-  defaultVariants: {
-    isValid: true,
   },
 });
 

--- a/frontend/src/components/Input/Core/label.css.ts
+++ b/frontend/src/components/Input/Core/label.css.ts
@@ -1,7 +1,7 @@
 
 import { style } from '@vanilla-extract/css';
 
-import { vars } from '../../theme/index.css';
+import { vars } from '@/theme/index.css';
 
 export const labelContainerStyle = style({
   display: 'inline-flex',

--- a/frontend/src/components/Input/Input.stories.tsx
+++ b/frontend/src/components/Input/Input.stories.tsx
@@ -50,7 +50,7 @@ export const Default: StoryObj<typeof Input.Single> = {
     placeholder: '이메일을 입력하세요',
   },
   render: (args) => (
-    <Input.Single {...args}/>
+    <Input.Single {...args} />
   ),
 };
 
@@ -64,6 +64,7 @@ export const MultiInput = () => {
 
   return (
     <Input.Multi
+      borderPlacement='inputField'
       isValid={true}
       label='시간'
       required={true}
@@ -94,10 +95,11 @@ export const CustomSeparatorIcon = () => {
 
   return (
     <Input.Multi
+      borderPlacement='container'
       isValid={true}
       label='시간'
       required={true}
-      separator={<Check fill={vars.color.Ref.Netural[600]}/>}
+      separator={<Check fill={vars.color.Ref.Netural[600]} />}
       type='text'
     >
       <Input.Multi.InputField 

--- a/frontend/src/components/Input/InputContext.ts
+++ b/frontend/src/components/Input/InputContext.ts
@@ -5,6 +5,7 @@ import type { CommonInputProps } from '.';
 interface InputContextProps {
   isValid: boolean;
   type: CommonInputProps['type'];
+  borderPlacement?: 'container' | 'inputField';
 }
 
 /**

--- a/frontend/src/components/Input/MultiInput.tsx
+++ b/frontend/src/components/Input/MultiInput.tsx
@@ -1,16 +1,24 @@
 import type { JSX, PropsWithChildren, ReactNode } from 'react';
 import { isValidElement } from 'react';
 
+import { intersperseElement } from '@/utils/jsxUtils';
+
 import { Text } from '../Text';
 import { type CommonInputProps, ICON_WIDTH } from '.';
-import HelperText from './HelperText';
-import { containerStyle, inputFieldsContainerStyle, separatorStyle } from './index.css';
+import HelperText from './Core/HelperText';
+import InputField from './Core/InputField';
+import Label from './Core/Label';
+import { 
+  containerStyle,
+  inputFieldsContainerStyle,
+  interactableBorderStyle,
+  separatorStyle, 
+} from './index.css';
 import { InputContext } from './InputContext';
-import InputField from './InputField';
-import Label from './Label';
 
 export interface MultiInputProps extends CommonInputProps, PropsWithChildren {
   separator?: string | JSX.Element;
+  borderPlacement: 'container' | 'inputField';
 }
 
 export const MultiInput = ({ 
@@ -21,6 +29,7 @@ export const MultiInput = ({
   separator = '',
   hint, 
   error, 
+  borderPlacement,
   children,
 }: MultiInputProps) => {
   const childElements = children ? 
@@ -28,20 +37,23 @@ export const MultiInput = ({
     : [];
   const separatorElement = prepareSeparatorLayout(separator);
   const childrenWithSeparators =
-    childElements.length > 1 ? intersperse(childElements, separatorElement) : childElements;
+    childElements.length > 1 ? intersperseElement(childElements, separatorElement) : childElements;
 
   return (
-    <InputContext.Provider value={{ isValid, type }}>
+    <InputContext.Provider value={{ isValid, type, borderPlacement }}>
       <div className={containerStyle}>
         <Label required={required}>{label}</Label>
-        <div className={inputFieldsContainerStyle}>
+        <div className={`
+         ${inputFieldsContainerStyle}
+         ${borderPlacement === 'container' && interactableBorderStyle({ isValid })}
+         `}
+        >
           {childrenWithSeparators}
         </div>
         {isValid ? 
           <HelperText type='hint'>{hint}</HelperText>
           : 
-          <HelperText type='error'>{error}</HelperText>
-        }
+          <HelperText type='error'>{error}</HelperText>}
       </div>
     </InputContext.Provider>
   );
@@ -60,22 +72,9 @@ const prepareSeparatorLayout = (separator: string | (JSX.Element & { props: Sepa
       </div>
     );
   }
-  return <separator.type {...separator.props} width={ICON_WIDTH}/>;
+  return <separator.type {...separator.props} width={ICON_WIDTH} />;
 };
 
-const intersperse = (
-  childElements: ReactNode[],
-  separator?: JSX.Element,
-): ReactNode[] => {
-  const result: ReactNode[] = [];
-  childElements.forEach((child, index) => {
-    result.push(child);
-    if (separator && index < childElements.length - 1) {
-      result.push(<separator.type {...separator.props} key={index} />);
-    }
-  });
-  return result;
-};
 MultiInput.InputField = InputField;
 
 export default MultiInput;

--- a/frontend/src/components/Input/MultiInput.tsx
+++ b/frontend/src/components/Input/MultiInput.tsx
@@ -1,6 +1,7 @@
 import type { JSX, PropsWithChildren, ReactNode } from 'react';
 import { isValidElement } from 'react';
 
+import clsx from '@/utils/clsx';
 import { intersperseElement } from '@/utils/jsxUtils';
 
 import { Text } from '../Text';
@@ -18,7 +19,7 @@ import { InputContext } from './InputContext';
 
 export interface MultiInputProps extends CommonInputProps, PropsWithChildren {
   separator?: string | JSX.Element;
-  borderPlacement: 'container' | 'inputField';
+  borderPlacement?: 'container' | 'inputField';
 }
 
 export const MultiInput = ({ 
@@ -29,7 +30,7 @@ export const MultiInput = ({
   separator = '',
   hint, 
   error, 
-  borderPlacement,
+  borderPlacement = 'inputField',
   children,
 }: MultiInputProps) => {
   const childElements = children ? 
@@ -43,10 +44,9 @@ export const MultiInput = ({
     <InputContext.Provider value={{ isValid, type, borderPlacement }}>
       <div className={containerStyle}>
         <Label required={required}>{label}</Label>
-        <div className={`
-         ${inputFieldsContainerStyle}
-         ${borderPlacement === 'container' && interactableBorderStyle({ isValid })}
-         `}
+        <div className={clsx(
+          inputFieldsContainerStyle,
+          interactableBorderStyle({ isValid }))}
         >
           {childrenWithSeparators}
         </div>

--- a/frontend/src/components/Input/MultiInput.tsx
+++ b/frontend/src/components/Input/MultiInput.tsx
@@ -46,7 +46,8 @@ export const MultiInput = ({
         <Label required={required}>{label}</Label>
         <div className={clsx(
           inputFieldsContainerStyle,
-          interactableBorderStyle({ isValid }))}
+          borderPlacement === 'container' && interactableBorderStyle({ isValid }), 
+        )}
         >
           {childrenWithSeparators}
         </div>

--- a/frontend/src/components/Input/SingleInput.tsx
+++ b/frontend/src/components/Input/SingleInput.tsx
@@ -1,11 +1,11 @@
 import type { InputHTMLAttributes } from 'react';
 
 import { type CommonInputProps } from '.';
-import HelperText from './HelperText';
-import { containerStyle, inputFieldsContainerStyle } from './index.css';
+import HelperText from './Core/HelperText';
+import InputField from './Core/InputField';
+import Label from './Core/Label';
+import { containerStyle, inputFieldsContainerStyle, interactableBorderStyle } from './index.css';
 import { InputContext } from './InputContext';
-import InputField from './InputField';
-import Label from './Label';
 
 export interface SingleInputProps extends CommonInputProps {
   inputProps?: Omit<InputHTMLAttributes<HTMLInputElement>, 'placeholder' | 'onClick' | 'readOnly'>;
@@ -25,7 +25,7 @@ export const SingleInput = ({
   <InputContext.Provider value={{ isValid, type }}>
     <div className={containerStyle}>
       <Label required={required}>{label}</Label>
-      <div className={inputFieldsContainerStyle}>
+      <div className={`${inputFieldsContainerStyle} ${interactableBorderStyle({ isValid })}`}>
         <InputField 
           {...inputProps}
           onClick={onClick} 

--- a/frontend/src/components/Input/index.css.ts
+++ b/frontend/src/components/Input/index.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
 import { vars } from '../../theme/index.css';
 
@@ -11,7 +12,10 @@ export const containerStyle = style({
 export const inputFieldsContainerStyle = style({ 
   display: 'flex',
   alignItems: 'center',
-  gap: vars.spacing[300],
+  height: 40,
+  gap: vars.spacing[200],
+  borderRadius: vars.radius[200],
+  boxSizing: 'border-box',
 });
 
 export const separatorStyle = style({
@@ -20,4 +24,26 @@ export const separatorStyle = style({
   justifyContent: 'center',
   width: 20,
   color: vars.color.Ref.Netural[500],
+});
+
+export const interactableBorderStyle = recipe({
+  base: {    
+    border: `1px solid ${vars.color.Ref.Netural[300]}`,
+    borderWidth: 1.5, 
+  },
+  variants: {
+    isValid: {
+      true: {
+        ':hover': {
+          borderColor: vars.color.Ref.Primary[200],
+        },
+        ':focus-within': {
+          borderColor: vars.color.Ref.Primary[500],
+        },
+      },
+      false: {
+        borderColor: vars.color.Ref.Red[500],
+      },
+    },
+  }, 
 });

--- a/frontend/src/utils/jsxUtils.tsx
+++ b/frontend/src/utils/jsxUtils.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from '@tanstack/react-router';
+import type { JSX } from 'react';
+
+export const intersperseElement = (
+  childElements: ReactNode[],
+  separator?: JSX.Element,
+): ReactNode[] => {
+  const result: ReactNode[] = [];
+  childElements.forEach((child, index) => {
+    result.push(child);
+    if (separator && index < childElements.length - 1) {
+      result.push(<separator.type {...separator.props} key={index} />);
+    }
+  });
+  return result;
+};


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #99 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
`borderPlacement = 'container' | 'inputField'` prop을 통해 border 설정 위치를 조정할 수 있습니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a flexible border placement option in input components for enhanced layout configuration.
	- Added a new `intersperseElement` function to manage child elements with separators in the `MultiInput` component.
- **Style**
	- Refreshed input and label styling with improved spacing, padding, and border rendering for a cleaner, more responsive interface.
	- Introduced a new style for `interactableBorderStyle` to enhance border rendering based on validity.
- **Refactor**
	- Streamlined the component structure and utility logic to ensure consistent visual behavior across input components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->