### PR TITLE
[BE-Feat] 후보 일정 확정 기능 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -61,7 +61,8 @@ public class DiscussionController {
         @PathVariable Long discussionId,
         @Valid @RequestBody SharedEventRequest request) {
 
-        SharedEventWithDiscussionInfoResponse response = discussionService.confirmSchedule(discussionId, request);
+        SharedEventWithDiscussionInfoResponse response = discussionService.confirmSchedule(
+            discussionId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -2,6 +2,8 @@ package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionResponse;
+import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
+import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.global.error.ErrorResponse;
 import endolphin.backend.global.util.URIUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,5 +43,25 @@ public class DiscussionController {
         CreateDiscussionResponse response = discussionService.createDiscussion(request);
         URI location = URIUtil.buildResourceUri(response.id());
         return ResponseEntity.created(location).body(response);
+    }
+
+    @Operation(summary = "논의 확정", description = "후보 일정을 해당 논의의 공유 일정으로 확정합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "논의 확정 성공",
+            content = @Content(schema = @Schema(implementation = SharedEventWithDiscussionInfoResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/{discussionId}/confirm")
+    public ResponseEntity<SharedEventWithDiscussionInfoResponse> confirmSchedule(
+        @PathVariable Long discussionId,
+        @Valid @RequestBody SharedEventRequest request) {
+
+        SharedEventWithDiscussionInfoResponse response = discussionService.confirmSchedule(discussionId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -1,7 +1,7 @@
 package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
-import endolphin.backend.domain.discussion.dto.CreateDiscussionResponse;
+import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.global.error.ErrorResponse;
@@ -29,7 +29,7 @@ public class DiscussionController {
     @Operation(summary = "논의 생성", description = "새 논의를 생성합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "논의 생성 성공",
-            content = @Content(schema = @Schema(implementation = CreateDiscussionResponse.class))),
+            content = @Content(schema = @Schema(implementation = DiscussionResponse.class))),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "인증 실패",
@@ -38,9 +38,9 @@ public class DiscussionController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping
-    public ResponseEntity<CreateDiscussionResponse> createDiscussion(
+    public ResponseEntity<DiscussionResponse> createDiscussion(
         @RequestBody @Valid CreateDiscussionRequest request) {
-        CreateDiscussionResponse response = discussionService.createDiscussion(request);
+        DiscussionResponse response = discussionService.createDiscussion(request);
         URI location = URIUtil.buildResourceUri(response.id());
         return ResponseEntity.created(location).body(response);
     }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -1,10 +1,19 @@
 package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DiscussionParticipantRepository extends JpaRepository<DiscussionParticipant, Long> {
+public interface DiscussionParticipantRepository extends
+    JpaRepository<DiscussionParticipant, Long> {
 
+    @Query("SELECT u.picture " +
+        "FROM DiscussionParticipant dp " +
+        "JOIN dp.user u " +
+        "WHERE dp.discussion.id = :discussionId")
+    List<String> findUserPicturesByDiscussionId(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -88,21 +88,11 @@ public class DiscussionService {
         );
     }
 
-    private String calculateTimeLeft(LocalDate deadline) {
+    private long calculateTimeLeft(LocalDate deadline) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime deadlineDateTime = deadline.atTime(23, 59, 59);
         Duration duration = Duration.between(now, deadlineDateTime);
 
-        long days = duration.toDays();
-        long hours = duration.toHours() % 24;
-        long minutes = duration.toMinutes() % 60;
-
-        if (days > 0) {
-            return "마감까지 " + days + "일";
-        } else if (hours > 0) {
-            return "마감까지 " + hours + "시간";
-        } else {
-            return "마감시간까지 " + minutes + "분";
-        }
+        return duration.toMillis();
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -1,7 +1,7 @@
 package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
-import endolphin.backend.domain.discussion.dto.CreateDiscussionResponse;
+import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
 import endolphin.backend.domain.shared_event.SharedEventService;
@@ -30,7 +30,7 @@ public class DiscussionService {
     private final UserService userService;
     private final SharedEventService sharedEventService;
 
-    public CreateDiscussionResponse createDiscussion(CreateDiscussionRequest request) {
+    public DiscussionResponse createDiscussion(CreateDiscussionRequest request) {
 
         Discussion discussion = Discussion.builder()
             .title(request.title())
@@ -54,7 +54,7 @@ public class DiscussionService {
             .build();
         discussionParticipantRepository.save(participant);
 
-        return new CreateDiscussionResponse(
+        return new DiscussionResponse(
             discussion.getId(),
             discussion.getTitle(),
             discussion.getDateRangeStart(),

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/CreateDiscussionResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/CreateDiscussionResponse.java
@@ -11,6 +11,6 @@ public record CreateDiscussionResponse(
     MeetingMethod meetingMethod,
     String location,
     Integer duration,
-    String timeLeft) {
+    long timeLeft) {
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/DiscussionResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/DiscussionResponse.java
@@ -3,7 +3,7 @@ package endolphin.backend.domain.discussion.dto;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
 import java.time.LocalDate;
 
-public record CreateDiscussionResponse(
+public record DiscussionResponse(
     Long id,
     String title,
     LocalDate dateRangeStart,

--- a/backend/src/main/java/endolphin/backend/domain/discussion/entity/Discussion.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/entity/Discussion.java
@@ -4,6 +4,7 @@ import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
 import endolphin.backend.global.base_entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -69,5 +70,10 @@ public class Discussion extends BaseTimeEntity {
         this.deadline = deadline;
         this.meetingMethod = meetingMethod;
         this.location = location;
+    }
+
+    public String getMeetingMethodOrLocation() {
+        return Optional.ofNullable(location)
+            .orElseGet(() -> meetingMethod != null ? meetingMethod.name() : null);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
@@ -1,0 +1,45 @@
+package endolphin.backend.domain.shared_event;
+
+import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
+import endolphin.backend.domain.shared_event.dto.SharedEventResponse;
+import endolphin.backend.domain.shared_event.entity.SharedEvent;
+import endolphin.backend.global.error.exception.ApiException;
+import endolphin.backend.global.error.exception.ErrorCode;
+import endolphin.backend.global.util.Validator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SharedEventService {
+
+    private final SharedEventRepository sharedEventRepository;
+
+    public SharedEventResponse createSharedEvent(Discussion discussion,
+        SharedEventRequest request) {
+        Validator.validateDateTimeRange(request.startTime(), request.endTime());
+
+        SharedEvent sharedEvent = SharedEvent.builder()
+            .discussion(discussion)
+            .start(request.startTime())
+            .end(request.endTime())
+            .build();
+
+        return SharedEventResponse.of(sharedEventRepository.save(sharedEvent));
+    }
+
+    public SharedEventResponse getSharedEvent(Long sharedEventId) {
+        SharedEvent sharedEvent = sharedEventRepository.findById(sharedEventId)
+            .orElseThrow(() -> new ApiException(ErrorCode.SHARED_EVENT_NOT_FOUND));
+
+        return SharedEventResponse.of(sharedEvent);
+    }
+
+    public void deleteSharedEvent(Long sharedEventId) {
+        sharedEventRepository.deleteById(sharedEventId);
+    }
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventRequest.java
@@ -1,0 +1,10 @@
+package endolphin.backend.domain.shared_event.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record SharedEventRequest(
+    @NotNull LocalDateTime startTime,
+    @NotNull LocalDateTime endTime) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventResponse.java
@@ -1,0 +1,19 @@
+package endolphin.backend.domain.shared_event.dto;
+
+import endolphin.backend.domain.shared_event.entity.SharedEvent;
+import java.time.LocalDateTime;
+
+public record SharedEventResponse(
+    Long id,
+    LocalDateTime startDateTime,
+    LocalDateTime endDateTime
+) {
+    public static SharedEventResponse of(SharedEvent event) {
+        return new SharedEventResponse(
+            event.getId(),
+            event.getStartDateTime(),
+            event.getEndDateTime()
+        );
+    }
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventWithDiscussionInfoResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventWithDiscussionInfoResponse.java
@@ -1,0 +1,12 @@
+package endolphin.backend.domain.shared_event.dto;
+
+import java.util.List;
+
+public record SharedEventWithDiscussionInfoResponse(
+    Long discussionId,
+    String title,
+    String meetingMethodOrLocation,
+    SharedEventResponse sharedEventResponse,
+    List<String> participantPictureUrls) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/entity/SharedEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/entity/SharedEvent.java
@@ -23,15 +23,15 @@ public class SharedEvent {
     private Discussion discussion;
 
     @Column(name = "start_time", nullable = false)
-    private LocalDateTime startTime;
+    private LocalDateTime startDateTime;
 
     @Column(name = "end_time", nullable = false)
-    private LocalDateTime endTime;
+    private LocalDateTime endDateTime;
 
     @Builder
     public SharedEvent(Discussion discussion, LocalDateTime start, LocalDateTime end) {
         this.discussion = discussion;
-        this.startTime = start;
-        this.endTime = end;
+        this.startDateTime = start;
+        this.endDateTime = end;
     }
 }

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
     // Discussion
     DISCUSSION_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "Discussion not found"),
 
+    //SharedEvent
+    SHARED_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "Shared Event not found")
+
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -12,6 +12,9 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "User not found"),
 
+    // Discussion
+    DISCUSSION_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "Discussion not found"),
+
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionControllerTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
-import endolphin.backend.domain.discussion.dto.CreateDiscussionResponse;
+import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -60,7 +60,7 @@ public class DiscussionControllerTest {
         );
 
         // given: 서비스가 반환할 응답 DTO 생성
-        CreateDiscussionResponse response = new CreateDiscussionResponse(
+        DiscussionResponse response = new DiscussionResponse(
             100L,
             "Test Discussion",
             LocalDate.of(2025, 2, 10),

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionControllerTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionControllerTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionResponse;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +68,7 @@ public class DiscussionControllerTest {
             MeetingMethod.ONLINE,
             null,
             60,
-            "마감까지 10일"
+            Duration.ofDays(10).toMillis()
         );
 
         given(discussionService.createDiscussion(request)).willReturn(response);

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -1,17 +1,29 @@
 package endolphin.backend.domain.discussion;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
+import endolphin.backend.domain.shared_event.SharedEventService;
+import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
+import endolphin.backend.domain.shared_event.dto.SharedEventResponse;
+import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.entity.User;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +43,9 @@ public class DiscussionServiceTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private SharedEventService sharedEventService;
 
     @InjectMocks
     private DiscussionService discussionService;
@@ -74,5 +89,49 @@ public class DiscussionServiceTest {
         assertThat(response.duration()).isEqualTo(60);
         assertThat(response.timeLeft()).isNotNull();
         assertThat(response.timeLeft()).isEqualTo("마감까지 10일");
+    }
+
+    @DisplayName("Discussion 일정 확정 테스트")
+    @Test
+    public void confirmSchedule_withValidRequest_returnsExpectedResponse() {
+        Long discussionId = 1L;
+        Discussion discussion = Discussion.builder()
+            .title("Project Sync")
+            .meetingMethod(MeetingMethod.ONLINE)
+            .build();
+
+        SharedEventRequest request = new SharedEventRequest(
+            LocalDateTime.of(2025, 3, 1, 10, 0),
+            LocalDateTime.of(2025, 3, 1, 12, 0)
+        );
+
+        SharedEventResponse sharedEventResponse = new SharedEventResponse(
+            101L,
+            request.startTime(),
+            request.endTime()
+        );
+
+        List<String> participantPictures = List.of("pic1.jpg", "pic2.jpg");
+
+        when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
+        when(sharedEventService.createSharedEvent(discussion, request)).thenReturn(
+            sharedEventResponse);
+        when(discussionParticipantRepository.findUserPicturesByDiscussionId(
+            discussionId)).thenReturn(participantPictures);
+
+        SharedEventWithDiscussionInfoResponse response = discussionService.confirmSchedule(
+            discussionId, request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.discussionId()).isEqualTo(discussionId);
+        assertThat(response.title()).isEqualTo("Project Sync");
+        assertThat(response.meetingMethodOrLocation()).isEqualTo("ONLINE");
+        assertThat(response.sharedEventResponse().id()).isEqualTo(101L);
+        assertThat(response.participantPictureUrls()).containsExactlyElementsOf(
+            participantPictures);
+
+        verify(discussionRepository).findById(discussionId);
+        verify(sharedEventService).createSharedEvent(discussion, request);
+        verify(discussionParticipantRepository).findUserPicturesByDiscussionId(discussionId);
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -2,10 +2,9 @@ package endolphin.backend.domain.discussion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +18,7 @@ import endolphin.backend.domain.shared_event.dto.SharedEventResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.entity.User;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -87,8 +87,9 @@ public class DiscussionServiceTest {
         assertThat(response.meetingMethod()).isEqualTo(MeetingMethod.OFFLINE);
         assertThat(response.location()).isEqualTo("회의실 1");
         assertThat(response.duration()).isEqualTo(60);
-        assertThat(response.timeLeft()).isNotNull();
-        assertThat(response.timeLeft()).isEqualTo("마감까지 10일");
+        long timeLeft = Duration.between(LocalDateTime.now(), request.deadline().atTime(23, 59, 59))
+            .toMillis();
+        assertThat(response.timeLeft()).isCloseTo(timeLeft, within(1000L));
     }
 
     @DisplayName("Discussion 일정 확정 테스트")

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
-import endolphin.backend.domain.discussion.dto.CreateDiscussionResponse;
+import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
 import endolphin.backend.domain.shared_event.SharedEventService;
@@ -76,7 +76,7 @@ public class DiscussionServiceTest {
         given(userService.getCurrentUser()).willReturn(dummyUser);
 
         // when
-        CreateDiscussionResponse response = discussionService.createDiscussion(request);
+        DiscussionResponse response = discussionService.createDiscussion(request);
 
         // then
         assertThat(response).isNotNull();

--- a/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
@@ -1,0 +1,112 @@
+package endolphin.backend.domain.shared_event;
+
+import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
+import endolphin.backend.domain.shared_event.dto.SharedEventResponse;
+import endolphin.backend.domain.shared_event.entity.SharedEvent;
+import endolphin.backend.global.error.ErrorResponse;
+import endolphin.backend.global.error.exception.ApiException;
+import endolphin.backend.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SharedEventServiceTest {
+
+    @Mock
+    private SharedEventRepository sharedEventRepository;
+
+    @InjectMocks
+    private SharedEventService sharedEventService;
+
+    private Discussion discussion;
+    private SharedEventRequest request;
+    private SharedEvent sharedEvent;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        discussion = Discussion.builder()
+            .title("Team Meeting")
+            .build();
+
+        request = new SharedEventRequest(
+            LocalDateTime.of(2025, 3, 1, 10, 0),
+            LocalDateTime.of(2025, 3, 1, 12, 0)
+        );
+
+        sharedEvent = SharedEvent.builder()
+            .discussion(discussion)
+            .start(request.startTime())
+            .end(request.endTime())
+            .build();
+
+        ReflectionTestUtils.setField(sharedEvent, "id", 100L);
+    }
+
+    @Test
+    void createSharedEvent_Success() {
+        when(sharedEventRepository.save(any(SharedEvent.class))).thenReturn(sharedEvent);
+
+        SharedEventResponse response = sharedEventService.createSharedEvent(discussion, request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(100L);
+        assertThat(response.startDateTime()).isEqualTo(request.startTime());
+        assertThat(response.endDateTime()).isEqualTo(request.endTime());
+
+        verify(sharedEventRepository, times(1)).save(any(SharedEvent.class));
+    }
+
+    @Test
+    void getSharedEvent_Success() {
+        when(sharedEventRepository.findById(100L)).thenReturn(Optional.of(sharedEvent));
+
+        SharedEventResponse response = sharedEventService.getSharedEvent(100L);
+
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(100L);
+
+        verify(sharedEventRepository, times(1)).findById(100L);
+    }
+
+    @Test
+    void getSharedEvent_NotFound_ThrowsException() {
+        when(sharedEventRepository.findById(999L)).thenReturn(Optional.empty());
+
+        ApiException exception = (ApiException) catchThrowable(() ->
+            sharedEventService.getSharedEvent(999L)
+        );
+
+        ErrorResponse errorResponse = ErrorResponse.of(exception.getErrorCode());
+
+        assertThat(errorResponse).isNotNull();
+        assertThat(errorResponse.message()).isEqualTo(
+            ErrorCode.SHARED_EVENT_NOT_FOUND.getMessage());
+        assertThat(errorResponse.code()).isEqualTo(ErrorCode.SHARED_EVENT_NOT_FOUND.getCode());
+
+        verify(sharedEventRepository, times(1)).findById(999L);
+    }
+
+    @Test
+    void deleteSharedEvent_Success() {
+        doNothing().when(sharedEventRepository).deleteById(100L);
+
+        sharedEventService.deleteSharedEvent(100L);
+
+        verify(sharedEventRepository, times(1)).deleteById(100L);
+    }
+}


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #108 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 후보일정을 확정하는 Api를 구현했습니다.
- 필요한 메서드를 여러 도메인에 추가했습니다.
- 일정 확정 이후에 발생하는 로직은 다음 작업때 진행할 예정입니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- DiscussionParticipantRepository에 Users 테이블을 조인하는 쿼리를 추가했습니다. 잘 살펴봐주세요