### PR TITLE
[BE-Feat] 구글 캘린더로 가져온 일정들을 서비스에 반영하는 기능 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/auth/AuthService.java
+++ b/backend/src/main/java/endolphin/backend/domain/auth/AuthService.java
@@ -47,7 +47,7 @@ public class AuthService {
             }
         } else {
             GoogleCalendarDto calendar = googleCalendarService.getPrimaryCalendar(
-                user.getAccessToken());
+                user);
             calendarService.createCalendar(calendar, user);
             List<GoogleEvent> events = googleCalendarService.getCalendarEvents(calendar.id(), user);
             //TODO: 이벤트 db에 저장

--- a/backend/src/main/java/endolphin/backend/domain/auth/AuthService.java
+++ b/backend/src/main/java/endolphin/backend/domain/auth/AuthService.java
@@ -2,6 +2,7 @@ package endolphin.backend.domain.auth;
 
 import endolphin.backend.domain.calendar.CalendarService;
 import endolphin.backend.domain.calendar.entity.Calendar;
+import endolphin.backend.domain.personal_event.PersonalEventService;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.global.error.exception.ErrorCode;
 import endolphin.backend.global.error.exception.OAuthException;
@@ -29,6 +30,7 @@ public class AuthService {
     private final CalendarService calendarService;
     private final UserService userService;
     private final JwtProvider jwtProvider;
+    private final PersonalEventService personalEventService;
 
     @Transactional
     public OAuthResponse oauth2Callback(String code) {
@@ -50,8 +52,8 @@ public class AuthService {
                 user);
             calendarService.createCalendar(calendar, user);
             List<GoogleEvent> events = googleCalendarService.getCalendarEvents(calendar.id(), user);
-            //TODO: 이벤트 db에 저장
 
+            personalEventService.syncWithGoogleEvents(events, user);
             googleCalendarService.subscribeToCalendar(calendar.id(), user);
         }
 

--- a/backend/src/main/java/endolphin/backend/domain/calendar/CalendarRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/calendar/CalendarRepository.java
@@ -9,4 +9,8 @@ import org.springframework.stereotype.Repository;
 public interface CalendarRepository extends JpaRepository<Calendar, Long> {
 
     Optional<Calendar> findByCalendarId(String calendarId);
+
+    boolean existsByUserId(Long userId);
+
+    Optional<Calendar> findByUserId(Long userId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/calendar/CalendarService.java
+++ b/backend/src/main/java/endolphin/backend/domain/calendar/CalendarService.java
@@ -20,14 +20,14 @@ public class CalendarService {
 
     private final CalendarRepository calendarRepository;
 
-    public void createCalendar(GoogleCalendarDto calendar, User user) {
+    public Calendar createCalendar(GoogleCalendarDto calendar, User user) {
         Calendar newCalendar = Calendar.builder()
             .calendarId(calendar.id())
             .user(user)
             .name(calendar.summary())
             .description(calendar.description())
             .build();
-        calendarRepository.save(newCalendar);
+        return calendarRepository.save(newCalendar);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/endolphin/backend/domain/calendar/CalendarService.java
+++ b/backend/src/main/java/endolphin/backend/domain/calendar/CalendarService.java
@@ -67,4 +67,13 @@ public class CalendarService {
         calendarRepository.save(calendar);
     }
 
+    public boolean isExistingCalendar(Long userId) {
+        return calendarRepository.existsByUserId(userId);
+    }
+
+    public Calendar getCalendarByUserId(Long userId) {
+        return calendarRepository.findByUserId(userId).orElseThrow(
+            () -> new CalendarException(ErrorCode.CALENDAR_NOT_FOUND_ERROR));
+    }
+
 }

--- a/backend/src/main/java/endolphin/backend/domain/calendar/CalendarService.java
+++ b/backend/src/main/java/endolphin/backend/domain/calendar/CalendarService.java
@@ -67,10 +67,12 @@ public class CalendarService {
         calendarRepository.save(calendar);
     }
 
+    @Transactional(readOnly = true)
     public boolean isExistingCalendar(Long userId) {
         return calendarRepository.existsByUserId(userId);
     }
 
+    @Transactional(readOnly = true)
     public Calendar getCalendarByUserId(Long userId) {
         return calendarRepository.findByUserId(userId).orElseThrow(
             () -> new CalendarException(ErrorCode.CALENDAR_NOT_FOUND_ERROR));

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -1,5 +1,6 @@
 package endolphin.backend.domain.discussion;
 
+import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
 import endolphin.backend.domain.user.entity.User;
 import java.util.List;
@@ -54,4 +55,9 @@ public interface DiscussionParticipantRepository extends
         @Param("offset") List<Long> offsets
     );
 
+    @Query("SELECT dp " +
+        "FROM DiscussionParticipant dp " +
+        "JOIN FETCH dp.discussion d " +
+        "WHERE dp.user.id = :userId")
+    List<Discussion> findDiscussionsByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -100,4 +100,9 @@ public class DiscussionParticipantService {
 
         return userService.getUserIdNameInIds(userIds);
     }
+
+    @Transactional(readOnly = true)
+    public List<Discussion> getDiscussionsByUserId(Long userId) {
+        return discussionParticipantRepository.findDiscussionsByUserId(userId);
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -140,7 +140,7 @@ public class PersonalEventPreprocessor {
         Discussion discussion, PersonalEvent personalEvent) {
         LocalDate eventStart = personalEvent.getStartTime().toLocalDate();
         LocalDate eventEnd = personalEvent.getEndTime().toLocalDate();
-        return eventStart.isBefore(discussion.getDateRangeEnd())
-            && eventEnd.isAfter(discussion.getDateRangeStart());
+        return !eventStart.isAfter(discussion.getDateRangeEnd())
+            && !eventEnd.isBefore(discussion.getDateRangeStart());
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -28,7 +28,6 @@ public class PersonalEventPreprocessor {
         Long offset = discussionParticipantService.getDiscussionParticipantOffset(discussion.getId(),
             user.getId());
         for (PersonalEvent personalEvent : personalEvents) {
-            convert(personalEvent, discussion, offset, true);
             if (discussion.getDiscussionStatus() == DiscussionStatus.ONGOING
                 && isTimeRangeOverlapping(discussion, personalEvent)) {
                 convert(personalEvent, discussion, offset, true);

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -2,6 +2,7 @@ package endolphin.backend.domain.personal_event;
 
 import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.redis.DiscussionBitmapService;
@@ -28,13 +29,20 @@ public class PersonalEventPreprocessor {
             user.getId());
         for (PersonalEvent personalEvent : personalEvents) {
             convert(personalEvent, discussion, offset, true);
+            if (discussion.getDiscussionStatus() == DiscussionStatus.ONGOING
+                && isTimeRangeOverlapping(discussion, personalEvent)) {
+                convert(personalEvent, discussion, index, true);
+            }
         }
     }
 
     public void preprocessOne(PersonalEvent personalEvent, Discussion discussion, User user, boolean value) {
         Long index = discussionParticipantService.getDiscussionParticipantIndex(discussion.getId(),
             user.getId());
-        convert(personalEvent, discussion, index, value);
+        if (discussion.getDiscussionStatus() == DiscussionStatus.ONGOING
+            && isTimeRangeOverlapping(discussion, personalEvent)) {
+            convert(personalEvent, discussion, index, value);
+        }
     }
 
     private void convert(PersonalEvent personalEvent, Discussion discussion, Long offset,
@@ -126,5 +134,13 @@ public class PersonalEventPreprocessor {
             time = time.plusMinutes(60 - minute);
         }
         return time;
+    }
+
+    private boolean isTimeRangeOverlapping(
+        Discussion discussion, PersonalEvent personalEvent) {
+        LocalDate eventStart = personalEvent.getStartTime().toLocalDate();
+        LocalDate eventEnd = personalEvent.getEndTime().toLocalDate();
+        return eventStart.isBefore(discussion.getDateRangeEnd())
+            && eventEnd.isAfter(discussion.getDateRangeStart());
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -31,6 +31,12 @@ public class PersonalEventPreprocessor {
         }
     }
 
+    public void preprocessOne(PersonalEvent personalEvent, Discussion discussion, User user, boolean value) {
+        Long index = discussionParticipantService.getDiscussionParticipantIndex(discussion.getId(),
+            user.getId());
+        convert(personalEvent, discussion, index, value);
+    }
+
     private void convert(PersonalEvent personalEvent, Discussion discussion, Long offset,
         boolean value) {
         Long discussionId = discussion.getId();

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -31,13 +31,13 @@ public class PersonalEventPreprocessor {
             convert(personalEvent, discussion, offset, true);
             if (discussion.getDiscussionStatus() == DiscussionStatus.ONGOING
                 && isTimeRangeOverlapping(discussion, personalEvent)) {
-                convert(personalEvent, discussion, index, true);
+                convert(personalEvent, discussion, offset, true);
             }
         }
     }
 
     public void preprocessOne(PersonalEvent personalEvent, Discussion discussion, User user, boolean value) {
-        Long index = discussionParticipantService.getDiscussionParticipantIndex(discussion.getId(),
+        Long index = discussionParticipantService.getDiscussionParticipantOffset(discussion.getId(),
             user.getId());
         if (discussion.getDiscussionStatus() == DiscussionStatus.ONGOING
             && isTimeRangeOverlapping(discussion, personalEvent)) {

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -27,4 +28,6 @@ public interface PersonalEventRepository extends JpaRepository<PersonalEvent, Lo
         @Param("user") User user,
         @Param("startDate") LocalDate startDate,
         @Param("endDate") LocalDate endDate);
+
+    Optional<PersonalEvent> findByGoogleEventId(String googleEventId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
@@ -29,5 +29,5 @@ public interface PersonalEventRepository extends JpaRepository<PersonalEvent, Lo
         @Param("startDate") LocalDate startDate,
         @Param("endDate") LocalDate endDate);
 
-    Optional<PersonalEvent> findByGoogleEventId(String googleEventId);
+    Optional<PersonalEvent> findByGoogleEventIdAndCalendarId(String googleEventId, String calendarId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -125,7 +125,7 @@ public class PersonalEventService {
         List<Discussion> discussions, User user) {
         personalEventRepository.findByGoogleEventId(googleEvent.eventId())
             .ifPresentOrElse(personalEvent -> {
-                    if (isChangedGoogleEvent(personalEvent, googleEvent)) {
+                    if (hasChangedGoogleEvent(personalEvent, googleEvent)) {
                         PersonalEvent oldEvent = personalEvent.copy();
                         personalEvent.update(googleEvent.startDateTime(), googleEvent.endDateTime(),
                             googleEvent.summary());
@@ -168,7 +168,7 @@ public class PersonalEventService {
             });
     }
 
-    private boolean isChangedGoogleEvent(PersonalEvent personalEvent, GoogleEvent googleEvent) {
+    private boolean hasChangedGoogleEvent(PersonalEvent personalEvent, GoogleEvent googleEvent) {
         if (!personalEvent.getStartTime().equals(googleEvent.startDateTime())) {
             return true;
         }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -2,7 +2,6 @@ package endolphin.backend.domain.personal_event;
 
 import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.entity.Discussion;
-import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.personal_event.dto.PersonalEventRequest;
 import endolphin.backend.domain.personal_event.dto.PersonalEventResponse;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
@@ -129,7 +128,8 @@ public class PersonalEventService {
 
     private void upsertPersonalEventByGoogleEvent(GoogleEvent googleEvent,
         List<Discussion> discussions, User user, String googleCalendarId) {
-        personalEventRepository.findByGoogleEventIdAndCalendarId(googleEvent.eventId(), googleCalendarId)
+        personalEventRepository.findByGoogleEventIdAndCalendarId(googleEvent.eventId(),
+                googleCalendarId)
             .ifPresentOrElse(personalEvent -> {
                     if (hasChangedGoogleEvent(personalEvent, googleEvent)) {
                         PersonalEvent oldEvent = personalEvent.copy();
@@ -138,11 +138,10 @@ public class PersonalEventService {
                         personalEventRepository.save(personalEvent);
                         // 비트맵 수정
                         discussions.forEach(discussion -> {
-                            if (discussion.getDiscussionStatus() == DiscussionStatus.ONGOING) {
-                                personalEventPreprocessor.preprocessOne(oldEvent, discussion, user, false);
-                                personalEventPreprocessor.preprocessOne(personalEvent, discussion, user,
-                                    true);
-                            }
+                            personalEventPreprocessor.
+                                preprocessOne(oldEvent, discussion, user, false);
+                            personalEventPreprocessor
+                                .preprocessOne(personalEvent, discussion, user, true);
                         });
                     }
                 },
@@ -151,24 +150,20 @@ public class PersonalEventService {
                     personalEventRepository.save(personalEvent);
                     // 비트맵 수정
                     discussions.forEach(discussion -> {
-                        if (discussion.getDiscussionStatus() == DiscussionStatus.ONGOING) {
-                            personalEventPreprocessor.preprocessOne(personalEvent, discussion, user,
-                                true);
-                        }
+                        personalEventPreprocessor.preprocessOne(personalEvent, discussion, user,
+                            true);
                     });
                 });
     }
 
     private void deletePersonalEventByGoogleEvent(GoogleEvent googleEvent,
         List<Discussion> discussions, User user, String googleCalendarId) {
-        personalEventRepository.findByGoogleEventIdAndCalendarId(googleEvent.eventId(), googleCalendarId)
+        personalEventRepository.findByGoogleEventIdAndCalendarId(googleEvent.eventId(),
+                googleCalendarId)
             .ifPresent(personalEvent -> {
                 // 비트맵 삭제
                 discussions.forEach(discussion -> {
-                    if (discussion.getDiscussionStatus().equals(DiscussionStatus.ONGOING)) {
-                        personalEventPreprocessor.preprocessOne(personalEvent, discussion, user,
-                            false);
-                    }
+                    personalEventPreprocessor.preprocessOne(personalEvent, discussion, user, false);
                 });
                 personalEventRepository.delete(personalEvent);
             });

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -138,7 +138,7 @@ public class PersonalEventService {
                         personalEventRepository.save(personalEvent);
                         // 비트맵 수정
                         discussions.forEach(discussion -> {
-                            if (discussion.getDiscussionStatus().equals(DiscussionStatus.ONGOING)) {
+                            if (discussion.getDiscussionStatus() == DiscussionStatus.ONGOING) {
                                 personalEventPreprocessor.preprocessOne(oldEvent, discussion, user, false);
                                 personalEventPreprocessor.preprocessOne(personalEvent, discussion, user,
                                     true);
@@ -151,7 +151,7 @@ public class PersonalEventService {
                     personalEventRepository.save(personalEvent);
                     // 비트맵 수정
                     discussions.forEach(discussion -> {
-                        if (discussion.getDiscussionStatus().equals(DiscussionStatus.ONGOING)) {
+                        if (discussion.getDiscussionStatus() == DiscussionStatus.ONGOING) {
                             personalEventPreprocessor.preprocessOne(personalEvent, discussion, user,
                                 true);
                         }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -2,6 +2,7 @@ package endolphin.backend.domain.personal_event;
 
 import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.personal_event.dto.PersonalEventRequest;
 import endolphin.backend.domain.personal_event.dto.PersonalEventResponse;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
@@ -130,8 +131,11 @@ public class PersonalEventService {
                 personalEventRepository.save(personalEvent);
                 // 비트맵 수정
                 discussions.forEach(discussion -> {
-                    personalEventPreprocessor.preprocessOne(oldEvent, discussion, user, false);
-                    personalEventPreprocessor.preprocessOne(personalEvent, discussion, user, true);
+                    if (discussion.getDiscussionStatus().equals(DiscussionStatus.ONGOING)) {
+                        personalEventPreprocessor.preprocessOne(oldEvent, discussion, user, false);
+                        personalEventPreprocessor.preprocessOne(personalEvent, discussion, user,
+                            true);
+                    }
                 });
             });
     }
@@ -142,7 +146,9 @@ public class PersonalEventService {
             .ifPresent(personalEvent -> {
                 // 비트맵 삭제
                 discussions.forEach(discussion -> {
-                    personalEventPreprocessor.preprocessOne(personalEvent, discussion, user, false);
+                    if (discussion.getDiscussionStatus().equals(DiscussionStatus.ONGOING)) {
+                        personalEventPreprocessor.preprocessOne(personalEvent, discussion, user, false);
+                    }
                 });
                 personalEventRepository.delete(personalEvent);
             });

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -109,7 +109,7 @@ public class PersonalEventService {
         personalEventPreprocessor.preprocess(personalEvents, discussion, user);
     }
 
-    public void syncWithGoogleCalendar(List<GoogleEvent> googleEvents, User user) {
+    public void syncWithGoogleEvents(List<GoogleEvent> googleEvents, User user) {
         List<Discussion> discussions = discussionParticipantService.getDiscussionsByUserId(
             user.getId());
         for (GoogleEvent googleEvent : googleEvents) {

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -170,15 +170,11 @@ public class PersonalEventService {
     }
 
     private boolean hasChangedGoogleEvent(PersonalEvent personalEvent, GoogleEvent googleEvent) {
-        if (!personalEvent.getStartTime().equals(googleEvent.startDateTime())) {
-            return true;
+        if (personalEvent.getStartTime().equals(googleEvent.startDateTime())
+            && personalEvent.getEndTime().equals(googleEvent.endDateTime())
+            && personalEvent.getTitle().equals(googleEvent.summary())) {
+            return false;
         }
-        if (!personalEvent.getEndTime().equals(googleEvent.endDateTime())) {
-            return true;
-        }
-        if (!personalEvent.getTitle().equals(googleEvent.summary())) {
-            return true;
-        }
-        return false;
+        return true;
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -124,7 +124,7 @@ public class PersonalEventService {
         List<Discussion> discussions, User user) {
         personalEventRepository.findByGoogleEventId(googleEvent.eventId())
             .ifPresent(personalEvent -> {
-                PersonalEvent oldEvent = personalEvent;
+                PersonalEvent oldEvent = personalEvent.copy();
                 personalEvent.update(googleEvent.startDateTime(), googleEvent.endDateTime(),
                     googleEvent.summary());
                 personalEventRepository.save(personalEvent);

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -108,14 +108,15 @@ public class PersonalEventService {
         personalEventPreprocessor.preprocess(personalEvents, discussion, user);
     }
 
-    public void syncWithGoogleEvents(List<GoogleEvent> googleEvents, User user) {
+    public void syncWithGoogleEvents(List<GoogleEvent> googleEvents, User user,
+        String googleCalendarId) {
         List<Discussion> discussions = discussionParticipantService.getDiscussionsByUserId(
             user.getId());
         for (GoogleEvent googleEvent : googleEvents) {
             if (googleEvent.status().equals(GoogleEventStatus.CONFIRMED)) {
-                upsertPersonalEventByGoogleEvent(googleEvent, discussions, user);
+                upsertPersonalEventByGoogleEvent(googleEvent, discussions, user, googleCalendarId);
             } else if (googleEvent.status().equals(GoogleEventStatus.CANCELLED)) {
-                deletePersonalEventByGoogleEvent(googleEvent, discussions, user);
+                deletePersonalEventByGoogleEvent(googleEvent, discussions, user, googleCalendarId);
             }
         }
     }
@@ -127,8 +128,8 @@ public class PersonalEventService {
     }
 
     private void upsertPersonalEventByGoogleEvent(GoogleEvent googleEvent,
-        List<Discussion> discussions, User user) {
-        personalEventRepository.findByGoogleEventId(googleEvent.eventId())
+        List<Discussion> discussions, User user, String googleCalendarId) {
+        personalEventRepository.findByGoogleEventIdAndCalendarId(googleEvent.eventId(), googleCalendarId)
             .ifPresentOrElse(personalEvent -> {
                     if (hasChangedGoogleEvent(personalEvent, googleEvent)) {
                         PersonalEvent oldEvent = personalEvent.copy();
@@ -159,8 +160,8 @@ public class PersonalEventService {
     }
 
     private void deletePersonalEventByGoogleEvent(GoogleEvent googleEvent,
-        List<Discussion> discussions, User user) {
-        personalEventRepository.findByGoogleEventId(googleEvent.eventId())
+        List<Discussion> discussions, User user, String googleCalendarId) {
+        personalEventRepository.findByGoogleEventIdAndCalendarId(googleEvent.eventId(), googleCalendarId)
             .ifPresent(personalEvent -> {
                 // 비트맵 삭제
                 discussions.forEach(discussion -> {

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
@@ -69,4 +69,13 @@ public class PersonalEvent extends BaseTimeEntity {
         this.endTime = endDateTime;
         this.title = title;
     }
+
+    public PersonalEvent copy() {
+        return PersonalEvent.builder()
+            .title(this.title)
+            .startTime(this.startTime)
+            .endTime(this.endTime)
+            .user(this.user)
+            .build();
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
@@ -63,4 +63,10 @@ public class PersonalEvent extends BaseTimeEntity {
         this.title = personalEventRequest.title();
         this.isAdjustable = personalEventRequest.isAdjustable();
     }
+
+    public void update(LocalDateTime startDateTime, LocalDateTime endDateTime, String title) {
+        this.startTime = startDateTime;
+        this.endTime = endDateTime;
+        this.title = title;
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
@@ -3,6 +3,7 @@ package endolphin.backend.domain.personal_event.entity;
 import endolphin.backend.domain.personal_event.dto.PersonalEventRequest;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.base_entity.BaseTimeEntity;
+import endolphin.backend.global.google.dto.GoogleEvent;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -76,6 +77,16 @@ public class PersonalEvent extends BaseTimeEntity {
             .startTime(this.startTime)
             .endTime(this.endTime)
             .user(this.user)
+            .build();
+    }
+
+    public static PersonalEvent from(GoogleEvent googleEvent, User user) {
+        return PersonalEvent.builder()
+            .title(googleEvent.summary())
+            .startTime(googleEvent.startDateTime())
+            .endTime(googleEvent.endDateTime())
+            .googleEventId(googleEvent.eventId())
+            .user(user)
             .build();
     }
 }

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -35,6 +35,9 @@ public enum ErrorCode {
     OAUTH_FORBIDDEN_ERROR(HttpStatus.FORBIDDEN, "O003", "OAuth Forbidden Error"),
     INVALID_OAUTH_CODE(HttpStatus.UNAUTHORIZED, "O004", "Invalid OAuth Code"),
     INVALID_OAUTH_USER_INFO(HttpStatus.UNAUTHORIZED, "O005", "Invalid OAuth User Info"),
+
+    // Google Calendar
+    EXPIRED_SYNC_TOKEN(HttpStatus.GONE, "GC001", "Expired Sync Token"),
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -16,6 +16,10 @@ public enum ErrorCode {
     DISCUSSION_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "Discussion not found"),
     DISCUSSION_NOT_ONGOING(HttpStatus.BAD_REQUEST, "D002", "Discussion not ongoing"),
 
+    // PersonalEvent
+    PERSONAL_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "Personal Event not found"),
+    INVALID_PERSONAL_EVENT_USER(HttpStatus.FORBIDDEN, "P002", "Not allowed to update this personal event"),
+
     //SharedEvent
     SHARED_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "Shared Event not found"),
 

--- a/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
+++ b/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
@@ -7,6 +7,8 @@ import endolphin.backend.global.config.GoogleCalendarUrl;
 import endolphin.backend.global.error.exception.CalendarException;
 import endolphin.backend.global.google.dto.GoogleCalendarDto;
 import endolphin.backend.global.google.dto.GoogleEvent;
+import endolphin.backend.global.google.enums.GoogleEventStatus;
+import endolphin.backend.global.google.enums.GoogleResourceState;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -124,8 +126,10 @@ public class GoogleCalendarService {
                     LocalDateTime startDateTime = parseDateTime(start);
                     LocalDateTime endDateTime = parseDateTime(end);
 
+                    GoogleEventStatus eventStatus = GoogleEventStatus.valueOf(status);
+
                     events.add(
-                        new GoogleEvent(eventId, summary, startDateTime, endDateTime, status));
+                        new GoogleEvent(eventId, summary, startDateTime, endDateTime, eventStatus));
                 }
 
                 if (response.containsKey("nextSyncToken")) {
@@ -259,13 +263,13 @@ public class GoogleCalendarService {
 
             String calendarId = parseCalendarId(resourceUri);
 
-            if ("sync".equals(resourceState)) {
+            if (GoogleResourceState.SYNC.getValue().equals(resourceState)) {
                 log.info("🔄 [SYNC] Resource ID: {}, Channel ID: {}, User ID: {}, expiration : {}",
                     resourceId,
                     channelId, userId, channelExpiration);
                 calendarService.setWebhookProperties(calendarId, resourceId, channelId,
                     channelExpiration);
-            } else if ("exists".equals(resourceState)) {
+            } else if (GoogleResourceState.EXISTS.getValue().equals(resourceState)) {
                 log.info("📅 [EXISTS] Calendar ID: {}, User ID: {}", calendarId, userId);
 
                 User user = userService.getUser(userId);
@@ -273,6 +277,7 @@ public class GoogleCalendarService {
                 /* TODO: 업데이트된 이벤트 처리 로직(personalEventService 호출)
                 GoogleEvent.status = "confirmed" -> 추가 or 변경, "cancelled" -> 삭제 입니다.
                  */
+
             } else {
                 throw new CalendarException(HttpStatus.BAD_REQUEST,
                     "Unknown State: " + resourceState);

--- a/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
+++ b/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
@@ -227,7 +227,7 @@ public class GoogleCalendarService {
     }
 
     public void subscribeToCalendar(Calendar calendar, User user) {
-        if (calendar.getChannelExpiration() != null && calendar.getChannelExpiration().isBefore(LocalDateTime.now())) {
+        if (calendar.getChannelExpiration() != null && !calendar.getChannelExpiration().isBefore(LocalDateTime.now())) {
             return;
         }
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();

--- a/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
+++ b/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
@@ -55,7 +55,7 @@ public class GoogleCalendarService {
             Map<String, Object> response = restClient.get()
                 .uri(eventsUrl)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + user.getAccessToken())
-                .retrieve()
+                .retrieve() // TODO: access Token 만료 처리
                 .body(new ParameterizedTypeReference<>() {
                 });
 
@@ -104,7 +104,7 @@ public class GoogleCalendarService {
             Map<String, Object> response = restClient.get()
                 .uri(eventsUrl)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + user.getAccessToken())
-                .retrieve()
+                .retrieve() // TODO: access token 재발급 처리
                 .body(new ParameterizedTypeReference<>() {
                 });
 
@@ -155,7 +155,7 @@ public class GoogleCalendarService {
             Map<String, Object> response = restClient.get()
                 .uri(googleCalendarUrl.primaryCalendarUrl())
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                .retrieve()
+                .retrieve() // TODO: access token 재발급 처리
                 .body(new ParameterizedTypeReference<>() {
                 });
 
@@ -169,40 +169,6 @@ public class GoogleCalendarService {
             } else {
                 throw new CalendarException(HttpStatus.BAD_REQUEST, "Primary 캘린더 조회 실패");
             }
-        } catch (Exception e) {
-            throw new CalendarException(HttpStatus.BAD_REQUEST, e.getMessage());
-        }
-    }
-
-    public List<GoogleCalendarDto> getUserCalendars(String accessToken) {
-        try {
-            Map<String, Object> response = restClient.get()
-                .uri(googleCalendarUrl.calendarListUrl())
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                .retrieve()
-                .body(new ParameterizedTypeReference<>() {
-                });
-
-            List<GoogleCalendarDto> calendarDtos = new ArrayList<>();
-
-            if (response != null && response.containsKey("items")) {
-                List<Map<String, Object>> calendars = (List<Map<String, Object>>) response.get(
-                    "items");
-
-                for (Map<String, Object> calendar : calendars) {
-                    String id = (String) calendar.get("id");
-                    String summary = (String) calendar.get("summary");
-                    String timeZone = (String) calendar.get("timeZone");
-                    String accessRole = (String) calendar.get("accessRole");
-
-                    calendarDtos.add(new GoogleCalendarDto(id, summary, timeZone, accessRole));
-                }
-            } else {
-                throw new CalendarException(HttpStatus.BAD_REQUEST, "캘린더 목록 조회 실패");
-            }
-
-            return calendarDtos;
-
         } catch (Exception e) {
             throw new CalendarException(HttpStatus.BAD_REQUEST, e.getMessage());
         }

--- a/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
+++ b/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
@@ -277,7 +277,7 @@ public class GoogleCalendarService {
                 User user = userService.getUser(userId);
                 List<GoogleEvent> events = syncWithCalendar(calendarId, user);
                 // TODO: 업데이트된 이벤트 처리 로직(personalEventService 호출)
-                personalEventService.syncWithGoogleCalendar(events);
+                personalEventService.syncWithGoogleCalendar(events, user);
             } else {
                 throw new CalendarException(HttpStatus.BAD_REQUEST,
                     "Unknown State: " + resourceState);

--- a/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
+++ b/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
@@ -163,10 +163,10 @@ public class GoogleCalendarService {
         } catch (OAuthException e) {
             String accessToken = googleOAuthService.reissueAccessToken(user.getAccessToken());
             userService.updateAccessToken(user, accessToken);
-            return getCalendarEvents(calendarId, user);
+            return syncWithCalendar(calendarId, user);
         } catch (CalendarException e) {
             calendarService.clearSyncToken(calendarId);
-            return getCalendarEvents(calendarId, user);
+            return syncWithCalendar(calendarId, user);
         } catch (Exception e) {
             throw new CalendarException(HttpStatus.BAD_REQUEST, e.getMessage());
         }
@@ -243,11 +243,9 @@ public class GoogleCalendarService {
                     "캘린더 구독 실패: " + googleCalendarId);
             }
         } catch (OAuthException e) {
-            if (e.getErrorCode() == ErrorCode.OAUTH_UNAUTHORIZED_ERROR) {
-                String accessToken = googleOAuthService.reissueAccessToken(user.getAccessToken());
-                userService.updateAccessToken(user, accessToken);
-                subscribeToCalendar(googleCalendarId, user);
-            }
+            String accessToken = googleOAuthService.reissueAccessToken(user.getAccessToken());
+            userService.updateAccessToken(user, accessToken);
+            subscribeToCalendar(googleCalendarId, user);
         } catch (Exception e) {
             throw new CalendarException(HttpStatus.FORBIDDEN, e.getMessage());
         }

--- a/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
+++ b/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
@@ -75,16 +75,12 @@ public class GoogleCalendarService {
                     LocalDateTime endDateTime = parseDateTime(end);
 
                     events.add(new GoogleEvent(eventId, summary, startDateTime, endDateTime, null));
-                    System.out.println(
-                        "eventId: " + eventId + ", summary: " + summary + ", startDateTime: "
-                            + startDateTime + ", endDateTime: " + endDateTime);
                 }
 
                 // ✅ nextSyncToken을 받아서 저장
                 if (response.containsKey("nextSyncToken")) {
                     String nextSyncToken = (String) response.get("nextSyncToken");
                     calendarService.updateSyncToken(calendarId, nextSyncToken);
-                    System.out.println("nextSyncToken: " + nextSyncToken);
                 }
             } else {
                 throw new CalendarException(HttpStatus.BAD_REQUEST, "캘린더 이벤트 조회 실패");
@@ -147,7 +143,6 @@ public class GoogleCalendarService {
         } catch (Exception e) {
             // syncToken 만료 시 초기화 후 재시도 (HTTP 410 처리)
             if (e.getMessage().contains("410")) {
-                System.out.println("⚠️ syncToken 만료됨. 초기 동기화로 전환합니다.");
                 calendarService.clearSyncToken(calendarId);
                 return getCalendarEvents(calendarId, user);
             }
@@ -215,6 +210,7 @@ public class GoogleCalendarService {
 
     public void subscribeToCalendar(GoogleCalendarDto calendarDto, User user) {
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        // TODO: 캘린더 서비스에서 채널만료기한을 조회해서 현재 시간 이후면 구독 하지 않음
         body.add("id", UUID.randomUUID().toString());
         body.add("type", "web_hook");
         body.add("address",

--- a/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
+++ b/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
@@ -63,7 +63,7 @@ public class GoogleCalendarService {
             Calendar calendar = calendarService.createCalendar(googleCalendarDto, user);
             List<GoogleEvent> events = getCalendarEvents(googleCalendarDto.id(), user);
 
-            personalEventService.syncWithGoogleEvents(events, user);
+            personalEventService.syncWithGoogleEvents(events, user, calendar.getCalendarId());
             subscribeToCalendar(calendar, user);
         }
     }
@@ -300,7 +300,7 @@ public class GoogleCalendarService {
 
                 User user = userService.getUser(userId);
                 List<GoogleEvent> events = syncWithCalendar(calendarId, user);
-                personalEventService.syncWithGoogleEvents(events, user);
+                personalEventService.syncWithGoogleEvents(events, user, calendarId);
             } else {
                 throw new CalendarException(HttpStatus.BAD_REQUEST,
                     "Unknown State: " + resourceState);

--- a/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
+++ b/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
@@ -1,6 +1,7 @@
 package endolphin.backend.global.google;
 
 import endolphin.backend.domain.calendar.CalendarService;
+import endolphin.backend.domain.personal_event.PersonalEventService;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.config.GoogleCalendarUrl;
@@ -41,6 +42,7 @@ public class GoogleCalendarService {
     private final GoogleCalendarUrl googleCalendarUrl;
     private final CalendarService calendarService;
     private final UserService userService;
+    private final PersonalEventService personalEventService;
 
     public List<GoogleEvent> getCalendarEvents(String calendarId, User user) {
         try {
@@ -274,10 +276,8 @@ public class GoogleCalendarService {
 
                 User user = userService.getUser(userId);
                 List<GoogleEvent> events = syncWithCalendar(calendarId, user);
-                /* TODO: 업데이트된 이벤트 처리 로직(personalEventService 호출)
-                GoogleEvent.status = "confirmed" -> 추가 or 변경, "cancelled" -> 삭제 입니다.
-                 */
-
+                // TODO: 업데이트된 이벤트 처리 로직(personalEventService 호출)
+                personalEventService.syncWithGoogleCalendar(events);
             } else {
                 throw new CalendarException(HttpStatus.BAD_REQUEST,
                     "Unknown State: " + resourceState);

--- a/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
+++ b/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
@@ -54,7 +54,7 @@ public class GoogleCalendarService {
     public void upsertGoogleCalendar(User user) {
         if (calendarService.isExistingCalendar(user.getId())) {
             Calendar calendar = calendarService.getCalendarByUserId(user.getId());
-            if (!calendar.getChannelExpiration().isBefore(LocalDateTime.now())) {
+            if (!calendar.getChannelExpiration().isAfter(LocalDateTime.now())) {
                 subscribeToCalendar(calendar, user);
             }
         } else {
@@ -227,8 +227,10 @@ public class GoogleCalendarService {
     }
 
     public void subscribeToCalendar(Calendar calendar, User user) {
+        if (calendar.getChannelExpiration() != null && calendar.getChannelExpiration().isBefore(LocalDateTime.now())) {
+            return;
+        }
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        // TODO: 캘린더 서비스에서 채널만료기한을 조회해서 현재 시간 이후면 구독 하지 않음
         body.add("id", UUID.randomUUID().toString());
         body.add("type", "web_hook");
         body.add("address",

--- a/backend/src/main/java/endolphin/backend/global/google/dto/GoogleEvent.java
+++ b/backend/src/main/java/endolphin/backend/global/google/dto/GoogleEvent.java
@@ -1,5 +1,6 @@
 package endolphin.backend.global.google.dto;
 
+import endolphin.backend.global.google.enums.GoogleEventStatus;
 import java.time.LocalDateTime;
 
 public record GoogleEvent(
@@ -7,7 +8,7 @@ public record GoogleEvent(
     String summary,
     LocalDateTime startDateTime,
     LocalDateTime endDateTime,
-    String state
+    GoogleEventStatus status
 ) {
 
 }

--- a/backend/src/main/java/endolphin/backend/global/google/enums/GoogleEventStatus.java
+++ b/backend/src/main/java/endolphin/backend/global/google/enums/GoogleEventStatus.java
@@ -1,0 +1,25 @@
+package endolphin.backend.global.google.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum GoogleEventStatus {
+    CONFIRMED("confirmed"),
+    CANCELLED("cancelled"),
+    TENTATIVE("tentative");
+
+    private final String value;
+    GoogleEventStatus(String value) {
+        this.value = value;
+    }
+
+    public static GoogleEventStatus fromValue(String value) {
+        String lowerCaseValue = value.toLowerCase();
+        for (GoogleEventStatus state : GoogleEventStatus.values()) {
+            if (state.getValue().equals(lowerCaseValue)) {
+                return state;
+            }
+        }
+        return CONFIRMED;
+    }
+}

--- a/backend/src/main/java/endolphin/backend/global/google/enums/GoogleResourceState.java
+++ b/backend/src/main/java/endolphin/backend/global/google/enums/GoogleResourceState.java
@@ -1,0 +1,15 @@
+package endolphin.backend.global.google.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum GoogleResourceState {
+    SYNC("sync"),
+    EXISTS("exists");
+
+    private final String value;
+
+    GoogleResourceState(String value) {
+        this.value = value;
+    }
+}

--- a/backend/src/test/java/endolphin/backend/domain/auth/AuthServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/auth/AuthServiceTest.java
@@ -2,32 +2,25 @@ package endolphin.backend.domain.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import endolphin.backend.domain.auth.dto.OAuthResponse;
-import endolphin.backend.domain.calendar.CalendarService;
 import endolphin.backend.domain.calendar.entity.Calendar;
+import endolphin.backend.domain.personal_event.PersonalEventService;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.google.GoogleCalendarService;
 import endolphin.backend.global.google.GoogleOAuthService;
-import endolphin.backend.global.google.dto.GoogleCalendarDto;
 import endolphin.backend.global.google.dto.GoogleTokens;
 import endolphin.backend.global.google.dto.GoogleUserInfo;
 import endolphin.backend.global.security.JwtProvider;
 
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,9 +31,6 @@ class AuthServiceTest {
 
     @Mock
     private GoogleOAuthService googleOAuthService;
-
-    @Mock
-    private CalendarService calendarService;
 
     @Mock
     private GoogleCalendarService googleCalendarService;
@@ -67,8 +57,6 @@ class AuthServiceTest {
             .refreshToken(googleTokens.refreshToken())
             .build();
 
-        GoogleCalendarDto googleCalendarDto = new GoogleCalendarDto("primary", "Test Calendar", "for test", "Asia/Seoul");
-
         given(googleOAuthService.getGoogleTokens(anyString()))
             .willReturn(googleTokens);
 
@@ -77,12 +65,6 @@ class AuthServiceTest {
 
         given(userService.upsertUser(any(GoogleUserInfo.class), any(GoogleTokens.class)))
             .willReturn(user);
-
-        given(calendarService.isExistingCalendar(any())).willReturn(false);
-
-
-        given(googleCalendarService.getPrimaryCalendar(user))
-            .willReturn(googleCalendarDto);
 
         given(jwtProvider.createToken(user.getId(), user.getEmail()))
             .willReturn("test-jwt-token");
@@ -92,51 +74,5 @@ class AuthServiceTest {
 
         // Then
         assertThat(response.accessToken()).isEqualTo("test-jwt-token");
-
-        // ✅ 추가된 메서드 호출 검증
-        verify(googleCalendarService).getPrimaryCalendar(user);
-        verify(googleCalendarService).subscribeToCalendar(googleCalendarDto.id(), user);
-    }
-
-    @Test
-    @DisplayName("로그인 콜백 테스트 - 이미 캘린더가 존재하고 구독 채널이 만료 된 경우")
-    void oauth2Callback_secondLogin() {
-        // given
-        String code = "test-auth-code";
-        GoogleTokens googleTokens = new GoogleTokens("test-access-token", "test-refresh-token");
-        GoogleUserInfo googleUserInfo = new GoogleUserInfo("test-sub", "test-name", "test-email", "test-pic");
-
-        User user = User.builder()
-            .email(googleUserInfo.email())
-            .name(googleUserInfo.name())
-            .picture(googleUserInfo.picture())
-            .accessToken(googleTokens.accessToken())
-            .refreshToken(googleTokens.refreshToken())
-            .build();
-
-        given(googleOAuthService.getGoogleTokens(anyString()))
-            .willReturn(googleTokens);
-
-        given(googleOAuthService.getUserInfo(anyString()))
-            .willReturn(googleUserInfo);
-
-        given(userService.upsertUser(any(GoogleUserInfo.class), any(GoogleTokens.class)))
-            .willReturn(user);
-
-        Calendar calendar = Mockito.mock(Calendar.class);
-        given(calendar.getChannelExpiration()).willReturn(LocalDateTime.now().plusDays(20L));
-        given(calendar.getCalendarId()).willReturn("primary");
-
-        given(calendarService.isExistingCalendar(any())).willReturn(true);
-        given(calendarService.getCalendarByUserId(any())).willReturn(calendar);
-
-        given(jwtProvider.createToken(user.getId(), user.getEmail()))
-            .willReturn("test-jwt-token");
-
-        OAuthResponse response = authService.oauth2Callback(code);
-
-        assertThat(response.accessToken()).isEqualTo("test-jwt-token");
-
-        verify(googleCalendarService, times(1)).subscribeToCalendar("primary", user);
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/auth/AuthServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/auth/AuthServiceTest.java
@@ -81,7 +81,7 @@ class AuthServiceTest {
         given(calendarService.isExistingCalendar(any())).willReturn(false);
 
 
-        given(googleCalendarService.getPrimaryCalendar(user.getAccessToken()))
+        given(googleCalendarService.getPrimaryCalendar(user))
             .willReturn(googleCalendarDto);
 
         given(jwtProvider.createToken(user.getId(), user.getEmail()))
@@ -94,7 +94,7 @@ class AuthServiceTest {
         assertThat(response.accessToken()).isEqualTo("test-jwt-token");
 
         // ✅ 추가된 메서드 호출 검증
-        verify(googleCalendarService).getPrimaryCalendar(user.getAccessToken());
+        verify(googleCalendarService).getPrimaryCalendar(user);
         verify(googleCalendarService).subscribeToCalendar(googleCalendarDto.id(), user);
     }
 

--- a/backend/src/test/java/endolphin/backend/domain/auth/AuthServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/auth/AuthServiceTest.java
@@ -2,13 +2,16 @@ package endolphin.backend.domain.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import endolphin.backend.domain.auth.dto.OAuthResponse;
 import endolphin.backend.domain.calendar.CalendarService;
+import endolphin.backend.domain.calendar.entity.Calendar;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.google.GoogleCalendarService;
@@ -18,11 +21,13 @@ import endolphin.backend.global.google.dto.GoogleTokens;
 import endolphin.backend.global.google.dto.GoogleUserInfo;
 import endolphin.backend.global.security.JwtProvider;
 
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,7 +53,7 @@ class AuthServiceTest {
 
     @Test
     @DisplayName("로그인 콜백 테스트 - 캘린더 연동 포함")
-    void oauth2Callback_ShouldReturnJwtTokenWithCalendarSync() {
+    void oauth2Callback_firstLogin() {
         // Given
         String code = "test-auth-code";
         GoogleTokens googleTokens = new GoogleTokens("test-access-token", "test-refresh-token");
@@ -73,6 +78,9 @@ class AuthServiceTest {
         given(userService.upsertUser(any(GoogleUserInfo.class), any(GoogleTokens.class)))
             .willReturn(user);
 
+        given(calendarService.isExistingCalendar(any())).willReturn(false);
+
+
         given(googleCalendarService.getPrimaryCalendar(user.getAccessToken()))
             .willReturn(googleCalendarDto);
 
@@ -87,6 +95,48 @@ class AuthServiceTest {
 
         // ✅ 추가된 메서드 호출 검증
         verify(googleCalendarService).getPrimaryCalendar(user.getAccessToken());
-        verify(googleCalendarService).subscribeToCalendar(googleCalendarDto, user);
+        verify(googleCalendarService).subscribeToCalendar(googleCalendarDto.id(), user);
+    }
+
+    @Test
+    @DisplayName("로그인 콜백 테스트 - 이미 캘린더가 존재하고 구독 채널이 만료 된 경우")
+    void oauth2Callback_secondLogin() {
+        // given
+        String code = "test-auth-code";
+        GoogleTokens googleTokens = new GoogleTokens("test-access-token", "test-refresh-token");
+        GoogleUserInfo googleUserInfo = new GoogleUserInfo("test-sub", "test-name", "test-email", "test-pic");
+
+        User user = User.builder()
+            .email(googleUserInfo.email())
+            .name(googleUserInfo.name())
+            .picture(googleUserInfo.picture())
+            .accessToken(googleTokens.accessToken())
+            .refreshToken(googleTokens.refreshToken())
+            .build();
+
+        given(googleOAuthService.getGoogleTokens(anyString()))
+            .willReturn(googleTokens);
+
+        given(googleOAuthService.getUserInfo(anyString()))
+            .willReturn(googleUserInfo);
+
+        given(userService.upsertUser(any(GoogleUserInfo.class), any(GoogleTokens.class)))
+            .willReturn(user);
+
+        Calendar calendar = Mockito.mock(Calendar.class);
+        given(calendar.getChannelExpiration()).willReturn(LocalDateTime.now().plusDays(20L));
+        given(calendar.getCalendarId()).willReturn("primary");
+
+        given(calendarService.isExistingCalendar(any())).willReturn(true);
+        given(calendarService.getCalendarByUserId(any())).willReturn(calendar);
+
+        given(jwtProvider.createToken(user.getId(), user.getEmail()))
+            .willReturn("test-jwt-token");
+
+        OAuthResponse response = authService.oauth2Callback(code);
+
+        assertThat(response.accessToken()).isEqualTo("test-jwt-token");
+
+        verify(googleCalendarService, times(1)).subscribeToCalendar("primary", user);
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
@@ -73,7 +73,7 @@ class PersonalEventPreprocessorTest {
         // count : 0
         PersonalEvent personalEvent = mock(PersonalEvent.class);
         given(personalEvent.getStartTime()).willReturn(LocalDateTime.of(2024, 3, 8, 8, 0, 0));
-        given(personalEvent.getEndTime()).willReturn(LocalDateTime.of(2024, 3, 10, 12, 0, 0));
+        given(personalEvent.getEndTime()).willReturn(LocalDateTime.of(2024, 3, 9, 12, 0, 0));
 
         // when
         preprocessor.preprocessOne(personalEvent, discussion, user, true);

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
@@ -4,6 +4,7 @@ import static org.mockito.BDDMockito.*;
 
 import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.redis.DiscussionBitmapService;
@@ -63,7 +64,7 @@ class PersonalEventPreprocessorTest {
         Long userId = 200L;
         Long participantIndex = 2L;
         // Discussion, User, PersonalEvent 모킹
-        Discussion discussion = getDiscussion();
+        Discussion discussion = getAnotherDiscussion();
         User user = getUser();
 
         given(discussionParticipantService.getDiscussionParticipantOffset(anyLong(), anyLong()))
@@ -73,10 +74,9 @@ class PersonalEventPreprocessorTest {
         PersonalEvent personalEvent = mock(PersonalEvent.class);
         given(personalEvent.getStartTime()).willReturn(LocalDateTime.of(2024, 3, 8, 8, 0, 0));
         given(personalEvent.getEndTime()).willReturn(LocalDateTime.of(2024, 3, 10, 12, 0, 0));
-        given(personalEvent.getId()).willReturn(2L);
 
         // when
-        preprocessor.preprocess(List.of(personalEvent), discussion, user);
+        preprocessor.preprocessOne(personalEvent, discussion, user, true);
 
         // then
         then(discussionBitmapService).should(times(0)).setBitValue(anyLong(), any(LocalDateTime.class), anyLong(), anyBoolean());
@@ -163,10 +163,20 @@ class PersonalEventPreprocessorTest {
     private Discussion getDiscussion() {
         Discussion discussion = Mockito.mock(Discussion.class);
         given(discussion.getId()).willReturn(1L);
+        given(discussion.getDiscussionStatus()).willReturn(DiscussionStatus.ONGOING);
         given(discussion.getDateRangeStart()).willReturn(LocalDate.of(2024, 3, 10));
         given(discussion.getDateRangeEnd()).willReturn(LocalDate.of(2024, 3, 20));
         given(discussion.getTimeRangeStart()).willReturn(LocalTime.of(12, 0));
         given(discussion.getTimeRangeEnd()).willReturn(LocalTime.of(15, 0));
+        return discussion;
+    }
+
+    private Discussion getAnotherDiscussion() {
+        Discussion discussion = Mockito.mock(Discussion.class);
+        given(discussion.getId()).willReturn(1L);
+        given(discussion.getDiscussionStatus()).willReturn(DiscussionStatus.ONGOING);
+        given(discussion.getDateRangeStart()).willReturn(LocalDate.of(2024, 3, 10));
+        given(discussion.getDateRangeEnd()).willReturn(LocalDate.of(2024, 3, 20));
         return discussion;
     }
 

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -201,7 +201,7 @@ class PersonalEventServiceTest {
     }
 
     @Test
-    @DisplayName("")
+    @DisplayName("업데이트된 구글 일정을 개인 일정에 반영하는 테스트")
     public void testUpdatePersonalEventByGoogleSync_Success() {
         // given
         User user = createTestUser();

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -268,7 +268,6 @@ class PersonalEventServiceTest {
 
     Discussion createDiscussion() {
         Discussion discussion = Mockito.mock(Discussion.class);
-        given(discussion.getDiscussionStatus()).willReturn(DiscussionStatus.ONGOING);
         return discussion;
     }
 

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -205,6 +205,7 @@ class PersonalEventServiceTest {
     public void testUpdatePersonalEventByGoogleSync_Success() {
         // given
         User user = createTestUser();
+        String googleCalendarId = "testGoogleCalendarId";
         GoogleEvent updatedGoogleEvent = createGoogleEvent("testEventId1", "testTitle1",
             LocalDateTime.of(2024, 3, 10, 10, 0),
             LocalDateTime.of(2024, 3, 10, 12, 0), GoogleEventStatus.CONFIRMED);
@@ -223,14 +224,14 @@ class PersonalEventServiceTest {
         given(existingEvent.copy()).willReturn(oldExistingEvent);
         PersonalEvent existingEvent2 = createPersonalEvent("Old Title2");
 
-        given(personalEventRepository.findByGoogleEventId(
-            eq(updatedGoogleEvent.eventId()))).willReturn(Optional.of(existingEvent));
-        given(personalEventRepository.findByGoogleEventId(
-            eq(deletedGoogleEvent.eventId()))).willReturn(Optional.of(existingEvent2));
+        given(personalEventRepository.findByGoogleEventIdAndCalendarId(
+            eq(updatedGoogleEvent.eventId()), eq(googleCalendarId))).willReturn(Optional.of(existingEvent));
+        given(personalEventRepository.findByGoogleEventIdAndCalendarId(
+            eq(deletedGoogleEvent.eventId()), eq(googleCalendarId))).willReturn(Optional.of(existingEvent2));
 
         // when
         personalEventService.syncWithGoogleEvents(List.of(updatedGoogleEvent, deletedGoogleEvent),
-            user);
+            user, googleCalendarId);
 
         // then
         then(personalEventPreprocessor).should(times(1))

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -205,36 +205,47 @@ class PersonalEventServiceTest {
     public void testUpdatePersonalEventByGoogleSync_Success() {
         // given
         User user = createTestUser();
-        GoogleEvent updatedGoogleEvent = createGoogleEvent("testEventId1","testTitle1",
+        GoogleEvent updatedGoogleEvent = createGoogleEvent("testEventId1", "testTitle1",
             LocalDateTime.of(2024, 3, 10, 10, 0),
             LocalDateTime.of(2024, 3, 10, 12, 0), GoogleEventStatus.CONFIRMED);
 
-        GoogleEvent deletedGoogleEvent = createGoogleEvent("testEventId2","testTitle2",
+        GoogleEvent deletedGoogleEvent = createGoogleEvent("testEventId2", "testTitle2",
             LocalDateTime.of(2024, 5, 10, 7, 0),
             LocalDateTime.of(2024, 5, 10, 12, 0), GoogleEventStatus.CANCELLED);
         Discussion discussion = createDiscussion();
         Discussion anotherDiscussion = createDiscussion();
-        given(discussionParticipantService.getDiscussionsByUserId(anyLong())).willReturn(List.of(discussion, anotherDiscussion));
+        given(discussionParticipantService.getDiscussionsByUserId(anyLong())).willReturn(
+            List.of(discussion, anotherDiscussion));
 
-        PersonalEvent existingEvent = createPersonalEvent("Old Title");
+        PersonalEvent existingEvent = createPersonalEvent("new Title");
+        given(existingEvent.getStartTime()).willReturn(LocalDateTime.of(2024, 3, 10, 10, 0));
         PersonalEvent oldExistingEvent = createPersonalEvent("Old Title");
         given(existingEvent.copy()).willReturn(oldExistingEvent);
         PersonalEvent existingEvent2 = createPersonalEvent("Old Title2");
 
-        given(personalEventRepository.findByGoogleEventId(eq(updatedGoogleEvent.eventId()))).willReturn(Optional.of(existingEvent));
-        given(personalEventRepository.findByGoogleEventId(eq(deletedGoogleEvent.eventId()))).willReturn(Optional.of(existingEvent2));
+        given(personalEventRepository.findByGoogleEventId(
+            eq(updatedGoogleEvent.eventId()))).willReturn(Optional.of(existingEvent));
+        given(personalEventRepository.findByGoogleEventId(
+            eq(deletedGoogleEvent.eventId()))).willReturn(Optional.of(existingEvent2));
 
         // when
-        personalEventService.syncWithGoogleEvents(List.of(updatedGoogleEvent, deletedGoogleEvent), user);
+        personalEventService.syncWithGoogleEvents(List.of(updatedGoogleEvent, deletedGoogleEvent),
+            user);
 
         // then
-        then(personalEventPreprocessor).should(times(1)).preprocessOne(eq(oldExistingEvent), eq(discussion), any(User.class), eq(false));
-        then(personalEventPreprocessor).should(times(1)).preprocessOne(eq(oldExistingEvent), eq(anotherDiscussion), any(User.class), eq(false));
-        then(personalEventPreprocessor).should(times(1)).preprocessOne(eq(existingEvent), eq(discussion), any(User.class), eq(true));
-        then(personalEventPreprocessor).should(times(1)).preprocessOne(eq(existingEvent), eq(anotherDiscussion), any(User.class), eq(true));
+        then(personalEventPreprocessor).should(times(1))
+            .preprocessOne(eq(oldExistingEvent), eq(discussion), any(User.class), eq(false));
+        then(personalEventPreprocessor).should(times(1))
+            .preprocessOne(eq(oldExistingEvent), eq(anotherDiscussion), any(User.class), eq(false));
+        then(personalEventPreprocessor).should(times(1))
+            .preprocessOne(eq(existingEvent), eq(discussion), any(User.class), eq(true));
+        then(personalEventPreprocessor).should(times(1))
+            .preprocessOne(eq(existingEvent), eq(anotherDiscussion), any(User.class), eq(true));
 
-        then(personalEventPreprocessor).should(times(1)).preprocessOne(eq(existingEvent2), eq(discussion), any(User.class), eq(false));
-        then(personalEventPreprocessor).should(times(1)).preprocessOne(eq(existingEvent2), eq(anotherDiscussion), any(User.class), eq(false));
+        then(personalEventPreprocessor).should(times(1))
+            .preprocessOne(eq(existingEvent2), eq(discussion), any(User.class), eq(false));
+        then(personalEventPreprocessor).should(times(1))
+            .preprocessOne(eq(existingEvent2), eq(anotherDiscussion), any(User.class), eq(false));
     }
 
     PersonalEvent createPersonalEvent(String title, int minusHour, User user) {

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -225,7 +225,7 @@ class PersonalEventServiceTest {
         given(personalEventRepository.findByGoogleEventId(eq(deletedGoogleEvent.eventId()))).willReturn(Optional.of(existingEvent2));
 
         // when
-        personalEventService.syncWithGoogleCalendar(List.of(updatedGoogleEvent, deletedGoogleEvent), user);
+        personalEventService.syncWithGoogleEvents(List.of(updatedGoogleEvent, deletedGoogleEvent), user);
 
         // then
         then(personalEventPreprocessor).should(times(1)).preprocessOne(eq(oldExistingEvent), eq(discussion), any(User.class), eq(false));

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -2,6 +2,7 @@ package endolphin.backend.domain.personal_event;
 
 import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.personal_event.dto.PersonalEventRequest;
 import endolphin.backend.domain.personal_event.dto.PersonalEventResponse;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
@@ -254,7 +255,9 @@ class PersonalEventServiceTest {
     }
 
     Discussion createDiscussion() {
-        return Mockito.mock(Discussion.class);
+        Discussion discussion = Mockito.mock(Discussion.class);
+        given(discussion.getDiscussionStatus()).willReturn(DiscussionStatus.ONGOING);
+        return discussion;
     }
 
     PersonalEvent createPersonalEvent(String title) {

--- a/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
@@ -46,7 +46,7 @@ class GoogleCalendarServiceTest {
     private GoogleCalendarService googleCalendarService;
 
     @Test
-    @DisplayName("사용자에게 캘린더가 이미 존재하고 구독 채널이 아직 유효할 경우")
+    @DisplayName("사용자에게 캘린더가 이미 존재하고 구독 채널이 만료되지 않은 경우")
     void upsertGoogleCalendar_existingCalendar_validExpiration() {
         // Given
         User user = Mockito.mock(User.class);
@@ -57,7 +57,7 @@ class GoogleCalendarServiceTest {
 
         // 채널 만료시간이 현재보다 이후인 캘린더를 리턴하도록 stub 처리
         Calendar calendar = Mockito.mock(Calendar.class);
-        given(calendar.getChannelExpiration()).willReturn(LocalDateTime.now().minusDays(1));
+        given(calendar.getChannelExpiration()).willReturn(LocalDateTime.now().plusDays(1));
 
         given(calendarService.getCalendarByUserId(eq(user.getId()))).willReturn(calendar);
 
@@ -110,14 +110,14 @@ class GoogleCalendarServiceTest {
     }
 
     @Test
-    @DisplayName("사용자에게 캘린더가 이미 존재하고 구독 채널이 만료되었을 경우")
+    @DisplayName("사용자에게 캘린더가 이미 존재하고 구독 채널이 만료된 경우")
     void upsertGoogleCalendar_existingCalendar_expired() {
         // Given
         User user = Mockito.mock(User.class);
         given(user.getId()).willReturn(1L);
         given(calendarService.isExistingCalendar(user.getId())).willReturn(true);
         Calendar calendar = Mockito.mock(Calendar.class);
-        given(calendar.getChannelExpiration()).willReturn(LocalDateTime.now().plusDays(1));
+        given(calendar.getChannelExpiration()).willReturn(LocalDateTime.now().minusDays(1));
         given(calendarService.getCalendarByUserId(user.getId())).willReturn(calendar);
 
         doNothing().when(googleCalendarService).subscribeToCalendar(calendar, user);

--- a/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
@@ -1,11 +1,134 @@
 package endolphin.backend.global.google;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 
+import endolphin.backend.domain.calendar.CalendarService;
+import endolphin.backend.domain.calendar.entity.Calendar;
+import endolphin.backend.domain.personal_event.PersonalEventService;
+import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.config.GoogleCalendarUrl;
+import endolphin.backend.global.google.dto.GoogleCalendarDto;
+import endolphin.backend.global.google.dto.GoogleEvent;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class GoogleCalendarServiceTest {
 
+    @Mock
+    private CalendarService calendarService;
+
+    @Mock
+    private GoogleCalendarUrl googleCalendarUrl;
+
+    @Mock
+    private PersonalEventService personalEventService;
+
+    // 테스트 대상 클래스. 내부의 getPrimaryCalendar(), getCalendarEvents()등을 spy를 통해 부분 모킹합니다.
+    @Spy
+    @InjectMocks
+    private GoogleCalendarService googleCalendarService;
+
+    @Test
+    @DisplayName("사용자에게 캘린더가 이미 존재하고 구독 채널이 아직 유효할 경우")
+    void upsertGoogleCalendar_existingCalendar_validExpiration() {
+        // Given
+        User user = Mockito.mock(User.class);
+        given(user.getId()).willReturn(1L);
+
+        // 캘린더가 존재한다고 응답
+        given(calendarService.isExistingCalendar(user.getId())).willReturn(true);
+
+        // 채널 만료시간이 현재보다 이후인 캘린더를 리턴하도록 stub 처리
+        Calendar calendar = Mockito.mock(Calendar.class);
+        given(calendar.getChannelExpiration()).willReturn(LocalDateTime.now().minusDays(1));
+
+        given(calendarService.getCalendarByUserId(eq(user.getId()))).willReturn(calendar);
+
+        // When
+        googleCalendarService.upsertGoogleCalendar(user);
+
+        // Then
+        then(calendarService).should().isExistingCalendar(user.getId());
+        then(calendarService).should().getCalendarByUserId(user.getId());
+
+        // 신규 캘린더 생성, 이벤트 동기화, 캘린더 채널 구독은 발생하지 않아야 합니다.
+        then(googleCalendarService).should(never()).subscribeToCalendar(any(), any());
+        then(calendarService).should(never()).createCalendar(any(), eq(user));
+        then(personalEventService).should(never()).syncWithGoogleEvents(any(), eq(user));
+    }
+
+    @Test
+    @DisplayName("사용자에게 캘린더가 존재하지 않을 경우")
+    void upsertGoogleCalendar_noExistingCalendar() {
+        // Given
+        User user = Mockito.mock(User.class);
+        given(user.getId()).willReturn(1L);
+
+        // 캘린더가 존재하지 않다고 응답
+        given(calendarService.isExistingCalendar(user.getId())).willReturn(false);
+
+        // 내부 메서드 getPrimaryCalendar() 를 stub 처리하여 더미 GoogleCalendarDto 리턴
+        GoogleCalendarDto googleCalendarDto = new GoogleCalendarDto("primary", "title", "test", "Asia/Seoul");
+
+        doReturn(googleCalendarDto).when(googleCalendarService).getPrimaryCalendar(user);
+
+        // 캘린더 생성시 stub 처리
+        Calendar calendar = new Calendar();
+        given(calendarService.createCalendar(googleCalendarDto, user)).willReturn(calendar);
+
+        // 내부 메서드 getCalendarEvents()도 stub 처리
+        List<GoogleEvent> events = new ArrayList<>();
+        // (필요하다면 더미 이벤트를 추가)
+        doReturn(events).when(googleCalendarService).getCalendarEvents(googleCalendarDto.id(), user);
+        doNothing().when(googleCalendarService).subscribeToCalendar(calendar, user);
+        // When
+        googleCalendarService.upsertGoogleCalendar(user);
+
+        // Then
+        then(calendarService).should().isExistingCalendar(user.getId());
+        then(googleCalendarService).should().getPrimaryCalendar(user);
+        then(calendarService).should().createCalendar(googleCalendarDto, user);
+        then(googleCalendarService).should().getCalendarEvents(googleCalendarDto.id(), user);
+        then(personalEventService).should().syncWithGoogleEvents(events, user);
+    }
+
+    @Test
+    @DisplayName("사용자에게 캘린더가 이미 존재하고 구독 채널이 만료되었을 경우")
+    void upsertGoogleCalendar_existingCalendar_expired() {
+        // Given
+        User user = Mockito.mock(User.class);
+        given(user.getId()).willReturn(1L);
+        given(calendarService.isExistingCalendar(user.getId())).willReturn(true);
+        Calendar calendar = Mockito.mock(Calendar.class);
+        given(calendar.getChannelExpiration()).willReturn(LocalDateTime.now().plusDays(1));
+        given(calendarService.getCalendarByUserId(user.getId())).willReturn(calendar);
+
+        doNothing().when(googleCalendarService).subscribeToCalendar(calendar, user);
+        // When
+        googleCalendarService.upsertGoogleCalendar(user);
+
+        // Then
+        then(calendarService).should().isExistingCalendar(user.getId());
+        then(calendarService).should().getCalendarByUserId(user.getId());
+        // 만료된 캘린더의 경우, 아무런 추가 작업도 하지 않아야 합니다.
+        then(calendarService).should(never()).createCalendar(any(), eq(user));
+        then(personalEventService).should(never()).syncWithGoogleEvents(any(), eq(user));
+    }
 }

--- a/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
@@ -1,7 +1,7 @@
 package endolphin.backend.global.google;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -71,7 +71,7 @@ class GoogleCalendarServiceTest {
         // 신규 캘린더 생성, 이벤트 동기화, 캘린더 채널 구독은 발생하지 않아야 합니다.
         then(googleCalendarService).should(never()).subscribeToCalendar(any(), any());
         then(calendarService).should(never()).createCalendar(any(), eq(user));
-        then(personalEventService).should(never()).syncWithGoogleEvents(any(), eq(user));
+        then(personalEventService).should(never()).syncWithGoogleEvents(any(), eq(user), anyString());
     }
 
     @Test
@@ -90,7 +90,8 @@ class GoogleCalendarServiceTest {
         doReturn(googleCalendarDto).when(googleCalendarService).getPrimaryCalendar(user);
 
         // 캘린더 생성시 stub 처리
-        Calendar calendar = new Calendar();
+        Calendar calendar = Mockito.mock(Calendar.class);
+        given(calendar.getCalendarId()).willReturn("primary");
         given(calendarService.createCalendar(googleCalendarDto, user)).willReturn(calendar);
 
         // 내부 메서드 getCalendarEvents()도 stub 처리
@@ -106,7 +107,7 @@ class GoogleCalendarServiceTest {
         then(googleCalendarService).should().getPrimaryCalendar(user);
         then(calendarService).should().createCalendar(googleCalendarDto, user);
         then(googleCalendarService).should().getCalendarEvents(googleCalendarDto.id(), user);
-        then(personalEventService).should().syncWithGoogleEvents(events, user);
+        then(personalEventService).should().syncWithGoogleEvents(events, user, googleCalendarDto.id());
     }
 
     @Test
@@ -129,6 +130,6 @@ class GoogleCalendarServiceTest {
         then(calendarService).should().getCalendarByUserId(user.getId());
         // 만료된 캘린더의 경우, 아무런 추가 작업도 하지 않아야 합니다.
         then(calendarService).should(never()).createCalendar(any(), eq(user));
-        then(personalEventService).should(never()).syncWithGoogleEvents(any(), eq(user));
+        then(personalEventService).should(never()).syncWithGoogleEvents(any(), eq(user), anyString());
     }
 }

--- a/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
@@ -1,0 +1,11 @@
+package endolphin.backend.global.google;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleCalendarServiceTest {
+
+}


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #137 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 구글 access token 만료 시 재발급하는 기능 구현
- 구글 캘린더 일정을 서비스에  반영하는 기능 구현
  - 캘린더 비트맵에 반영
  - 개인 일정에 반영
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
PersonalEventService를 중점으로 봐주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced calendar integration now provides seamless event synchronization and personalized calendar management.
  - Users can retrieve their calendar and related discussion details more efficiently.
  - Added support for processing individual event updates.
  - New methods for checking calendar existence and retrieving discussions by user ID.
  - Introduced new error codes for improved error handling related to personal events.

- **Refactor & Improvements**
  - Streamlined authentication and calendar subscription flows for improved performance.
  - Upgraded error handling delivers clearer, more informative messages.
  - Improved handling of personal events in relation to Google events, including synchronization and user validation.

- **Tests**
  - Expanded test coverage to ensure robust synchronization and calendar functionality.
  - Added unit tests for the Google Calendar service to validate new functionalities.
  - Enhanced tests for personal event synchronization with discussions and Google events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->