### PR TITLE
[BE-Fix] 구글 로그인 시 프론트 엔드로 리다이렉션 하도록 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/auth/AuthController.java
+++ b/backend/src/main/java/endolphin/backend/domain/auth/AuthController.java
@@ -3,8 +3,10 @@ package endolphin.backend.domain.auth;
 import endolphin.backend.domain.auth.dto.OAuthResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,8 +20,16 @@ public class AuthController {
 
     @Operation(summary = "구글 로그인 콜백", description = "사용자가 Google 계정으로 로그인하여 JWT 토큰을 발급받습니다.")
     @GetMapping("/oauth2/callback")
-    public ResponseEntity<OAuthResponse> oauthCallback(@RequestParam("code") String code) {
-        OAuthResponse response = authService.oauth2Callback(code);
-        return ResponseEntity.ok(response);
+    public void oauthCallback(@RequestParam("code") String code,
+        HttpServletResponse response) throws IOException {
+        OAuthResponse oAuthResponse = authService.oauth2Callback(code);
+
+        Cookie cookie = new Cookie("accessToken", oAuthResponse.accessToken());
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(60 * 60);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        response.sendRedirect("http://localhost:5173");
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/auth/AuthController.java
+++ b/backend/src/main/java/endolphin/backend/domain/auth/AuthController.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +19,15 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Value("${app.frontend.url}")
+    private String frontendUrl;
+
+    @Value("${app.frontend.callback}")
+    private String frontendCallback;
+
+    @Value("${app.server.domain}")
+    private String domain;
+
     @Operation(summary = "구글 로그인 콜백", description = "사용자가 Google 계정으로 로그인하여 JWT 토큰을 발급받습니다.")
     @GetMapping("/oauth2/callback")
     public void oauthCallback(@RequestParam("code") String code,
@@ -28,8 +38,10 @@ public class AuthController {
         cookie.setHttpOnly(true);
         cookie.setMaxAge(60 * 60);
         cookie.setPath("/");
+        cookie.setDomain(domain);
+        
         response.addCookie(cookie);
 
-        response.sendRedirect("http://localhost:5173");
+        response.sendRedirect(String.format("%s%s", frontendUrl, frontendCallback));
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/auth/AuthController.java
+++ b/backend/src/main/java/endolphin/backend/domain/auth/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Tag(name = "Auth", description = "인증 관리 API")
 @RestController
@@ -39,9 +40,13 @@ public class AuthController {
         cookie.setMaxAge(60 * 60);
         cookie.setPath("/");
         cookie.setDomain(domain);
-        
+
         response.addCookie(cookie);
 
-        response.sendRedirect(String.format("%s%s", frontendUrl, frontendCallback));
+        String redirectUrl = UriComponentsBuilder.fromUriString(frontendUrl)
+            .path(frontendCallback)
+            .build().toUriString();
+
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -58,3 +58,11 @@ springdoc:
     path: /swagger-ui           # Swagger UI 경로
     tags-sorter: alpha          # alpha: 알파벳 순 태그 정렬, method: HTTP Method 순 정렬
     operations-sorter: alpha    # alpha: 알파벳 순 태그 정렬, method: HTTP Method 순 정렬
+
+app:
+  frontend:
+    url: "test"
+    callback: "test"
+
+  server:
+    domain: "test"


### PR DESCRIPTION
토큰을 쿠키에 저장

<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
로그인 성공 후 프론트엔드로 리다이렉션하도록 수정하였습니다.
리다이렉션 후에도 토큰을 가져가지 위해 쿠키에 토큰을 저장했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the OAuth authentication flow: After sign-in, your access token is now stored securely in a temporary, HTTP-only cookie. You are automatically redirected to the main application page for a smoother login experience. Overall, these significant updates enhance security and contribute to a more efficient, user-friendly authentication process, ensuring a reliable sign-in experience for all users.
  - New configuration options for the frontend and server settings have been added, allowing for easier management of application URLs and domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->