### PR TITLE
[BE-Feat] 논의 확정 이후 비즈니스 로직 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -58,7 +59,7 @@ public class DiscussionController {
     })
     @PostMapping("/{discussionId}/confirm")
     public ResponseEntity<SharedEventWithDiscussionInfoResponse> confirmSchedule(
-        @PathVariable Long discussionId,
+        @PathVariable @Min(1) Long discussionId,
         @Valid @RequestBody SharedEventRequest request) {
 
         SharedEventWithDiscussionInfoResponse response = discussionService.confirmSchedule(

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -1,6 +1,7 @@
 package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
+import endolphin.backend.domain.user.dto.UserProfile;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,4 +17,10 @@ public interface DiscussionParticipantRepository extends
         "JOIN dp.user u " +
         "WHERE dp.discussion.id = :discussionId")
     List<String> findUserPicturesByDiscussionId(@Param("discussionId") Long discussionId);
+
+    @Query("select new endolphin.backend.domain.user.dto.UserProfile(u.id, u.picture) " +
+        "from DiscussionParticipant dp " +
+        "join dp.user u " +
+        "where dp.discussion.id = :discussionId")
+    List<UserProfile> findUserProfilesByDiscussionId(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -18,9 +18,9 @@ public interface DiscussionParticipantRepository extends
         "WHERE dp.discussion.id = :discussionId")
     List<String> findUserPicturesByDiscussionId(@Param("discussionId") Long discussionId);
 
-    @Query("select u " +
+    @Query("select dp " +
         "from DiscussionParticipant dp " +
-        "join dp.user u " +
+        "join fetch dp.user " +
         "where dp.discussion.id = :discussionId")
     List<User> findUsersByDiscussionId(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -1,7 +1,7 @@
 package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
-import endolphin.backend.domain.user.dto.UserProfile;
+import endolphin.backend.domain.user.entity.User;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,9 +18,9 @@ public interface DiscussionParticipantRepository extends
         "WHERE dp.discussion.id = :discussionId")
     List<String> findUserPicturesByDiscussionId(@Param("discussionId") Long discussionId);
 
-    @Query("select new endolphin.backend.domain.user.dto.UserProfile(u.id, u.picture) " +
+    @Query("select u " +
         "from DiscussionParticipant dp " +
         "join dp.user u " +
         "where dp.discussion.id = :discussionId")
-    List<UserProfile> findUserProfilesByDiscussionId(@Param("discussionId") Long discussionId);
+    List<User> findUsersByDiscussionId(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -1,0 +1,30 @@
+package endolphin.backend.domain.discussion;
+
+import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
+import endolphin.backend.domain.user.entity.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DiscussionParticipantService {
+
+    private final DiscussionParticipantRepository discussionParticipantRepository;
+
+    public void addDiscussionParticipant(Discussion discussion, User user) {
+        DiscussionParticipant participant = DiscussionParticipant.builder()
+            .discussion(discussion)
+            .user(user)
+            .isHost(true) // TODO 전처리 진행하실때 user index 관련 로직으로 변경해주시면 감사하겠습니다.
+            .build();
+        discussionParticipantRepository.save(participant);
+    }
+
+    public List<User> getUsersByDiscussionId(Long discussionId){
+        return discussionParticipantRepository.findUsersByDiscussionId(discussionId);
+    }
+}

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -24,6 +24,7 @@ public class DiscussionParticipantService {
         discussionParticipantRepository.save(participant);
     }
 
+    @Transactional(readOnly = true)
     public List<User> getUsersByDiscussionId(Long discussionId){
         return discussionParticipantRepository.findUsersByDiscussionId(discussionId);
     }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -9,6 +9,7 @@ import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventResponse;
 import endolphin.backend.domain.user.UserService;
+import endolphin.backend.domain.user.dto.UserProfile;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
@@ -73,8 +74,15 @@ public class DiscussionService {
 
         SharedEventResponse sharedEventResponse = sharedEventService.createSharedEvent(discussion,
             request);
-        List<String> participantPictures = discussionParticipantRepository.findUserPicturesByDiscussionId(
+
+        List<UserProfile> participants = discussionParticipantRepository.findUserProfilesByDiscussionId(
             discussionId);
+
+        List<Long> participantIds = participants.stream().map(UserProfile::id)
+            .toList();
+
+        List<String> participantPictures = participants.stream().map(UserProfile::pictureUrl)
+            .toList();
 
         //TODO: 모든 참여자의 개인 일정에 확정 일정 추가
         //TODO: Redis 데이터 삭제

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -9,7 +9,6 @@ import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.user.UserService;
-import endolphin.backend.domain.user.dto.UserProfile;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
@@ -75,13 +74,10 @@ public class DiscussionService {
         SharedEventDto sharedEventDto = sharedEventService.createSharedEvent(discussion,
             request);
 
-        List<UserProfile> participants = discussionParticipantRepository.findUserProfilesByDiscussionId(
+        List<User> participants = discussionParticipantRepository.findUsersByDiscussionId(
             discussionId);
 
-        List<Long> participantIds = participants.stream().map(UserProfile::id)
-            .toList();
-
-        List<String> participantPictures = participants.stream().map(UserProfile::pictureUrl)
+        List<String> participantPictures = participants.stream().map(User::getPicture)
             .toList();
 
         //TODO: 모든 참여자의 개인 일정에 확정 일정 추가

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -31,10 +31,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class DiscussionService {
 
     private final DiscussionRepository discussionRepository;
-    private final DiscussionParticipantRepository discussionParticipantRepository;
     private final UserService userService;
     private final PersonalEventService personalEventService;
     private final SharedEventService sharedEventService;
+    private final DiscussionParticipantService discussionParticipantService;
     private final DiscussionBitmapService discussionBitmapService;
 
     public DiscussionResponse createDiscussion(CreateDiscussionRequest request) {
@@ -54,12 +54,8 @@ public class DiscussionService {
         discussionRepository.save(discussion);
 
         User currentUser = userService.getCurrentUser();
-        DiscussionParticipant participant = DiscussionParticipant.builder()
-            .discussion(discussion)
-            .user(currentUser)
-            .isHost(true)
-            .build();
-        discussionParticipantRepository.save(participant);
+
+        discussionParticipantService.addDiscussionParticipant(discussion, currentUser);
 
         return new DiscussionResponse(
             discussion.getId(),
@@ -81,8 +77,7 @@ public class DiscussionService {
         SharedEventDto sharedEventDto = sharedEventService.createSharedEvent(discussion,
             request);
 
-        List<User> participants = discussionParticipantRepository.findUsersByDiscussionId(
-            discussionId);
+        List<User> participants = discussionParticipantService.getUsersByDiscussionId(discussionId);
 
         List<String> participantPictures = participants.stream().map(User::getPicture)
             .toList();

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -7,7 +7,7 @@ import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
 import endolphin.backend.domain.shared_event.SharedEventService;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
-import endolphin.backend.domain.shared_event.dto.SharedEventResponse;
+import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.dto.UserProfile;
 import endolphin.backend.domain.user.entity.User;
@@ -72,7 +72,7 @@ public class DiscussionService {
         Discussion discussion = discussionRepository.findById(discussionId)
             .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_NOT_FOUND));
 
-        SharedEventResponse sharedEventResponse = sharedEventService.createSharedEvent(discussion,
+        SharedEventDto sharedEventDto = sharedEventService.createSharedEvent(discussion,
             request);
 
         List<UserProfile> participants = discussionParticipantRepository.findUserProfilesByDiscussionId(
@@ -91,7 +91,7 @@ public class DiscussionService {
             discussionId,
             discussion.getTitle(),
             discussion.getMeetingMethodOrLocation(),
-            sharedEventResponse,
+            sharedEventDto,
             participantPictures
         );
     }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -82,13 +82,14 @@ public class DiscussionService {
         List<String> participantPictures = participants.stream().map(User::getPicture)
             .toList();
 
-        personalEventService.createPersonalEventsForParticipants(participants, discussion, sharedEventDto);
+        personalEventService.createPersonalEventsForParticipants(participants, discussion,
+            sharedEventDto);
 
         discussionBitmapService.deleteDiscussionBitmapsUsingScan(discussionId)
             .thenRun(() -> log.info("Redis keys deleted successfully for discussionId : {}",
                 discussionId))
             .exceptionally(ex -> {
-                log.error("Failed to delete Redis keys", ex);
+                log.error("Failed to delete Redis keys for three times", ex);
                 return null;
             });
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -82,16 +82,7 @@ public class DiscussionService {
         List<String> participantPictures = participants.stream().map(User::getPicture)
             .toList();
 
-        personalEventService.createPersonalEventsForParticipants(participants, discussion, sharedEventDto)
-            .thenRun(() -> log.info("PersonalEvent creation success for discussion {}", discussionId))
-            .exceptionally(ex -> {
-                /*TODO 실패시 처리
-                실패시 retry 사용을 위해 spring-retry 라이브러리 사용할지, 직접 구현할지?
-                아니면 이 부분을 그냥 동기로 처리할지에 대해 의견 주시면 감사하겠습니다.
-                 */
-                log.error("PersonalEvent creation failed: {}", ex.getMessage(), ex);
-                return null;
-            });
+        personalEventService.createPersonalEventsForParticipants(participants, discussion, sharedEventDto);
 
         discussionBitmapService.deleteDiscussionBitmapsUsingScan(discussionId)
             .thenRun(() -> log.info("Redis keys deleted successfully for discussionId : {}",

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -1,15 +1,19 @@
 package endolphin.backend.domain.personal_event;
 
+import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.personal_event.dto.PersonalEventRequest;
 import endolphin.backend.domain.personal_event.dto.PersonalEventResponse;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.dto.ListResponse;
 import endolphin.backend.global.util.Validator;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +51,24 @@ public class PersonalEventService {
             .build();
         PersonalEvent result = personalEventRepository.save(personalEvent);
         return PersonalEventResponse.fromEntity(result);
+    }
+
+    @Async
+    public CompletableFuture<Void> createPersonalEventsForParticipants(List<User> participants,
+        Discussion discussion,
+        SharedEventDto sharedEvent) {
+        for (User participant : participants) {
+            PersonalEvent personalEvent = PersonalEvent.builder()
+                .title(discussion.getTitle())
+                .startTime(sharedEvent.startDateTime())
+                .endTime(sharedEvent.endDateTime())
+                .user(participant)
+                .build();
+
+            personalEventRepository.save(personalEvent);
+        }
+
+        return CompletableFuture.completedFuture(null);
     }
 
     public PersonalEventResponse updatePersonalEvent(PersonalEventRequest request,

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -57,18 +57,22 @@ public class PersonalEventService {
     public CompletableFuture<Void> createPersonalEventsForParticipants(List<User> participants,
         Discussion discussion,
         SharedEventDto sharedEvent) {
-        for (User participant : participants) {
-            PersonalEvent personalEvent = PersonalEvent.builder()
-                .title(discussion.getTitle())
-                .startTime(sharedEvent.startDateTime())
-                .endTime(sharedEvent.endDateTime())
-                .user(participant)
-                .build();
+        try {
+            for (User participant : participants) {
+                PersonalEvent personalEvent = PersonalEvent.builder()
+                    .title(discussion.getTitle())
+                    .startTime(sharedEvent.startDateTime())
+                    .endTime(sharedEvent.endDateTime())
+                    .user(participant)
+                    .build();
 
-            personalEventRepository.save(personalEvent);
+                personalEventRepository.save(personalEvent);
+            }
+
+            return CompletableFuture.completedFuture(null);
+        } catch (Exception ex) {
+            return CompletableFuture.failedFuture(ex);
         }
-
-        return CompletableFuture.completedFuture(null);
     }
 
     public PersonalEventResponse updatePersonalEvent(PersonalEventRequest request,

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -58,16 +58,16 @@ public class PersonalEventService {
         Discussion discussion,
         SharedEventDto sharedEvent) {
         try {
-            for (User participant : participants) {
-                PersonalEvent personalEvent = PersonalEvent.builder()
+            List<PersonalEvent> events = participants.stream()
+                .map(participant -> PersonalEvent.builder()
                     .title(discussion.getTitle())
                     .startTime(sharedEvent.startDateTime())
                     .endTime(sharedEvent.endDateTime())
                     .user(participant)
-                    .build();
+                    .build())
+                .toList();
 
-                personalEventRepository.save(personalEvent);
-            }
+            personalEventRepository.saveAll(events);
 
             return CompletableFuture.completedFuture(null);
         } catch (Exception ex) {

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -11,9 +11,7 @@ import endolphin.backend.global.dto.ListResponse;
 import endolphin.backend.global.util.Validator;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,26 +51,19 @@ public class PersonalEventService {
         return PersonalEventResponse.fromEntity(result);
     }
 
-    @Async
-    public CompletableFuture<Void> createPersonalEventsForParticipants(List<User> participants,
+    public void createPersonalEventsForParticipants(List<User> participants,
         Discussion discussion,
         SharedEventDto sharedEvent) {
-        try {
-            List<PersonalEvent> events = participants.stream()
-                .map(participant -> PersonalEvent.builder()
-                    .title(discussion.getTitle())
-                    .startTime(sharedEvent.startDateTime())
-                    .endTime(sharedEvent.endDateTime())
-                    .user(participant)
-                    .build())
-                .toList();
+        List<PersonalEvent> events = participants.stream()
+            .map(participant -> PersonalEvent.builder()
+                .title(discussion.getTitle())
+                .startTime(sharedEvent.startDateTime())
+                .endTime(sharedEvent.endDateTime())
+                .user(participant)
+                .build())
+            .toList();
 
-            personalEventRepository.saveAll(events);
-
-            return CompletableFuture.completedFuture(null);
-        } catch (Exception ex) {
-            return CompletableFuture.failedFuture(ex);
-        }
+        personalEventRepository.saveAll(events);
     }
 
     public PersonalEventResponse updatePersonalEvent(PersonalEventRequest request,

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
@@ -31,6 +31,7 @@ public class SharedEventService {
         return SharedEventResponse.of(sharedEventRepository.save(sharedEvent));
     }
 
+    @Transactional(readOnly = true)
     public SharedEventResponse getSharedEvent(Long sharedEventId) {
         SharedEvent sharedEvent = sharedEventRepository.findById(sharedEventId)
             .orElseThrow(() -> new ApiException(ErrorCode.SHARED_EVENT_NOT_FOUND));

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
@@ -39,6 +39,9 @@ public class SharedEventService {
     }
 
     public void deleteSharedEvent(Long sharedEventId) {
+        if (!sharedEventRepository.existsById(sharedEventId)) {
+            throw new ApiException(ErrorCode.SHARED_EVENT_NOT_FOUND);
+        }
         sharedEventRepository.deleteById(sharedEventId);
     }
 

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
@@ -20,12 +20,12 @@ public class SharedEventService {
 
     public SharedEventResponse createSharedEvent(Discussion discussion,
         SharedEventRequest request) {
-        Validator.validateDateTimeRange(request.startTime(), request.endTime());
+        Validator.validateDateTimeRange(request.startDateTime(), request.endDateTime());
 
         SharedEvent sharedEvent = SharedEvent.builder()
             .discussion(discussion)
-            .start(request.startTime())
-            .end(request.endTime())
+            .start(request.startDateTime())
+            .end(request.endDateTime())
             .build();
 
         return SharedEventResponse.of(sharedEventRepository.save(sharedEvent));

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
@@ -2,7 +2,7 @@ package endolphin.backend.domain.shared_event;
 
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
-import endolphin.backend.domain.shared_event.dto.SharedEventResponse;
+import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.shared_event.entity.SharedEvent;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
@@ -18,7 +18,7 @@ public class SharedEventService {
 
     private final SharedEventRepository sharedEventRepository;
 
-    public SharedEventResponse createSharedEvent(Discussion discussion,
+    public SharedEventDto createSharedEvent(Discussion discussion,
         SharedEventRequest request) {
         Validator.validateDateTimeRange(request.startDateTime(), request.endDateTime());
 
@@ -28,15 +28,15 @@ public class SharedEventService {
             .end(request.endDateTime())
             .build();
 
-        return SharedEventResponse.of(sharedEventRepository.save(sharedEvent));
+        return SharedEventDto.of(sharedEventRepository.save(sharedEvent));
     }
 
     @Transactional(readOnly = true)
-    public SharedEventResponse getSharedEvent(Long sharedEventId) {
+    public SharedEventDto getSharedEvent(Long sharedEventId) {
         SharedEvent sharedEvent = sharedEventRepository.findById(sharedEventId)
             .orElseThrow(() -> new ApiException(ErrorCode.SHARED_EVENT_NOT_FOUND));
 
-        return SharedEventResponse.of(sharedEvent);
+        return SharedEventDto.of(sharedEvent);
     }
 
     public void deleteSharedEvent(Long sharedEventId) {

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventDto.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventDto.java
@@ -3,13 +3,13 @@ package endolphin.backend.domain.shared_event.dto;
 import endolphin.backend.domain.shared_event.entity.SharedEvent;
 import java.time.LocalDateTime;
 
-public record SharedEventResponse(
+public record SharedEventDto(
     Long id,
     LocalDateTime startDateTime,
     LocalDateTime endDateTime
 ) {
-    public static SharedEventResponse of(SharedEvent event) {
-        return new SharedEventResponse(
+    public static SharedEventDto of(SharedEvent event) {
+        return new SharedEventDto(
             event.getId(),
             event.getStartDateTime(),
             event.getEndDateTime()

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public record SharedEventRequest(
-    @NotNull LocalDateTime startTime,
-    @NotNull LocalDateTime endTime) {
+    @NotNull LocalDateTime startDateTime,
+    @NotNull LocalDateTime endDateTime) {
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventWithDiscussionInfoResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/dto/SharedEventWithDiscussionInfoResponse.java
@@ -6,7 +6,7 @@ public record SharedEventWithDiscussionInfoResponse(
     Long discussionId,
     String title,
     String meetingMethodOrLocation,
-    SharedEventResponse sharedEventResponse,
+    SharedEventDto sharedEventDto,
     List<String> participantPictureUrls) {
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/user/dto/UserProfile.java
+++ b/backend/src/main/java/endolphin/backend/domain/user/dto/UserProfile.java
@@ -1,8 +1,0 @@
-package endolphin.backend.domain.user.dto;
-
-public record UserProfile(
-    Long id,
-    String pictureUrl
-) {
-
-}

--- a/backend/src/main/java/endolphin/backend/domain/user/dto/UserProfile.java
+++ b/backend/src/main/java/endolphin/backend/domain/user/dto/UserProfile.java
@@ -1,0 +1,8 @@
+package endolphin.backend.domain.user.dto;
+
+public record UserProfile(
+    Long id,
+    String pictureUrl
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/global/config/EnableAsyncConfig.java
+++ b/backend/src/main/java/endolphin/backend/global/config/EnableAsyncConfig.java
@@ -1,0 +1,10 @@
+package endolphin.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class EnableAsyncConfig {
+
+}

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ApiException.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ApiException.java
@@ -7,6 +7,7 @@ public class ApiException extends RuntimeException {
     private final ErrorCode errorCode;
 
     public ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -108,8 +108,8 @@ public class DiscussionServiceTest {
 
         SharedEventResponse sharedEventResponse = new SharedEventResponse(
             101L,
-            request.startTime(),
-            request.endTime()
+            request.startDateTime(),
+            request.endDateTime()
         );
 
         List<String> participantPictures = List.of("pic1.jpg", "pic2.jpg");

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -14,7 +14,7 @@ import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
 import endolphin.backend.domain.shared_event.SharedEventService;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
-import endolphin.backend.domain.shared_event.dto.SharedEventResponse;
+import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.dto.UserProfile;
@@ -107,7 +107,7 @@ public class DiscussionServiceTest {
             LocalDateTime.of(2025, 3, 1, 12, 0)
         );
 
-        SharedEventResponse sharedEventResponse = new SharedEventResponse(
+        SharedEventDto sharedEventDto = new SharedEventDto(
             101L,
             request.startDateTime(),
             request.endDateTime()
@@ -123,7 +123,7 @@ public class DiscussionServiceTest {
 
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
         when(sharedEventService.createSharedEvent(discussion, request)).thenReturn(
-            sharedEventResponse);
+            sharedEventDto);
         when(discussionParticipantRepository.findUserProfilesByDiscussionId(discussionId))
             .thenReturn(dummyParticipants);
 
@@ -134,7 +134,7 @@ public class DiscussionServiceTest {
         assertThat(response.discussionId()).isEqualTo(discussionId);
         assertThat(response.title()).isEqualTo("Project Sync");
         assertThat(response.meetingMethodOrLocation()).isEqualTo("ONLINE");
-        assertThat(response.sharedEventResponse().id()).isEqualTo(101L);
+        assertThat(response.sharedEventDto().id()).isEqualTo(101L);
 
         assertThat(response.participantPictureUrls()).containsExactlyElementsOf(
             participantPictures);

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -17,7 +17,6 @@ import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.domain.user.UserService;
-import endolphin.backend.domain.user.dto.UserProfile;
 import endolphin.backend.domain.user.entity.User;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -113,18 +112,18 @@ public class DiscussionServiceTest {
             request.endDateTime()
         );
 
-        List<UserProfile> dummyParticipants = List.of(
-            new UserProfile(1L, "picA"),
-            new UserProfile(2L, "picB")
+        List<User> dummyParticipants = List.of(
+            User.builder().name("Bob").email("email1").picture("picA").build(),
+            User.builder().name("Alice").email("email2").picture("picB").build()
         );
 
-        List<String> participantPictures = dummyParticipants.stream().map(UserProfile::pictureUrl)
+        List<String> participantPictures = dummyParticipants.stream().map(User::getPicture)
             .toList();
 
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
         when(sharedEventService.createSharedEvent(discussion, request)).thenReturn(
             sharedEventDto);
-        when(discussionParticipantRepository.findUserProfilesByDiscussionId(discussionId))
+        when(discussionParticipantRepository.findUsersByDiscussionId(discussionId))
             .thenReturn(dummyParticipants);
 
         SharedEventWithDiscussionInfoResponse response = discussionService.confirmSchedule(
@@ -142,6 +141,6 @@ public class DiscussionServiceTest {
         verify(discussionRepository).findById(discussionId);
         verify(sharedEventService).createSharedEvent(discussion, request);
 
-        verify(discussionParticipantRepository).findUserProfilesByDiscussionId(discussionId);
+        verify(discussionParticipantRepository).findUsersByDiscussionId(discussionId);
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -43,9 +43,6 @@ public class DiscussionServiceTest {
     private DiscussionRepository discussionRepository;
 
     @Mock
-    private DiscussionParticipantRepository discussionParticipantRepository;
-
-    @Mock
     private UserService userService;
 
     @Mock
@@ -56,6 +53,9 @@ public class DiscussionServiceTest {
 
     @Mock
     private DiscussionBitmapService discussionBitmapService;
+
+    @Mock
+    private DiscussionParticipantService discussionParticipantService;
 
     @InjectMocks
     private DiscussionService discussionService;
@@ -133,7 +133,7 @@ public class DiscussionServiceTest {
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
         when(sharedEventService.createSharedEvent(discussion, request)).thenReturn(
             sharedEventDto);
-        when(discussionParticipantRepository.findUsersByDiscussionId(discussionId))
+        when(discussionParticipantService.getUsersByDiscussionId(discussionId))
             .thenReturn(dummyParticipants);
 
         when(personalEventService.createPersonalEventsForParticipants(
@@ -159,7 +159,7 @@ public class DiscussionServiceTest {
         verify(discussionRepository).findById(discussionId);
         verify(sharedEventService).createSharedEvent(discussion, request);
 
-        verify(discussionParticipantRepository).findUsersByDiscussionId(discussionId);
+        verify(discussionParticipantService).getUsersByDiscussionId(discussionId);
     }
 
     @DisplayName("논의 확정 후 비동기 작업 실패 시 처리 확인")
@@ -191,7 +191,7 @@ public class DiscussionServiceTest {
         // 정상 데이터 반환 설정
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
         when(sharedEventService.createSharedEvent(discussion, request)).thenReturn(sharedEventDto);
-        when(discussionParticipantRepository.findUsersByDiscussionId(discussionId))
+        when(discussionParticipantService.getUsersByDiscussionId(discussionId))
             .thenReturn(dummyParticipants);
 
         // 비동기 작업 실패 시뮬레이션
@@ -214,7 +214,7 @@ public class DiscussionServiceTest {
 
         verify(discussionRepository).findById(discussionId);
         verify(sharedEventService).createSharedEvent(discussion, request);
-        verify(discussionParticipantRepository).findUsersByDiscussionId(discussionId);
+        verify(discussionParticipantService).getUsersByDiscussionId(discussionId);
         verify(personalEventService).createPersonalEventsForParticipants(
             dummyParticipants, discussion, sharedEventDto
         );

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,6 +13,7 @@ import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
+import endolphin.backend.domain.personal_event.PersonalEventService;
 import endolphin.backend.domain.shared_event.SharedEventService;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventDto;
@@ -24,6 +26,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +49,9 @@ public class DiscussionServiceTest {
 
     @Mock
     private SharedEventService sharedEventService;
+
+    @Mock
+    private PersonalEventService personalEventService;
 
     @InjectMocks
     private DiscussionService discussionService;
@@ -125,6 +131,10 @@ public class DiscussionServiceTest {
             sharedEventDto);
         when(discussionParticipantRepository.findUsersByDiscussionId(discussionId))
             .thenReturn(dummyParticipants);
+
+        when(personalEventService.createPersonalEventsForParticipants(
+            anyList(), any(Discussion.class), any(SharedEventDto.class)
+        )).thenReturn(CompletableFuture.completedFuture(null));
 
         SharedEventWithDiscussionInfoResponse response = discussionService.confirmSchedule(
             discussionId, request);

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -136,10 +136,6 @@ public class DiscussionServiceTest {
         when(discussionParticipantService.getUsersByDiscussionId(discussionId))
             .thenReturn(dummyParticipants);
 
-        when(personalEventService.createPersonalEventsForParticipants(
-            anyList(), any(Discussion.class), any(SharedEventDto.class)
-        )).thenReturn(CompletableFuture.completedFuture(null));
-
         when(discussionBitmapService.deleteDiscussionBitmapsUsingScan(
             any(Long.class)
         )).thenReturn(CompletableFuture.completedFuture(null));
@@ -162,7 +158,7 @@ public class DiscussionServiceTest {
         verify(discussionParticipantService).getUsersByDiscussionId(discussionId);
     }
 
-    @DisplayName("논의 확정 후 비동기 작업 실패 시 처리 확인")
+    @DisplayName("논의 확정 비동기 작업 실패 시 응답 확인")
     @Test
     public void confirmSchedule_asyncFailureHandledGracefully() {
         // Given
@@ -193,11 +189,6 @@ public class DiscussionServiceTest {
         when(sharedEventService.createSharedEvent(discussion, request)).thenReturn(sharedEventDto);
         when(discussionParticipantService.getUsersByDiscussionId(discussionId))
             .thenReturn(dummyParticipants);
-
-        // 비동기 작업 실패 시뮬레이션
-        when(personalEventService.createPersonalEventsForParticipants(
-            anyList(), any(Discussion.class), any(SharedEventDto.class)
-        )).thenReturn(CompletableFuture.failedFuture(new RuntimeException("DB Error")));
 
         when(discussionBitmapService.deleteDiscussionBitmapsUsingScan(any()))
             .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Redis Error")));

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -17,6 +17,7 @@ import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.domain.user.UserService;
+import endolphin.backend.domain.user.dto.UserProfile;
 import endolphin.backend.domain.user.entity.User;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -112,13 +113,19 @@ public class DiscussionServiceTest {
             request.endDateTime()
         );
 
-        List<String> participantPictures = List.of("pic1.jpg", "pic2.jpg");
+        List<UserProfile> dummyParticipants = List.of(
+            new UserProfile(1L, "picA"),
+            new UserProfile(2L, "picB")
+        );
+
+        List<String> participantPictures = dummyParticipants.stream().map(UserProfile::pictureUrl)
+            .toList();
 
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
         when(sharedEventService.createSharedEvent(discussion, request)).thenReturn(
             sharedEventResponse);
-        when(discussionParticipantRepository.findUserPicturesByDiscussionId(
-            discussionId)).thenReturn(participantPictures);
+        when(discussionParticipantRepository.findUserProfilesByDiscussionId(discussionId))
+            .thenReturn(dummyParticipants);
 
         SharedEventWithDiscussionInfoResponse response = discussionService.confirmSchedule(
             discussionId, request);
@@ -128,11 +135,13 @@ public class DiscussionServiceTest {
         assertThat(response.title()).isEqualTo("Project Sync");
         assertThat(response.meetingMethodOrLocation()).isEqualTo("ONLINE");
         assertThat(response.sharedEventResponse().id()).isEqualTo(101L);
+
         assertThat(response.participantPictureUrls()).containsExactlyElementsOf(
             participantPictures);
 
         verify(discussionRepository).findById(discussionId);
         verify(sharedEventService).createSharedEvent(discussion, request);
-        verify(discussionParticipantRepository).findUserPicturesByDiscussionId(discussionId);
+
+        verify(discussionParticipantRepository).findUserProfilesByDiscussionId(discussionId);
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
@@ -2,7 +2,7 @@ package endolphin.backend.domain.shared_event;
 
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
-import endolphin.backend.domain.shared_event.dto.SharedEventResponse;
+import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.shared_event.entity.SharedEvent;
 import endolphin.backend.global.error.ErrorResponse;
 import endolphin.backend.global.error.exception.ApiException;
@@ -63,7 +63,7 @@ class SharedEventServiceTest {
     void createSharedEvent_Success() {
         when(sharedEventRepository.save(any(SharedEvent.class))).thenReturn(sharedEvent);
 
-        SharedEventResponse response = sharedEventService.createSharedEvent(discussion, request);
+        SharedEventDto response = sharedEventService.createSharedEvent(discussion, request);
 
         assertThat(response).isNotNull();
         assertThat(response.id()).isEqualTo(100L);
@@ -78,7 +78,7 @@ class SharedEventServiceTest {
     void getSharedEvent_Success() {
         when(sharedEventRepository.findById(100L)).thenReturn(Optional.of(sharedEvent));
 
-        SharedEventResponse response = sharedEventService.getSharedEvent(100L);
+        SharedEventDto response = sharedEventService.getSharedEvent(100L);
 
         assertThat(response).isNotNull();
         assertThat(response.id()).isEqualTo(100L);

--- a/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
@@ -50,8 +50,8 @@ class SharedEventServiceTest {
 
         sharedEvent = SharedEvent.builder()
             .discussion(discussion)
-            .start(request.startTime())
-            .end(request.endTime())
+            .start(request.startDateTime())
+            .end(request.endDateTime())
             .build();
 
         ReflectionTestUtils.setField(sharedEvent, "id", 100L);
@@ -65,8 +65,8 @@ class SharedEventServiceTest {
 
         assertThat(response).isNotNull();
         assertThat(response.id()).isEqualTo(100L);
-        assertThat(response.startDateTime()).isEqualTo(request.startTime());
-        assertThat(response.endDateTime()).isEqualTo(request.endTime());
+        assertThat(response.startDateTime()).isEqualTo(request.startDateTime());
+        assertThat(response.endDateTime()).isEqualTo(request.endDateTime());
 
         verify(sharedEventRepository, times(1)).save(any(SharedEvent.class));
     }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #113 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 추후 비동기 처리 사용을 위해 EnableAsyncConfig 추가했습니다.
- 후보 일정 확정 이후 참여자들의 개인 일정에 추가되는 로직을 구현했습니다.
- 후보 일정 확정 이후 Redis 데이터 삭제 로직을 추가했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 개인 일정 추가, Redis 데이터 삭제를 일단 비동기로 처리했습니다.
- Redis 데이터 삭제는 비동기로 진행하는 것이 좋아보이는데 개인 일정 추가에 대해서는 의견 주시면 감사하겠습니다.
- 비동기 메서드에서 에러 발생 시 처리를 어떻게 하면 좋을 지 의견 주시면 감사하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved discussion scheduling now creates personal events concurrently for participants.
	- Enhanced retrieval of complete participant details offers a more comprehensive event overview.
	- Updated input validation ensures only valid discussion identifiers are processed.
	- Introduced a new service for managing discussion participants, allowing for easier addition and retrieval of participants.
	- Transitioned to a new data transfer object for shared events, improving consistency and clarity.
- **Bug Fixes**
	- Refined error handling for event deletion delivers clearer feedback when events aren’t found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->