### PR TITLE
[BE-Feat] 개인 일정 전처리 과정의 테스트 케이스 추가

### DIFF
--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
@@ -160,6 +160,60 @@ class PersonalEventPreprocessorTest {
         then(discussionBitmapService).should(times(33)).setBitValue(anyLong(), any(LocalDateTime.class), anyLong(), anyBoolean());
     }
 
+    @Test
+    @DisplayName("논의 시간이 23:30 까지 일 경우")
+    public void test6() {
+        // given
+        Long userId = 200L;
+        Long participantIndex = 2L;
+        // Discussion, User, PersonalEvent 모킹
+        // 20:30 ~ 23:30
+        Discussion discussion = getAnotherDiscussion();
+        User user = getUser();
+
+        given(discussionParticipantService.getDiscussionParticipantOffset(anyLong(), anyLong()))
+            .willReturn(participantIndex);
+
+        // count : 1 + 6
+        PersonalEvent personalEvent = mock(PersonalEvent.class);
+        given(personalEvent.getStartTime()).willReturn(LocalDateTime.of(2024, 3, 15, 23, 0, 0));
+        given(personalEvent.getEndTime()).willReturn(LocalDateTime.of(2024, 3, 16, 23, 40, 0));
+        given(personalEvent.getId()).willReturn(5L);
+
+        // when
+        preprocessor.preprocess(List.of(personalEvent), discussion, user);
+
+        // then
+        then(discussionBitmapService).should(times(1 + 6)).setBitValue(anyLong(), any(LocalDateTime.class), anyLong(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("논의 시간이 23:30까지 일 때 테스트")
+    public void test7() {
+        // given
+        Long userId = 200L;
+        Long participantIndex = 2L;
+        // Discussion, User, PersonalEvent 모킹
+        // 20:30 ~ 23:30
+        Discussion discussion = getAnotherDiscussion();
+        User user = getUser();
+
+        given(discussionParticipantService.getDiscussionParticipantOffset(anyLong(), anyLong()))
+            .willReturn(participantIndex);
+
+        // count : 5
+        PersonalEvent personalEvent = mock(PersonalEvent.class);
+        given(personalEvent.getStartTime()).willReturn(LocalDateTime.of(2024, 3, 15, 20, 0, 0));
+        given(personalEvent.getEndTime()).willReturn(LocalDateTime.of(2024, 3, 16, 1, 0, 0));
+        given(personalEvent.getId()).willReturn(5L);
+
+        // when
+        preprocessor.preprocess(List.of(personalEvent), discussion, user);
+
+        // then
+        then(discussionBitmapService).should(times(6)).setBitValue(anyLong(), any(LocalDateTime.class), anyLong(), anyBoolean());
+    }
+
     private Discussion getDiscussion() {
         Discussion discussion = Mockito.mock(Discussion.class);
         given(discussion.getId()).willReturn(1L);
@@ -174,9 +228,10 @@ class PersonalEventPreprocessorTest {
     private Discussion getAnotherDiscussion() {
         Discussion discussion = Mockito.mock(Discussion.class);
         given(discussion.getId()).willReturn(1L);
-        given(discussion.getDiscussionStatus()).willReturn(DiscussionStatus.ONGOING);
         given(discussion.getDateRangeStart()).willReturn(LocalDate.of(2024, 3, 10));
         given(discussion.getDateRangeEnd()).willReturn(LocalDate.of(2024, 3, 20));
+        given(discussion.getTimeRangeStart()).willReturn(LocalTime.of(20, 30));
+        given(discussion.getTimeRangeEnd()).willReturn(LocalTime.of(23, 30));
         return discussion;
     }
 

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
@@ -64,7 +64,11 @@ class PersonalEventPreprocessorTest {
         Long userId = 200L;
         Long participantIndex = 2L;
         // Discussion, User, PersonalEvent 모킹
-        Discussion discussion = getAnotherDiscussion();
+        Discussion discussion = Mockito.mock(Discussion.class);
+        given(discussion.getId()).willReturn(1L);
+        given(discussion.getDiscussionStatus()).willReturn(DiscussionStatus.ONGOING);
+        given(discussion.getDateRangeStart()).willReturn(LocalDate.of(2024, 3, 10));
+        given(discussion.getDateRangeEnd()).willReturn(LocalDate.of(2024, 3, 20));
         User user = getUser();
 
         given(discussionParticipantService.getDiscussionParticipantOffset(anyLong(), anyLong()))
@@ -228,6 +232,7 @@ class PersonalEventPreprocessorTest {
     private Discussion getAnotherDiscussion() {
         Discussion discussion = Mockito.mock(Discussion.class);
         given(discussion.getId()).willReturn(1L);
+        given(discussion.getDiscussionStatus()).willReturn(DiscussionStatus.ONGOING);
         given(discussion.getDateRangeStart()).willReturn(LocalDate.of(2024, 3, 10));
         given(discussion.getDateRangeEnd()).willReturn(LocalDate.of(2024, 3, 20));
         given(discussion.getTimeRangeStart()).willReturn(LocalTime.of(20, 30));


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #105
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
전처리 과정의 테스트 케이스를 추가하였습니다.
<img width="1167" alt="Image" src="https://github.com/user-attachments/assets/4d1390a6-bd45-4afd-846b-0ad5db62b432" />

<img width="1167" alt="Image" src="https://github.com/user-attachments/assets/5f42b443-e866-4317-9bbe-ce3f9ef7b26f" />

<img width="443" alt="Image" src="https://github.com/user-attachments/assets/ab85dc7c-2423-4de0-ba58-89253124046d" />


## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced new test scenarios to validate that event scheduling correctly handles overlaps with predefined discussion periods.
  - Included cases covering events that extend past midnight to ensure robust performance across multi-day situations.
  - Enhanced test coverage with two additional tests focusing on specific time constraints related to discussions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->