### PR TITLE
[BE-Feat] 후보 일정 전처리 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -3,6 +3,7 @@ package endolphin.backend.domain.discussion;
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
 import endolphin.backend.domain.user.entity.User;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +24,10 @@ public interface DiscussionParticipantRepository extends
         "join fetch dp.user " +
         "where dp.discussion.id = :discussionId")
     List<User> findUsersByDiscussionId(@Param("discussionId") Long discussionId);
+
+    @Query("SELECT dp.index " +
+        "FROM DiscussionParticipant dp " +
+        "WHERE dp.discussion.id = :discussionId AND dp.user.id = :userId")
+    Optional<Long> findIndexByDiscussionIdAndUserId(@Param("discussionId") Long discussionId,
+        @Param("userId") Long userId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -30,4 +30,9 @@ public interface DiscussionParticipantRepository extends
         "WHERE dp.discussion.id = :discussionId AND dp.user.id = :userId")
     Optional<Long> findIndexByDiscussionIdAndUserId(@Param("discussionId") Long discussionId,
         @Param("userId") Long userId);
+
+    @Query("SELECT COALESCE(MAX(dp.index), -1) " +
+        "FROM DiscussionParticipant dp " +
+        "WHERE dp.discussion.id = :discussionId")
+    Optional<Long> findMaxIndexByDiscussionId(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -3,6 +3,8 @@ package endolphin.backend.domain.discussion;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
 import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.error.exception.ApiException;
+import endolphin.backend.global.error.exception.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,5 +29,11 @@ public class DiscussionParticipantService {
     @Transactional(readOnly = true)
     public List<User> getUsersByDiscussionId(Long discussionId){
         return discussionParticipantRepository.findUsersByDiscussionId(discussionId);
+    }
+
+    @Transactional(readOnly = true)
+    public Long getDiscussionParticipantIndex(Long discussionId, Long userId) {
+        return discussionParticipantRepository.findIndexByDiscussionIdAndUserId(discussionId, userId)
+            .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -18,11 +18,25 @@ public class DiscussionParticipantService {
     private final DiscussionParticipantRepository discussionParticipantRepository;
 
     public void addDiscussionParticipant(Discussion discussion, User user) {
-        DiscussionParticipant participant = DiscussionParticipant.builder()
-            .discussion(discussion)
-            .user(user)
-            .isHost(true) // TODO 전처리 진행하실때 user index 관련 로직으로 변경해주시면 감사하겠습니다.
-            .build();
+        Long index = discussionParticipantRepository.findMaxIndexByDiscussionId(discussion.getId())
+            .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_NOT_FOUND));
+        index += 1;
+        DiscussionParticipant participant;
+        if (index == 0) {
+            participant = DiscussionParticipant.builder()
+                .discussion(discussion)
+                .user(user)
+                .isHost(true)
+                .index(index)
+                .build();
+        } else {
+            participant = DiscussionParticipant.builder()
+                .discussion(discussion)
+                .user(user)
+                .isHost(false)
+                .index(index)
+                .build();
+        }
         discussionParticipantRepository.save(participant);
     }
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -3,7 +3,6 @@ package endolphin.backend.domain.discussion;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
-import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
 import endolphin.backend.domain.personal_event.PersonalEventService;
 import endolphin.backend.domain.shared_event.SharedEventService;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
@@ -18,7 +17,6 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -100,12 +98,6 @@ public class DiscussionService {
             sharedEventDto,
             participantPictures
         );
-    }
-
-    @Transactional(readOnly = true)
-    public Long getDiscussionParticipantIndex(Long discussionId, Long userId) {
-        return discussionParticipantRepository.findIndexByDiscussionIdAndUserId(discussionId, userId)
-            .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND));
     }
 
     private long calculateTimeLeft(LocalDate deadline) {

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -102,6 +102,12 @@ public class DiscussionService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public Long getDiscussionParticipantIndex(Long discussionId, Long userId) {
+        return discussionParticipantRepository.findIndexByDiscussionIdAndUserId(discussionId, userId)
+            .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND));
+    }
+
     private long calculateTimeLeft(LocalDate deadline) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime deadlineDateTime = deadline.atTime(23, 59, 59);

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -52,7 +52,6 @@ public class DiscussionService {
 
         discussion = discussionRepository.save(discussion);
 
-        discussionBitmapService.initializeDiscussionBitmap(discussion);
         discussionParticipantService.addDiscussionParticipant(discussion, currentUser);
         personalEventService.preprocessPersonalEvents(currentUser, discussion);
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -36,6 +36,7 @@ public class DiscussionService {
     private final DiscussionBitmapService discussionBitmapService;
 
     public DiscussionResponse createDiscussion(CreateDiscussionRequest request) {
+        User currentUser = userService.getCurrentUser();
 
         Discussion discussion = Discussion.builder()
             .title(request.title())
@@ -49,11 +50,11 @@ public class DiscussionService {
             .location(request.location())
             .build();
 
-        discussionRepository.save(discussion);
+        discussion = discussionRepository.save(discussion);
 
-        User currentUser = userService.getCurrentUser();
-
+        discussionBitmapService.initializeDiscussionBitmap(discussion);
         discussionParticipantService.addDiscussionParticipant(discussion, currentUser);
+        personalEventService.preprocessPersonalEvents(currentUser, discussion);
 
         return new DiscussionResponse(
             discussion.getId(),

--- a/backend/src/main/java/endolphin/backend/domain/discussion/entity/DiscussionParticipant.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/entity/DiscussionParticipant.java
@@ -29,11 +29,15 @@ public class DiscussionParticipant {
     @Column(name = "is_host", nullable = false)
     private boolean isHost;
 
+    @Column(name = "index", nullable = false)
+    private Long index;
+
     @Builder
-    public DiscussionParticipant(Discussion discussion, User user, boolean isHost) {
+    public DiscussionParticipant(Discussion discussion, User user, boolean isHost, Long index) {
         this.discussion = discussion;
         this.user = user;
         this.isHost = isHost;
+        this.index = index;
     }
 }
 

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -1,6 +1,6 @@
 package endolphin.backend.domain.personal_event;
 
-import endolphin.backend.domain.discussion.DiscussionService;
+import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.user.entity.User;
@@ -15,10 +15,10 @@ import org.springframework.stereotype.Service;
 public class PersonalEventPreprocessor {
 
     private final DiscussionBitmapService discussionBitmapService;
-    private final DiscussionService discussionService;
+    private final DiscussionParticipantService discussionParticipantService;
 
     public void preprocess(List<PersonalEvent> personalEvents, Discussion discussion, User user) {
-        Long index = discussionService.getDiscussionParticipantIndex(discussion.getId(),
+        Long index = discussionParticipantService.getDiscussionParticipantIndex(discussion.getId(),
             user.getId());
         for (PersonalEvent personalEvent : personalEvents) {
             convert(personalEvent, discussion.getId(), index);

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -1,0 +1,17 @@
+package endolphin.backend.domain.personal_event;
+
+import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalEventPreprocessor {
+
+    @Async
+    public void preprocess(List<PersonalEvent> personalEvents) {
+
+    }
+}

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -1,17 +1,58 @@
 package endolphin.backend.domain.personal_event;
 
+import endolphin.backend.domain.discussion.DiscussionService;
+import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.redis.DiscussionBitmapService;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class PersonalEventPreprocessor {
 
-    @Async
-    public void preprocess(List<PersonalEvent> personalEvents) {
+    private final DiscussionBitmapService discussionBitmapService;
+    private final DiscussionService discussionService;
 
+    public void preprocess(List<PersonalEvent> personalEvents, Discussion discussion, User user) {
+        Long index = discussionService.getDiscussionParticipantIndex(discussion.getId(),
+            user.getId());
+        for (PersonalEvent personalEvent : personalEvents) {
+            convert(personalEvent, discussion.getId(), index);
+        }
+    }
+
+    private void convert(PersonalEvent personalEvent, Long discussionId, Long offset) {
+        LocalDateTime personalEventStartTime = roundDownToNearestHalfHour(personalEvent.getStartTime());
+        LocalDateTime personalEventEndTime = roundUpToNearestHalfHour(personalEvent.getEndTime());
+
+        while (personalEventStartTime.isBefore(personalEventEndTime)) {
+            // TODO: 에러 처리
+            discussionBitmapService.setBitValue(discussionId, personalEventStartTime, offset, true);
+            personalEventStartTime = personalEventStartTime.plusMinutes(30);
+        }
+    }
+
+    private LocalDateTime roundDownToNearestHalfHour(LocalDateTime time) {
+        int minute = time.getMinute();
+        if (minute < 30) {
+            time = time.minusMinutes(minute);
+        } else {
+            time = time.minusMinutes(minute - 30);
+        }
+        return time;
+    }
+
+    private LocalDateTime roundUpToNearestHalfHour(LocalDateTime time) {
+        int minute = time.getMinute();
+        if (minute < 30) {
+            time = time.plusMinutes(30 - minute);
+        } else {
+            time = time.plusMinutes(60 - minute);
+        }
+        return time;
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -5,15 +5,19 @@ import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.redis.DiscussionBitmapService;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class PersonalEventPreprocessor {
 
     private final DiscussionBitmapService discussionBitmapService;
@@ -23,19 +27,76 @@ public class PersonalEventPreprocessor {
         Long index = discussionParticipantService.getDiscussionParticipantIndex(discussion.getId(),
             user.getId());
         for (PersonalEvent personalEvent : personalEvents) {
-            convert(personalEvent, discussion.getId(), index);
+            convert(personalEvent, discussion, index, true);
         }
     }
 
-    private void convert(PersonalEvent personalEvent, Long discussionId, Long offset) {
-        LocalDateTime personalEventStartTime = roundDownToNearestHalfHour(personalEvent.getStartTime());
+    private void convert(PersonalEvent personalEvent, Discussion discussion, Long offset,
+        boolean value) {
+        Long discussionId = discussion.getId();
+        LocalDateTime personalEventStartTime = roundDownToNearestHalfHour(
+            personalEvent.getStartTime());
         LocalDateTime personalEventEndTime = roundUpToNearestHalfHour(personalEvent.getEndTime());
 
-        while (personalEventStartTime.isBefore(personalEventEndTime)) {
-            // TODO: 에러 처리
-            discussionBitmapService.setBitValue(discussionId, personalEventStartTime, offset, true);
-            personalEventStartTime = personalEventStartTime.plusMinutes(30);
+        LocalDate discussionStartDate = discussion.getDateRangeStart();
+        LocalDate discussionEndDate = discussion.getDateRangeEnd();
+        LocalTime discussionStartTime = discussion.getTimeRangeStart();
+        LocalTime discussionEndTime = discussion.getTimeRangeEnd();
+
+        LocalDateTime currentDateTime = getCurrentDateTime(personalEventStartTime,
+            discussionStartDate, discussionStartTime, discussionEndTime);
+
+        LocalDateTime untilDateTime = getUntilDateTime(personalEventEndTime, discussionEndDate,
+            discussionEndTime, discussionStartTime);
+
+        log.info("id: {}, currentDateTime: {} untilDateTime: {}", personalEvent.getId(), currentDateTime, untilDateTime);
+
+        while (!currentDateTime.toLocalDate().isAfter(untilDateTime.toLocalDate())) {
+            while (currentDateTime.toLocalTime().isBefore(discussionEndTime)
+            && currentDateTime.isBefore(untilDateTime)) {
+                discussionBitmapService.setBitValue(discussionId, currentDateTime, offset, value);
+                currentDateTime = currentDateTime.plusMinutes(30);
+            }
+            currentDateTime = currentDateTime.plusDays(1);
+            currentDateTime = currentDateTime.toLocalDate().atTime(discussionStartTime);
         }
+    }
+
+    private LocalDateTime getCurrentDateTime(LocalDateTime personalEventStartTime,
+        LocalDate discussionStartDate, LocalTime discussionStartTime, LocalTime discussionEndTime) {
+
+        LocalDate currentDate = personalEventStartTime.toLocalDate();
+        if (currentDate.isBefore(discussionStartDate)) {
+            return discussionStartDate.atTime(discussionStartTime);
+        }
+
+        LocalTime currentTime = personalEventStartTime.toLocalTime();
+        if (currentTime.isBefore(discussionStartTime)) {
+            currentTime = discussionStartTime;
+        } else if (currentTime.isAfter(discussionEndTime)) {
+            currentTime = discussionStartTime;
+            currentDate = currentDate.plusDays(1);
+        }
+
+        return currentDate.atTime(currentTime);
+    }
+
+    private LocalDateTime getUntilDateTime(LocalDateTime personalEventEndTime,
+        LocalDate discussionEndDate, LocalTime discussionEndTime, LocalTime discussionStartTime) {
+        LocalDate untilDate = personalEventEndTime.toLocalDate();
+        if (untilDate.isAfter(discussionEndDate)) {
+            return discussionEndDate.atTime(discussionEndTime);
+        }
+
+        LocalTime untilTime = personalEventEndTime.toLocalTime();
+        if (untilTime.isAfter(discussionEndTime)) {
+            untilTime = discussionEndTime;
+        } else if (untilTime.isBefore(discussionStartTime)) {
+            untilTime = discussionEndTime;
+            untilDate = untilDate.minusDays(1);
+        }
+
+        return untilDate.atTime(untilTime);
     }
 
     private LocalDateTime roundDownToNearestHalfHour(LocalDateTime time) {
@@ -50,7 +111,10 @@ public class PersonalEventPreprocessor {
 
     private LocalDateTime roundUpToNearestHalfHour(LocalDateTime time) {
         int minute = time.getMinute();
-        if (minute < 30) {
+        if (minute == 0) {
+            time = time.plusMinutes(minute);
+        }
+        else if (minute < 30) {
             time = time.plusMinutes(30 - minute);
         } else {
             time = time.plusMinutes(60 - minute);

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -9,8 +9,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class PersonalEventPreprocessor {
 

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
@@ -18,14 +18,12 @@ public interface PersonalEventRepository extends JpaRepository<PersonalEvent, Lo
 
     @Query("SELECT p FROM PersonalEvent p " +
         "WHERE p.user = :user " +
-        "   AND (CAST(p.startTime AS localdate) BETWEEN :startDate AND :endDate " +
+        "   AND ((CAST(p.startTime AS localdate) BETWEEN :startDate AND :endDate " +
         "   OR CAST(p.endTime AS localdate) BETWEEN :startDate AND :endDate) " +
-        "   AND (CAST(p.startTime AS localtime ) BETWEEN :startTime AND :endTime " +
-        "   OR CAST(p.endTime AS localtime) BETWEEN :startTime AND :endTime)")
+        "   OR ((CAST(p.startTime AS localdate) <= :startDate AND CAST(p.startTime AS localdate) <= :endDate) " +
+        "   AND (CAST(p.endTime AS localdate) >= :startDate AND CAST(p.endTime AS localdate) >= :endDate)))")
     List<PersonalEvent> findFilteredPersonalEvents(
         @Param("user") User user,
         @Param("startDate") LocalDate startDate,
-        @Param("endDate") LocalDate endDate,
-        @Param("startTime") LocalTime startTime,
-        @Param("endTime") LocalTime endTime);
+        @Param("endDate") LocalDate endDate);
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
@@ -2,13 +2,30 @@ package endolphin.backend.domain.personal_event;
 
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.user.entity.User;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PersonalEventRepository extends JpaRepository<PersonalEvent, Long> {
 
     List<PersonalEvent> findByUserAndStartTimeBetween(User user, LocalDateTime start, LocalDateTime end);
+
+    @Query("SELECT p FROM PersonalEvent p " +
+        "WHERE p.user = :user " +
+        "   AND (CAST(p.startTime AS localdate) BETWEEN :startDate AND :endDate " +
+        "   OR CAST(p.endTime AS localdate) BETWEEN :startDate AND :endDate) " +
+        "   AND (CAST(p.startTime AS localtime ) BETWEEN :startTime AND :endTime " +
+        "   OR CAST(p.endTime AS localtime) BETWEEN :startTime AND :endTime)")
+    List<PersonalEvent> findFilteredPersonalEvents(
+        @Param("user") User user,
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate,
+        @Param("startTime") LocalTime startTime,
+        @Param("endTime") LocalTime endTime);
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -22,6 +22,7 @@ public class PersonalEventService {
 
     private final PersonalEventRepository personalEventRepository;
     private final UserService userService;
+    private final PersonalEventPreprocessor personalEventPreprocessor;
 
     @Transactional(readOnly = true)
     public ListResponse<PersonalEventResponse> listPersonalEvents(LocalDateTime startDateTime,
@@ -94,5 +95,13 @@ public class PersonalEventService {
     public PersonalEvent getPersonalEvent(Long personalEventId) {
         return personalEventRepository.findById(personalEventId)
             .orElseThrow(() -> new RuntimeException("Personal event not found"));
+    }
+
+    public void preprocessPersonalEvents(User user, Discussion discussion) {
+        List<PersonalEvent> personalEvents = personalEventRepository.findFilteredPersonalEvents(
+            user, discussion.getDateRangeStart(), discussion.getDateRangeEnd(),
+            discussion.getTimeRangeStart(), discussion.getTimeRangeEnd());
+
+        personalEventPreprocessor.preprocess(personalEvents, discussion, user);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -99,8 +99,7 @@ public class PersonalEventService {
 
     public void preprocessPersonalEvents(User user, Discussion discussion) {
         List<PersonalEvent> personalEvents = personalEventRepository.findFilteredPersonalEvents(
-            user, discussion.getDateRangeStart(), discussion.getDateRangeEnd(),
-            discussion.getTimeRangeStart(), discussion.getTimeRangeEnd());
+            user, discussion.getDateRangeStart(), discussion.getDateRangeEnd());
 
         personalEventPreprocessor.preprocess(personalEvents, discussion, user);
     }

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     SHARED_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "Shared Event not found"),
 
     // DiscussionParticipant
-    DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "S002", "Discussion participant not found"),
+    DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP001", "Discussion participant not found"),
 
     //Calendar
     CALENDAR_UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "CA001", "Unauthorized"),

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
     //SharedEvent
     SHARED_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "Shared Event not found"),
 
+    // DiscussionParticipant
+    DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "S002", "Discussion participant not found"),
+
     //Calendar
     CALENDAR_UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "CA001", "Unauthorized"),
     CALENDAR_FORBIDDEN_ERROR(HttpStatus.FORBIDDEN, "CA002", "Forbidden"),

--- a/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
+++ b/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
@@ -68,7 +68,7 @@ public class DiscussionBitmapService {
 
         LocalDate currentDate = startDate;
 
-        while(currentDate.isBefore(endDate)) {
+        while(!currentDate.isAfter(endDate)) {
             LocalDateTime todayStartTime = currentDate.atTime(startTime);
             LocalDateTime todayEndTime = currentDate.atTime(endTime);
             while(todayStartTime.isBefore(todayEndTime)) {

--- a/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
+++ b/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
@@ -1,7 +1,10 @@
 package endolphin.backend.global.redis;
 
+import endolphin.backend.domain.discussion.entity.Discussion;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +56,26 @@ public class DiscussionBitmapService {
         } catch (RedisSystemException e) {
             //TODO: 예외 처리
             throw e;
+        }
+    }
+
+    public void initializeDiscussionBitmap(Discussion discussion) {
+        Long discussionId = discussion.getId();
+        LocalDate startDate = discussion.getDateRangeStart();
+        LocalDate endDate = discussion.getDateRangeEnd();
+        LocalTime startTime = discussion.getTimeRangeStart();
+        LocalTime endTime = discussion.getTimeRangeEnd();
+
+        LocalDate currentDate = startDate;
+
+        while(currentDate.isBefore(endDate)) {
+            LocalDateTime todayStartTime = currentDate.atTime(startTime);
+            LocalDateTime todayEndTime = currentDate.atTime(endTime);
+            while(todayStartTime.isBefore(todayEndTime)) {
+                initializeBitmap(discussionId, todayStartTime);
+                todayStartTime = todayStartTime.plusMinutes(30);
+            }
+            currentDate = currentDate.plusDays(1);
         }
     }
 

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
@@ -3,7 +3,7 @@ package endolphin.backend.domain.personal_event;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import endolphin.backend.domain.discussion.DiscussionService;
+import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.user.entity.User;
@@ -23,7 +23,7 @@ class PersonalEventPreprocessorTest {
     @Mock
     private DiscussionBitmapService discussionBitmapService;
     @Mock
-    private DiscussionService discussionService;
+    private DiscussionParticipantService discussionParticipantService;
     @InjectMocks
     private PersonalEventPreprocessor preprocessor;
 
@@ -42,7 +42,7 @@ class PersonalEventPreprocessorTest {
         User user = mock(User.class);
         given(user.getId()).willReturn(userId);
 
-        given(discussionService.getDiscussionParticipantIndex(discussionId, userId))
+        given(discussionParticipantService.getDiscussionParticipantIndex(discussionId, userId))
             .willReturn(participantIndex);
 
         // PersonalEvent: 시작 10:15, 종료 11:15

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
@@ -1,0 +1,68 @@
+package endolphin.backend.domain.personal_event;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import endolphin.backend.domain.discussion.DiscussionService;
+import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.redis.DiscussionBitmapService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PersonalEventPreprocessorTest {
+
+    @Mock
+    private DiscussionBitmapService discussionBitmapService;
+    @Mock
+    private DiscussionService discussionService;
+    @InjectMocks
+    private PersonalEventPreprocessor preprocessor;
+
+    @Test
+    @DisplayName("preprocess 메소드: PersonalEvent의 시간 변환 후 setBitValue 호출 검증")
+    void testPreprocessCallsSetBitValueWithCorrectTimes() {
+        // given
+        Long discussionId = 100L;
+        Long userId = 200L;
+        Long participantIndex = 3L;
+
+        // Discussion, User, PersonalEvent 모킹
+        Discussion discussion = mock(Discussion.class);
+        given(discussion.getId()).willReturn(discussionId);
+
+        User user = mock(User.class);
+        given(user.getId()).willReturn(userId);
+
+        given(discussionService.getDiscussionParticipantIndex(discussionId, userId))
+            .willReturn(participantIndex);
+
+        // PersonalEvent: 시작 10:15, 종료 11:15
+        PersonalEvent personalEvent = mock(PersonalEvent.class);
+        LocalDateTime startTime = LocalDateTime.of(2025, 2, 9, 10, 15);
+        LocalDateTime endTime = LocalDateTime.of(2025, 2, 9, 11, 15);
+        given(personalEvent.getStartTime()).willReturn(startTime);
+        given(personalEvent.getEndTime()).willReturn(endTime);
+
+        // when
+        preprocessor.preprocess(List.of(personalEvent), discussion, user);
+
+        // then: 예상 호출 시간은 10:00, 10:30, 11:00 (11:30은 조건 미충족)
+        LocalDateTime expectedTime1 = LocalDateTime.of(2025, 2, 9, 10, 0);
+        LocalDateTime expectedTime2 = LocalDateTime.of(2025, 2, 9, 10, 30);
+        LocalDateTime expectedTime3 = LocalDateTime.of(2025, 2, 9, 11, 0);
+
+        then(discussionBitmapService).should().setBitValue(discussionId, expectedTime1, participantIndex, true);
+        then(discussionBitmapService).should().setBitValue(discussionId, expectedTime2, participantIndex, true);
+        then(discussionBitmapService).should().setBitValue(discussionId, expectedTime3, participantIndex, true);
+        then(discussionBitmapService).shouldHaveNoMoreInteractions();
+    }
+}

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
@@ -8,13 +8,16 @@ import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.redis.DiscussionBitmapService;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,41 +31,149 @@ class PersonalEventPreprocessorTest {
     private PersonalEventPreprocessor preprocessor;
 
     @Test
-    @DisplayName("preprocess 메소드: PersonalEvent의 시간 변환 후 setBitValue 호출 검증")
+    @DisplayName("날짜 동일, 시간 범위 내에 있는 경우")
     void testPreprocessCallsSetBitValueWithCorrectTimes() {
         // given
-        Long discussionId = 100L;
         Long userId = 200L;
-        Long participantIndex = 3L;
+        Long participantIndex = 2L;
 
         // Discussion, User, PersonalEvent 모킹
-        Discussion discussion = mock(Discussion.class);
-        given(discussion.getId()).willReturn(discussionId);
+        Discussion discussion = getDiscussion();
+        User user = getUser();
 
-        User user = mock(User.class);
-        given(user.getId()).willReturn(userId);
-
-        given(discussionParticipantService.getDiscussionParticipantIndex(discussionId, userId))
+        given(discussionParticipantService.getDiscussionParticipantIndex(anyLong(), anyLong()))
             .willReturn(participantIndex);
 
-        // PersonalEvent: 시작 10:15, 종료 11:15
+        // count : 2
         PersonalEvent personalEvent = mock(PersonalEvent.class);
-        LocalDateTime startTime = LocalDateTime.of(2025, 2, 9, 10, 15);
-        LocalDateTime endTime = LocalDateTime.of(2025, 2, 9, 11, 15);
-        given(personalEvent.getStartTime()).willReturn(startTime);
-        given(personalEvent.getEndTime()).willReturn(endTime);
+        given(personalEvent.getStartTime()).willReturn(LocalDateTime.of(2024, 3, 15, 13, 0));
+        given(personalEvent.getEndTime()).willReturn(LocalDateTime.of(2024, 3, 15, 14, 0));
+        given(personalEvent.getId()).willReturn(1L);
 
         // when
         preprocessor.preprocess(List.of(personalEvent), discussion, user);
 
-        // then: 예상 호출 시간은 10:00, 10:30, 11:00 (11:30은 조건 미충족)
-        LocalDateTime expectedTime1 = LocalDateTime.of(2025, 2, 9, 10, 0);
-        LocalDateTime expectedTime2 = LocalDateTime.of(2025, 2, 9, 10, 30);
-        LocalDateTime expectedTime3 = LocalDateTime.of(2025, 2, 9, 11, 0);
+        // then
+        then(discussionBitmapService).should(times(2)).setBitValue(anyLong(), any(LocalDateTime.class), anyLong(), anyBoolean());
+    }
 
-        then(discussionBitmapService).should().setBitValue(discussionId, expectedTime1, participantIndex, true);
-        then(discussionBitmapService).should().setBitValue(discussionId, expectedTime2, participantIndex, true);
-        then(discussionBitmapService).should().setBitValue(discussionId, expectedTime3, participantIndex, true);
-        then(discussionBitmapService).shouldHaveNoMoreInteractions();
+    @Test
+    @DisplayName("날짜 범위 밖에 있는 경우")
+    public void test2() {
+        // given
+        Long userId = 200L;
+        Long participantIndex = 2L;
+        // Discussion, User, PersonalEvent 모킹
+        Discussion discussion = getDiscussion();
+        User user = getUser();
+
+        given(discussionParticipantService.getDiscussionParticipantIndex(anyLong(), anyLong()))
+            .willReturn(participantIndex);
+
+        // count : 0
+        PersonalEvent personalEvent = mock(PersonalEvent.class);
+        given(personalEvent.getStartTime()).willReturn(LocalDateTime.of(2024, 3, 8, 8, 0, 0));
+        given(personalEvent.getEndTime()).willReturn(LocalDateTime.of(2024, 3, 10, 12, 0, 0));
+        given(personalEvent.getId()).willReturn(2L);
+
+        // when
+        preprocessor.preprocess(List.of(personalEvent), discussion, user);
+
+        // then
+        then(discussionBitmapService).should(times(0)).setBitValue(anyLong(), any(LocalDateTime.class), anyLong(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("날짜 범위가 걸쳐있는 경우")
+    public void test3() {
+        // given
+        Long userId = 200L;
+        Long participantIndex = 2L;
+        // Discussion, User, PersonalEvent 모킹
+        Discussion discussion = getDiscussion();
+        User user = getUser();
+
+        given(discussionParticipantService.getDiscussionParticipantIndex(anyLong(), anyLong()))
+            .willReturn(participantIndex);
+
+        // count : 6 + 6 + 2 = 14
+        PersonalEvent personalEvent = mock(PersonalEvent.class);
+        given(personalEvent.getStartTime()).willReturn(LocalDateTime.of(2024, 3, 8, 8, 0, 0));
+        given(personalEvent.getEndTime()).willReturn(LocalDateTime.of(2024, 3, 12, 13, 0, 0));
+        given(personalEvent.getId()).willReturn(3L);
+
+        // when
+        preprocessor.preprocess(List.of(personalEvent), discussion, user);
+
+        // then
+        then(discussionBitmapService).should(times(14)).setBitValue(anyLong(), any(LocalDateTime.class), anyLong(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("날짜 범위를 모두 포함하는 경우")
+    public void test4() {
+        // given
+        Long userId = 200L;
+        Long participantIndex = 2L;
+        // Discussion, User, PersonalEvent 모킹
+        Discussion discussion = getDiscussion();
+        User user = getUser();
+
+        given(discussionParticipantService.getDiscussionParticipantIndex(anyLong(), anyLong()))
+            .willReturn(participantIndex);
+
+        // count : 6 * 11
+        PersonalEvent personalEvent = mock(PersonalEvent.class);
+        given(personalEvent.getStartTime()).willReturn(LocalDateTime.of(2024, 3, 8, 20, 0, 0));
+        given(personalEvent.getEndTime()).willReturn(LocalDateTime.of(2024, 3, 30, 9, 0, 0));
+        given(personalEvent.getId()).willReturn(4L);
+
+        // when
+        preprocessor.preprocess(List.of(personalEvent), discussion, user);
+
+        // then
+        then(discussionBitmapService).should(times(66)).setBitValue(anyLong(), any(LocalDateTime.class), anyLong(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("날짜 범위 안에 속하는 경우")
+    public void test5() {
+        // given
+        Long userId = 200L;
+        Long participantIndex = 2L;
+        // Discussion, User, PersonalEvent 모킹
+        Discussion discussion = getDiscussion();
+        User user = getUser();
+
+        given(discussionParticipantService.getDiscussionParticipantIndex(anyLong(), anyLong()))
+            .willReturn(participantIndex);
+
+        // count : 3 + 6 * 5
+        PersonalEvent personalEvent = mock(PersonalEvent.class);
+        given(personalEvent.getStartTime()).willReturn(LocalDateTime.of(2024, 3, 12, 13, 50, 0));
+        given(personalEvent.getEndTime()).willReturn(LocalDateTime.of(2024, 3, 18, 10, 11, 0));
+        given(personalEvent.getId()).willReturn(5L);
+
+        // when
+        preprocessor.preprocess(List.of(personalEvent), discussion, user);
+
+        // then
+        then(discussionBitmapService).should(times(33)).setBitValue(anyLong(), any(LocalDateTime.class), anyLong(), anyBoolean());
+    }
+
+    private Discussion getDiscussion() {
+        Discussion discussion = Mockito.mock(Discussion.class);
+        given(discussion.getId()).willReturn(1L);
+        given(discussion.getDateRangeStart()).willReturn(LocalDate.of(2024, 3, 10));
+        given(discussion.getDateRangeEnd()).willReturn(LocalDate.of(2024, 3, 20));
+        given(discussion.getTimeRangeStart()).willReturn(LocalTime.of(12, 0));
+        given(discussion.getTimeRangeEnd()).willReturn(LocalTime.of(15, 0));
+        return discussion;
+    }
+
+    private User getUser() {
+        User user = Mockito.mock(User.class);
+        given(user.getId()).willReturn(1L);
+        return user;
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventRepositoryTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventRepositoryTest.java
@@ -75,28 +75,24 @@ class PersonalEventRepositoryTest {
     }
 
     @Test
-    @DisplayName("findFilteredPersonalEvents: 날짜 및 시간 필터 조건에 맞는 PersonalEvent 조회")
+    @DisplayName("findFilteredPersonalEvents: 날짜 필터 조건에 맞는 PersonalEvent 조회")
     void testFindFilteredPersonalEvents() {
         // Given: 테스트용 사용자 생성 및 persist
         entityManager.persist(testUser);
 
         // 필터링 조건
         // 날짜 조건: 2025-02-09 (단일 날짜 범위)
-        LocalDate filterDate = LocalDate.of(2025, 2, 9);
-        // 시간 조건: 09:00 ~ 18:00
-        LocalTime filterStartTime = LocalTime.of(9, 0);
-        LocalTime filterEndTime = LocalTime.of(18, 0);
+        LocalDate filterStartDate = LocalDate.of(2025, 2, 9);
+        LocalDate filterEndDate = LocalDate.of(2025, 2, 12);
 
         // PersonalEvent 생성
-        // 1) 조건에 부합하는 이벤트: 날짜 및 시간이 모두 범위 내
-        PersonalEvent matchingEvent = PersonalEvent.builder()
+        PersonalEvent matchingEvent1 = PersonalEvent.builder()
             .user(testUser)
             .title("Matching Event")
             .startTime(LocalDateTime.of(2025, 2, 9, 10, 0))
             .endTime(LocalDateTime.of(2025, 2, 9, 12, 0))
             .build();
 
-        // 2) 날짜가 맞지 않는 이벤트
         PersonalEvent nonMatchingDateEvent = PersonalEvent.builder()
             .user(testUser)
             .title("Non Matching Date Event")
@@ -104,45 +100,42 @@ class PersonalEventRepositoryTest {
             .endTime(LocalDateTime.of(2025, 2, 8, 12, 0))
             .build();
 
-        // 3) 시간 조건에 맞지 않는 이벤트 (시간이 범위보다 빠름)
-        PersonalEvent nonMatchingTimeEvent = PersonalEvent.builder()
+        PersonalEvent matchingEvent2 = PersonalEvent.builder()
             .user(testUser)
-            .title("Non Matching Time Event")
+            .title("Matching Time Event")
             .startTime(LocalDateTime.of(2025, 2, 9, 8, 0))
-            .endTime(LocalDateTime.of(2025, 2, 9, 8, 30))
+            .endTime(LocalDateTime.of(2025, 2, 20, 8, 30))
             .build();
 
         // 4) 조건에 걸치는 이벤트
-        PersonalEvent matchingEvent2 = PersonalEvent.builder()
-            .user(testUser)
-            .title("Matching Event2")
-            .startTime(LocalDateTime.of(2025, 2, 9, 7, 0))
-            .endTime(LocalDateTime.of(2025, 2, 9, 12, 0))
-            .build();
-
         PersonalEvent matchingEvent3 = PersonalEvent.builder()
             .user(testUser)
-            .title("Matching Event3")
-            .startTime(LocalDateTime.of(2025, 2, 9, 12, 0))
-            .endTime(LocalDateTime.of(2025, 2, 9, 20, 0))
+            .title("Matching Event2")
+            .startTime(LocalDateTime.of(2025, 2, 10, 7, 0))
+            .endTime(LocalDateTime.of(2025, 2, 11, 1, 0))
             .build();
 
-        entityManager.persist(matchingEvent);
+        PersonalEvent matchingEvent4 = PersonalEvent.builder()
+            .user(testUser)
+            .title("Matching Event3")
+            .startTime(LocalDateTime.of(2025, 2, 8, 12, 0))
+            .endTime(LocalDateTime.of(2025, 2, 13, 20, 0))
+            .build();
+
+        entityManager.persist(matchingEvent1);
         entityManager.persist(nonMatchingDateEvent);
-        entityManager.persist(nonMatchingTimeEvent);
         entityManager.persist(matchingEvent2);
         entityManager.persist(matchingEvent3);
+        entityManager.persist(matchingEvent4);
         entityManager.flush();
         entityManager.clear();
 
         // When: 필터 조건에 따라 이벤트 조회
         List<PersonalEvent> events = personalEventRepository.findFilteredPersonalEvents(
-            testUser, filterDate, filterDate, filterStartTime, filterEndTime);
+            testUser, filterStartDate, filterEndDate);
 
         // Then: "Matching Event"만 조회되어야 한다.
         assertThat(events)
-            .hasSize(3)
-            .extracting(PersonalEvent::getTitle)
-            .containsExactly(matchingEvent.getTitle(), matchingEvent2.getTitle(), matchingEvent3.getTitle());
+            .hasSize(4);
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventRepositoryTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventRepositoryTest.java
@@ -5,13 +5,16 @@ import static org.assertj.core.api.Assertions.*;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.user.UserRepository;
 import endolphin.backend.domain.user.entity.User;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 @DataJpaTest
 class PersonalEventRepositoryTest {
@@ -21,6 +24,9 @@ class PersonalEventRepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
 
     private User testUser;
 
@@ -66,5 +72,77 @@ class PersonalEventRepositoryTest {
         // then
         assertThat(personalEventList.size()).isEqualTo(2);
         assertThat(personalEventList.get(0).getTitle()).isEqualTo("Meeting");
+    }
+
+    @Test
+    @DisplayName("findFilteredPersonalEvents: 날짜 및 시간 필터 조건에 맞는 PersonalEvent 조회")
+    void testFindFilteredPersonalEvents() {
+        // Given: 테스트용 사용자 생성 및 persist
+        entityManager.persist(testUser);
+
+        // 필터링 조건
+        // 날짜 조건: 2025-02-09 (단일 날짜 범위)
+        LocalDate filterDate = LocalDate.of(2025, 2, 9);
+        // 시간 조건: 09:00 ~ 18:00
+        LocalTime filterStartTime = LocalTime.of(9, 0);
+        LocalTime filterEndTime = LocalTime.of(18, 0);
+
+        // PersonalEvent 생성
+        // 1) 조건에 부합하는 이벤트: 날짜 및 시간이 모두 범위 내
+        PersonalEvent matchingEvent = PersonalEvent.builder()
+            .user(testUser)
+            .title("Matching Event")
+            .startTime(LocalDateTime.of(2025, 2, 9, 10, 0))
+            .endTime(LocalDateTime.of(2025, 2, 9, 12, 0))
+            .build();
+
+        // 2) 날짜가 맞지 않는 이벤트
+        PersonalEvent nonMatchingDateEvent = PersonalEvent.builder()
+            .user(testUser)
+            .title("Non Matching Date Event")
+            .startTime(LocalDateTime.of(2025, 2, 8, 10, 0))
+            .endTime(LocalDateTime.of(2025, 2, 8, 12, 0))
+            .build();
+
+        // 3) 시간 조건에 맞지 않는 이벤트 (시간이 범위보다 빠름)
+        PersonalEvent nonMatchingTimeEvent = PersonalEvent.builder()
+            .user(testUser)
+            .title("Non Matching Time Event")
+            .startTime(LocalDateTime.of(2025, 2, 9, 8, 0))
+            .endTime(LocalDateTime.of(2025, 2, 9, 8, 30))
+            .build();
+
+        // 4) 조건에 걸치는 이벤트
+        PersonalEvent matchingEvent2 = PersonalEvent.builder()
+            .user(testUser)
+            .title("Matching Event2")
+            .startTime(LocalDateTime.of(2025, 2, 9, 7, 0))
+            .endTime(LocalDateTime.of(2025, 2, 9, 12, 0))
+            .build();
+
+        PersonalEvent matchingEvent3 = PersonalEvent.builder()
+            .user(testUser)
+            .title("Matching Event3")
+            .startTime(LocalDateTime.of(2025, 2, 9, 12, 0))
+            .endTime(LocalDateTime.of(2025, 2, 9, 20, 0))
+            .build();
+
+        entityManager.persist(matchingEvent);
+        entityManager.persist(nonMatchingDateEvent);
+        entityManager.persist(nonMatchingTimeEvent);
+        entityManager.persist(matchingEvent2);
+        entityManager.persist(matchingEvent3);
+        entityManager.flush();
+        entityManager.clear();
+
+        // When: 필터 조건에 따라 이벤트 조회
+        List<PersonalEvent> events = personalEventRepository.findFilteredPersonalEvents(
+            testUser, filterDate, filterDate, filterStartTime, filterEndTime);
+
+        // Then: "Matching Event"만 조회되어야 한다.
+        assertThat(events)
+            .hasSize(3)
+            .extracting(PersonalEvent::getTitle)
+            .containsExactly(matchingEvent.getTitle(), matchingEvent2.getTitle(), matchingEvent3.getTitle());
     }
 }

--- a/backend/src/test/java/endolphin/backend/global/redis/DiscussionBitmapServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/redis/DiscussionBitmapServiceTest.java
@@ -3,6 +3,7 @@ package endolphin.backend.global.redis;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
+import java.util.BitSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
@@ -69,5 +70,26 @@ public class DiscussionBitmapServiceTest {
         assertThat(afterDelete)
             .as("deleteDiscussionBitmapsUsingScan should remove the bitmap")
             .isNull();
+    }
+
+    @Test
+    @DisplayName("비트 설정 테스트")
+    public void testSetPersonalEventBitToBitmap() {
+        Long discussionId = 100L;
+        LocalDateTime dateTime = LocalDateTime.now();
+
+        // 초기화 전
+        byte[] bitmapData = bitmapService.getBitmapData(discussionId, dateTime);
+
+        assertThat(bitmapData).isNull();
+
+        // bit 설정
+        Boolean result = bitmapService.setBitValue(discussionId, dateTime, 3, true);
+        assertThat(result).isFalse();
+
+        bitmapData = bitmapService.getBitmapData(discussionId, dateTime);
+        assertThat(bitmapData).isNotNull();
+        BitSet bs = BitSet.valueOf(bitmapData);
+        assertThat(bs.get(3 + 1)).isTrue();
     }
 }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #105
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 논의 생성 시 비트맵 초기화 기능 구현 -> 삭제
- 논의 참여 시 개인 일정을 비트맵에 반영하는 기능 구현
- 논의 날짜 범위에 맞는 개인 일정을 가져오는 기능 구현
- 개인 일정을 비트맵으로 변환하는 기능 구현
- 참가자의 논의 인덱스 설정 기능 구현
- 개인 일정을 논의 기간에 맞추어 가져오는 기능 구현
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 전처리 과정 코드 봐주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic discussion participant management with improved role assignment.
  - Added integrated personal event processing to enhance scheduling and boost event synchronization.

- **Improvements**
  - Refined discussion creation flow to capture the latest updates and ensure data accuracy.
  - Enhanced error notifications for missing discussion participants to provide clearer user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->