### PR TITLE
[BE-Feat] 후보 일정 검색 api 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/CandidateEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/CandidateEventService.java
@@ -39,6 +39,10 @@ public class CandidateEventService {
         int filter = discussionParticipantService.getFilter(discussionId,
             request.selectedUserIdList());
 
+        if(filter == 0) {
+            return new CalendarViewResponse(Collections.emptyList());
+        }
+
         List<CandidateEvent> events = searchCandidateEvents(discussion, filter);
 
         int returnSize = (request.size() != null) ? request.size() : getReturnSize(discussion);
@@ -62,6 +66,10 @@ public class CandidateEventService {
 
         int filter = discussionParticipantService.getFilter(discussionId,
             request.selectedUserIdList());
+
+        if(filter == 0) {
+            return new RankViewResponse(Collections.emptyList(), Collections.emptyList());
+        }
 
         List<CandidateEvent> events = searchCandidateEvents(discussion, filter);
 

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/CandidateEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/CandidateEventService.java
@@ -1,0 +1,134 @@
+package endolphin.backend.domain.candidate_event;
+
+import endolphin.backend.domain.candidate_event.dto.CandidateEvent;
+import endolphin.backend.domain.candidate_event.dto.GetCandidateEventsRequest;
+import endolphin.backend.domain.discussion.DiscussionService;
+import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.global.redis.DiscussionBitmapService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CandidateEventService {
+
+    private final DiscussionBitmapService discussionBitmapService;
+    private final DiscussionService discussionService;
+
+    public List<CandidateEvent> getCandidateEvents(Long discussionId,
+        GetCandidateEventsRequest request, boolean forCalendarView) {
+
+        Discussion discussion = discussionService.getDiscussionById(discussionId);
+
+        List<CandidateEvent> events = searchCandidateEvents(discussion, 0);
+
+        int size = getReturnSize(discussion);
+
+        return sortCandidateEvents(events, size);
+    }
+
+    public List<CandidateEvent> searchCandidateEvents(Discussion discussion, int filter) {
+        long startDateTime = convertToMinute(discussion.getDateRangeStart()
+            .atTime(discussion.getTimeRangeStart()));
+
+        long endDateTime = convertToMinute(discussion.getDateRangeEnd()
+            .atTime(discussion.getTimeRangeEnd()));
+
+        long now = convertToMinute(LocalDateTime.now());
+
+        long minuteKey = startDateTime;
+
+        int duration = discussion.getDuration();
+
+        if (now > endDateTime) {
+            return null;
+        }
+
+        if (now < startDateTime) {
+            minuteKey = now;
+        }
+
+        long maxTime = endDateTime % 1440 - duration;
+
+        Map<Long, byte[]> dataBlocks = discussionBitmapService.getDataOfDiscussionId(
+            discussion.getId(), startDateTime, endDateTime);
+        long day = 0;
+
+        List<CandidateEvent> events = new ArrayList<>();
+
+        while (minuteKey < endDateTime) {
+
+            if (minuteKey % 1440 >= maxTime) {
+                minuteKey = ++day * 1440 + startDateTime;
+                continue;
+            }
+
+            if (!dataBlocks.containsKey(minuteKey)) {
+                minuteKey += 30;
+                continue;
+            }
+
+            int data = toInt(dataBlocks.get(minuteKey)) & filter;
+            int totalTime = Integer.bitCount(data);
+            long nextMinuteKey = minuteKey + 30;
+            long endKey = minuteKey + duration;
+
+            for (long i = nextMinuteKey; i < endKey + duration; i += 30) {
+                if (dataBlocks.containsKey(i)) {
+                    int nextData = toInt(dataBlocks.get(i)) & filter;
+                    data &= nextData;
+                    totalTime += Integer.bitCount(nextData);
+                } else {
+                    nextMinuteKey += 30;
+                }
+            }
+
+            events.add(
+                new CandidateEvent(minuteKey, endKey, Integer.bitCount(data), totalTime, data));
+            minuteKey = nextMinuteKey;
+        }
+
+        return events.isEmpty() ? null : events;
+    }
+
+    public List<CandidateEvent> sortCandidateEvents(List<CandidateEvent> candidateEvents,
+        int size) {
+        return null;
+    }
+
+    private int getReturnSize(Discussion discussion) {
+        LocalDate startDate = discussion.getDateRangeStart();
+        if(LocalDate.now().isAfter(startDate)) {
+            startDate = LocalDate.now();
+        }
+
+        long between = ChronoUnit.DAYS.between(startDate, discussion.getDateRangeEnd()) + 1;
+
+        if(between < 1) {
+            return 0;
+        }
+        else if(between < 3) {
+            return 6;
+        }
+        else if(between < 15){
+            return 2 * (int) between;
+        }
+
+        return 30;
+    }
+
+    private int toInt(byte[] data) {
+        return ((data[0] & 0xFF) << 8) | (data[1] & 0xFF);
+    }
+
+    private Long convertToMinute(LocalDateTime dateTime) {
+        return dateTime.toEpochSecond(ZoneOffset.ofHours(9)) / 60;
+    }
+}

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/CandidateEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/CandidateEventService.java
@@ -2,8 +2,10 @@ package endolphin.backend.domain.candidate_event;
 
 import endolphin.backend.domain.candidate_event.dto.CandidateEvent;
 import endolphin.backend.domain.candidate_event.dto.CalendarViewRequest;
+import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.DiscussionService;
 import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.user.UserService;
 import endolphin.backend.global.redis.DiscussionBitmapService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -23,13 +25,16 @@ public class CandidateEventService {
 
     private final DiscussionBitmapService discussionBitmapService;
     private final DiscussionService discussionService;
+    private final DiscussionParticipantService discussionParticipantService;
 
     public List<CandidateEvent> getEventsOnCalendarView(Long discussionId,
         CalendarViewRequest request) {
 
         Discussion discussion = discussionService.getDiscussionById(discussionId);
 
-        List<CandidateEvent> events = searchCandidateEvents(discussion, 0);
+        int filter = discussionParticipantService.getFilter(discussionId, request.selectedUserIdList());
+
+        List<CandidateEvent> events = searchCandidateEvents(discussion, filter);
 
         int returnSize = (request.size() != null) ? request.size() : getReturnSize(discussion);
 

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CalendarViewRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CalendarViewRequest.java
@@ -1,13 +1,15 @@
 package endolphin.backend.domain.candidate_event.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
 import java.util.List;
 
 public record CalendarViewRequest(
     LocalDate startDate,
     LocalDate endDate,
-    List<Long> selectedUserIdList,
+    @Valid List<@Min(0) @Max(14) Long> selectedUserIdList,
     @Max(30) Integer size
 ) {
 

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CalendarViewRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CalendarViewRequest.java
@@ -1,13 +1,14 @@
 package endolphin.backend.domain.candidate_event.dto;
 
+import jakarta.validation.constraints.Max;
 import java.time.LocalDate;
 import java.util.List;
 
-public record GetCandidateEventsRequest(
+public record CalendarViewRequest(
     LocalDate startDate,
     LocalDate endDate,
     List<Long> selectedUserIdList,
-    Integer size
+    @Max(30) Integer size
 ) {
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CalendarViewResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CalendarViewResponse.java
@@ -1,0 +1,9 @@
+package endolphin.backend.domain.candidate_event.dto;
+
+import java.util.List;
+
+public record CalendarViewResponse(
+    List<CandidateEventResponse> events
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CandidateEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CandidateEvent.java
@@ -1,0 +1,14 @@
+package endolphin.backend.domain.candidate_event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CandidateEvent(
+    LocalDateTime startDateTime,
+    LocalDateTime endDateTime,
+    int userCount,
+    int totalTimeToAdjust,
+    List<Long> userOffsetList
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CandidateEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CandidateEvent.java
@@ -4,11 +4,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record CandidateEvent(
-    LocalDateTime startDateTime,
-    LocalDateTime endDateTime,
+    long startDateTime,
+    long endDateTime,
     int userCount,
     int totalTimeToAdjust,
-    List<Long> userOffsetList
+    int usersData
 ) {
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CandidateEventResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/CandidateEventResponse.java
@@ -1,0 +1,13 @@
+package endolphin.backend.domain.candidate_event.dto;
+
+import endolphin.backend.domain.user.dto.UserIdNameDto;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CandidateEventResponse(
+    LocalDateTime startDateTime,
+    LocalDateTime endDateTime,
+    List<UserIdNameDto> usersForAdjust
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/GetCandidateEventsRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/GetCandidateEventsRequest.java
@@ -1,0 +1,13 @@
+package endolphin.backend.domain.candidate_event.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GetCandidateEventsRequest(
+    LocalDate startDate,
+    LocalDate endDate,
+    List<Long> selectedUserIdList,
+    Integer size
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/RankViewRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/RankViewRequest.java
@@ -1,0 +1,9 @@
+package endolphin.backend.domain.candidate_event.dto;
+
+import java.util.List;
+
+public record RankViewRequest(
+    List<Long> selectedUserIdList
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/RankViewRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/RankViewRequest.java
@@ -1,9 +1,12 @@
 package endolphin.backend.domain.candidate_event.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.List;
 
 public record RankViewRequest(
-    List<Long> selectedUserIdList
+    @Valid List<@Min(0) @Max(14) Long> selectedUserIdList
 ) {
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/RankViewResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/dto/RankViewResponse.java
@@ -1,0 +1,10 @@
+package endolphin.backend.domain.candidate_event.dto;
+
+import java.util.List;
+
+public record RankViewResponse(
+    List<CandidateEventResponse> eventsRankedDefault,
+    List<CandidateEventResponse> eventsRankedOfTime
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -3,6 +3,8 @@ package endolphin.backend.domain.discussion;
 import endolphin.backend.domain.candidate_event.CandidateEventService;
 import endolphin.backend.domain.candidate_event.dto.CalendarViewRequest;
 import endolphin.backend.domain.candidate_event.dto.CalendarViewResponse;
+import endolphin.backend.domain.candidate_event.dto.RankViewRequest;
+import endolphin.backend.domain.candidate_event.dto.RankViewResponse;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
@@ -88,6 +90,27 @@ public class DiscussionController {
         @Valid @RequestBody CalendarViewRequest request) {
 
         CalendarViewResponse response = candidateEventService.getEventsOnCalendarView(discussionId,
+            request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "후보 일정 랭크 뷰", description = "후보 일정을 랭크 뷰로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "후보 일정 조회 성공",
+            content = @Content(schema = @Schema(implementation = RankViewResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/{discussionId}/candidate-event/rank")
+    public ResponseEntity<RankViewResponse> getCandidateEventsForRankView(
+        @PathVariable @Min(1) Long discussionId,
+        @Valid @RequestBody RankViewRequest request) {
+
+        RankViewResponse response = candidateEventService.getEventsOnRankView(discussionId,
             request);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -1,5 +1,8 @@
 package endolphin.backend.domain.discussion;
 
+import endolphin.backend.domain.candidate_event.CandidateEventService;
+import endolphin.backend.domain.candidate_event.dto.CalendarViewRequest;
+import endolphin.backend.domain.candidate_event.dto.CalendarViewResponse;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
@@ -26,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class DiscussionController {
 
     private final DiscussionService discussionService;
+    private final CandidateEventService candidateEventService;
 
     @Operation(summary = "논의 생성", description = "새 논의를 생성합니다.")
     @ApiResponses(value = {
@@ -64,6 +68,27 @@ public class DiscussionController {
 
         SharedEventWithDiscussionInfoResponse response = discussionService.confirmSchedule(
             discussionId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "후보 일정 캘린더 뷰", description = "후보 일정을 캘린더 뷰로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "후보 일정 조회 성공",
+            content = @Content(schema = @Schema(implementation = CalendarViewResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/{discussionId}/candidate-event/calendar")
+    public ResponseEntity<CalendarViewResponse> getCandidateEventsForCalendarView(
+        @PathVariable @Min(1) Long discussionId,
+        @Valid @RequestBody CalendarViewRequest request) {
+
+        CalendarViewResponse response = candidateEventService.getEventsOnCalendarView(discussionId,
+            request);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -48,7 +48,7 @@ public interface DiscussionParticipantRepository extends
     @Query("SELECT dp.user.id " +
         "FROM DiscussionParticipant dp " +
         "WHERE dp.discussion.id = :discussionId " +
-        "AND dp.userOffset = :offset")
+        "AND dp.userOffset IN :offset")
     List<Long> findUserIdsByDiscussionIdAndOffset(
         @Param("discussionId") Long discussionId,
         @Param("offset") List<Long> offsets

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -25,14 +25,14 @@ public interface DiscussionParticipantRepository extends
         "where dp.discussion.id = :discussionId")
     List<User> findUsersByDiscussionId(@Param("discussionId") Long discussionId);
 
-    @Query("SELECT dp.index " +
+    @Query("SELECT dp.userOffset " +
         "FROM DiscussionParticipant dp " +
         "WHERE dp.discussion.id = :discussionId AND dp.user.id = :userId")
-    Optional<Long> findIndexByDiscussionIdAndUserId(@Param("discussionId") Long discussionId,
+    Optional<Long> findOffsetByDiscussionIdAndUserId(@Param("discussionId") Long discussionId,
         @Param("userId") Long userId);
 
-    @Query("SELECT COALESCE(MAX(dp.index), -1) " +
+    @Query("SELECT COALESCE(MAX(dp.userOffset), -1) " +
         "FROM DiscussionParticipant dp " +
         "WHERE dp.discussion.id = :discussionId")
-    Optional<Long> findMaxIndexByDiscussionId(@Param("discussionId") Long discussionId);
+    Long findMaxOffsetByDiscussionId(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -44,4 +44,14 @@ public interface DiscussionParticipantRepository extends
         @Param("discussionId") Long discussionId,
         @Param("userIds") List<Long> userIds
     );
+
+    @Query("SELECT dp.user.id " +
+        "FROM DiscussionParticipant dp " +
+        "WHERE dp.discussion.id = :discussionId " +
+        "AND dp.userOffset = :offset")
+    List<Long> findUserIdsByDiscussionIdAndOffset(
+        @Param("discussionId") Long discussionId,
+        @Param("offset") List<Long> offsets
+    );
+
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -35,4 +35,13 @@ public interface DiscussionParticipantRepository extends
         "FROM DiscussionParticipant dp " +
         "WHERE dp.discussion.id = :discussionId")
     Long findMaxOffsetByDiscussionId(@Param("discussionId") Long discussionId);
+
+    @Query("SELECT dp.userOffset " +
+        "FROM DiscussionParticipant dp " +
+        "WHERE dp.discussion.id = :discussionId " +
+        "AND dp.user.id IN :userIds")
+    List<Long> findOffsetsByDiscussionIdAndUserIds(
+        @Param("discussionId") Long discussionId,
+        @Param("userIds") List<Long> userIds
+    );
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -66,7 +66,7 @@ public class DiscussionParticipantService {
     public int getFilter(Long discussionId, List<Long> userIds) {
 
         if(userIds == null || userIds.isEmpty()) {
-            return 0XFFFF;
+            return 0;
         }
 
         List<Long> userOffsets = discussionParticipantRepository.findOffsetsByDiscussionIdAndUserIds(

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -64,6 +64,11 @@ public class DiscussionParticipantService {
 
     @Transactional(readOnly = true)
     public int getFilter(Long discussionId, List<Long> userIds) {
+
+        if(userIds == null || userIds.isEmpty()) {
+            return 0XFFFF;
+        }
+
         List<Long> userOffsets = discussionParticipantRepository.findOffsetsByDiscussionIdAndUserIds(
             discussionId, userIds);
 
@@ -78,6 +83,10 @@ public class DiscussionParticipantService {
 
     @Transactional(readOnly = true)
     public List<UserIdNameDto> getUsersFromData(Long discussionId, int data) {
+        if(data == 0) {
+            return new ArrayList<>();
+        }
+
         List<Long> userOffsets = new ArrayList<>();
 
         for (int i = 0; i < 16; i++) {

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -18,11 +18,12 @@ public class DiscussionParticipantService {
     private final DiscussionParticipantRepository discussionParticipantRepository;
 
     public void addDiscussionParticipant(Discussion discussion, User user) {
-        Long offset = discussionParticipantRepository.findMaxOffsetByDiscussionId(discussion.getId());
+        Long offset = discussionParticipantRepository.findMaxOffsetByDiscussionId(
+            discussion.getId());
 
         offset += 1;
 
-        if(offset >= 15) {
+        if (offset >= 15) {
             throw new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_EXCEED_LIMIT);
         }
 
@@ -46,13 +47,28 @@ public class DiscussionParticipantService {
     }
 
     @Transactional(readOnly = true)
-    public List<User> getUsersByDiscussionId(Long discussionId){
+    public List<User> getUsersByDiscussionId(Long discussionId) {
         return discussionParticipantRepository.findUsersByDiscussionId(discussionId);
     }
 
     @Transactional(readOnly = true)
     public Long getDiscussionParticipantOffset(Long discussionId, Long userId) {
-        return discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userId)
+        return discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId,
+                userId)
             .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public int getFilter(Long discussionId, List<Long> userIds) {
+        List<Long> userOffsets = discussionParticipantRepository.findOffsetsByDiscussionIdAndUserIds(
+            discussionId, userIds);
+
+        int filter = 0;
+
+        for (Long offset : userOffsets) {
+            filter |= (1 << 15 - offset);
+        }
+
+        return filter;
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -19,7 +19,13 @@ public class DiscussionParticipantService {
 
     public void addDiscussionParticipant(Discussion discussion, User user) {
         Long offset = discussionParticipantRepository.findMaxOffsetByDiscussionId(discussion.getId());
+
         offset += 1;
+
+        if(offset >= 15) {
+            throw new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_EXCEED_LIMIT);
+        }
+
         DiscussionParticipant participant;
         if (offset == 0) {
             participant = DiscussionParticipant.builder()

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -2,9 +2,12 @@ package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
+import endolphin.backend.domain.user.UserService;
+import endolphin.backend.domain.user.dto.UserIdNameDto;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DiscussionParticipantService {
 
     private final DiscussionParticipantRepository discussionParticipantRepository;
+    private final UserService userService;
 
     public void addDiscussionParticipant(Discussion discussion, User user) {
         Long offset = discussionParticipantRepository.findMaxOffsetByDiscussionId(
@@ -70,5 +74,21 @@ public class DiscussionParticipantService {
         }
 
         return filter;
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserIdNameDto> getUsersFromData(Long discussionId, int data) {
+        List<Long> userOffsets = new ArrayList<>();
+
+        for (int i = 0; i < 16; i++) {
+            if ((data & (1 << (15 - i))) != 0) {
+                userOffsets.add((long) i);
+            }
+        }
+
+        List<Long> userIds = discussionParticipantRepository.findUserIdsByDiscussionIdAndOffset(
+            discussionId, userOffsets);
+
+        return userService.getUserIdNameInIds(userIds);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -18,23 +18,22 @@ public class DiscussionParticipantService {
     private final DiscussionParticipantRepository discussionParticipantRepository;
 
     public void addDiscussionParticipant(Discussion discussion, User user) {
-        Long index = discussionParticipantRepository.findMaxIndexByDiscussionId(discussion.getId())
-            .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_NOT_FOUND));
-        index += 1;
+        Long offset = discussionParticipantRepository.findMaxOffsetByDiscussionId(discussion.getId());
+        offset += 1;
         DiscussionParticipant participant;
-        if (index == 0) {
+        if (offset == 0) {
             participant = DiscussionParticipant.builder()
                 .discussion(discussion)
                 .user(user)
                 .isHost(true)
-                .index(index)
+                .userOffset(offset)
                 .build();
         } else {
             participant = DiscussionParticipant.builder()
                 .discussion(discussion)
                 .user(user)
                 .isHost(false)
-                .index(index)
+                .userOffset(offset)
                 .build();
         }
         discussionParticipantRepository.save(participant);
@@ -46,8 +45,8 @@ public class DiscussionParticipantService {
     }
 
     @Transactional(readOnly = true)
-    public Long getDiscussionParticipantIndex(Long discussionId, Long userId) {
-        return discussionParticipantRepository.findIndexByDiscussionIdAndUserId(discussionId, userId)
+    public Long getDiscussionParticipantOffset(Long discussionId, Long userId) {
+        return discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userId)
             .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -107,4 +107,10 @@ public class DiscussionService {
 
         return duration.toMillis();
     }
+
+    @Transactional(readOnly = true)
+    public Discussion getDiscussionById(Long discussionId) {
+        return discussionRepository.findById(discussionId)
+            .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_NOT_FOUND));
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/entity/DiscussionParticipant.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/entity/DiscussionParticipant.java
@@ -29,7 +29,7 @@ public class DiscussionParticipant {
     @Column(name = "is_host", nullable = false)
     private boolean isHost;
 
-    @Column(name = "user_offfset", nullable = false)
+    @Column(name = "user_offset", nullable = false)
     private Long userOffset;
 
     @Builder

--- a/backend/src/main/java/endolphin/backend/domain/discussion/entity/DiscussionParticipant.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/entity/DiscussionParticipant.java
@@ -29,15 +29,15 @@ public class DiscussionParticipant {
     @Column(name = "is_host", nullable = false)
     private boolean isHost;
 
-    @Column(name = "index", nullable = false)
-    private Long index;
+    @Column(name = "user_offfset", nullable = false)
+    private Long userOffset;
 
     @Builder
-    public DiscussionParticipant(Discussion discussion, User user, boolean isHost, Long index) {
+    public DiscussionParticipant(Discussion discussion, User user, boolean isHost, Long userOffset) {
         this.discussion = discussion;
         this.user = user;
         this.isHost = isHost;
-        this.index = index;
+        this.userOffset = userOffset;
     }
 }
 

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessor.java
@@ -24,10 +24,10 @@ public class PersonalEventPreprocessor {
     private final DiscussionParticipantService discussionParticipantService;
 
     public void preprocess(List<PersonalEvent> personalEvents, Discussion discussion, User user) {
-        Long index = discussionParticipantService.getDiscussionParticipantIndex(discussion.getId(),
+        Long offset = discussionParticipantService.getDiscussionParticipantOffset(discussion.getId(),
             user.getId());
         for (PersonalEvent personalEvent : personalEvents) {
-            convert(personalEvent, discussion, index, true);
+            convert(personalEvent, discussion, offset, true);
         }
     }
 

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
@@ -14,14 +14,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PersonalEventRepository extends JpaRepository<PersonalEvent, Long> {
 
-    List<PersonalEvent> findByUserAndStartTimeBetween(User user, LocalDateTime start, LocalDateTime end);
+    List<PersonalEvent> findByUserAndStartTimeBetween(User user, LocalDateTime start,
+        LocalDateTime end);
 
     @Query("SELECT p FROM PersonalEvent p " +
         "WHERE p.user = :user " +
-        "   AND ((CAST(p.startTime AS localdate) BETWEEN :startDate AND :endDate " +
-        "   OR CAST(p.endTime AS localdate) BETWEEN :startDate AND :endDate) " +
-        "   OR ((CAST(p.startTime AS localdate) <= :startDate AND CAST(p.startTime AS localdate) <= :endDate) " +
-        "   AND (CAST(p.endTime AS localdate) >= :startDate AND CAST(p.endTime AS localdate) >= :endDate)))")
+        "AND (" +
+        "   CAST(p.startTime as localdate) <= :endDate " +
+        "   AND CAST(p.endTime as localdate) >= :startDate" +
+        ")")
     List<PersonalEvent> findFilteredPersonalEvents(
         @Param("user") User user,
         @Param("startDate") LocalDate startDate,

--- a/backend/src/main/java/endolphin/backend/domain/user/UserRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/user/UserRepository.java
@@ -1,12 +1,20 @@
 package endolphin.backend.domain.user;
 
+import endolphin.backend.domain.user.dto.UserIdNameDto;
 import endolphin.backend.domain.user.entity.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    @Query("SELECT new endolphin.backend.domain.user.dto.UserIdNameDto(u.id, u.name) " +
+        "FROM User u WHERE u.id IN :userIds")
+    List<UserIdNameDto> findUserIdNameInIds(@Param("userIds") List<Long> userIds);
 }

--- a/backend/src/main/java/endolphin/backend/domain/user/UserService.java
+++ b/backend/src/main/java/endolphin/backend/domain/user/UserService.java
@@ -1,5 +1,6 @@
 package endolphin.backend.domain.user;
 
+import endolphin.backend.domain.user.dto.UserIdNameDto;
 import endolphin.backend.global.google.dto.GoogleUserInfo;
 import endolphin.backend.global.google.dto.GoogleTokens;
 import endolphin.backend.domain.user.entity.User;
@@ -7,6 +8,7 @@ import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
 import endolphin.backend.global.security.UserContext;
 import endolphin.backend.global.security.UserInfo;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,11 @@ public class UserService {
     public User getUser(Long userId) {
         return userRepository.findById(userId)
             .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserIdNameDto> getUserIdNameInIds(List<Long> userIds) {
+        return userRepository.findUserIdNameInIds(userIds);
     }
 
     public void updateAccessToken(User user, String accessToken) {

--- a/backend/src/main/java/endolphin/backend/domain/user/dto/UserIdNameDto.java
+++ b/backend/src/main/java/endolphin/backend/domain/user/dto/UserIdNameDto.java
@@ -1,0 +1,8 @@
+package endolphin.backend.domain.user.dto;
+
+public record UserIdNameDto(
+    Long id,
+    String name
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     SHARED_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "Shared Event not found"),
 
     // DiscussionParticipant
-    DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP001", "Discussion participant not found"),
+    DISCUSSION_PARTICIPANT_EXCEED_LIMIT(HttpStatus.FORBIDDEN, "DP001", "Discussion participant exceed limit"),
+    DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP002", "Discussion participant not found"),
 
     //Calendar
     CALENDAR_UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "CA001", "Unauthorized"),

--- a/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
+++ b/backend/src/main/java/endolphin/backend/global/redis/DiscussionBitmapService.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.connection.RedisCommandsProvider;
 import org.springframework.data.redis.connection.RedisConnection;
@@ -34,7 +35,7 @@ public class DiscussionBitmapService {
      * LocalDateTime을 분 단위의 long 값(에포크 기준 분 값)으로 변환.
      */
     private long convertToMinuteKey(LocalDateTime dateTime) {
-        return dateTime.toEpochSecond(ZoneOffset.ofHours(9)) / 60;
+        return dateTime.toEpochSecond(ZoneOffset.UTC) / 60;
     }
 
     /**
@@ -148,7 +149,8 @@ public class DiscussionBitmapService {
         return CompletableFuture.completedFuture(null);
     }
 
-    public Map<Long, byte[]> getDataOfDiscussionId(Long discussionId, Long startDateTime, Long endDateTime) {
+    public Map<Long, byte[]> getDataOfDiscussionId(Long discussionId, Long startDateTime,
+        Long endDateTime) {
         String pattern = discussionId + ":*";
         ScanOptions scanOptions = ScanOptions.scanOptions().match(pattern).count(1000).build();
 
@@ -165,9 +167,9 @@ public class DiscussionBitmapService {
                     if (colonIndex != -1 && colonIndex < keyStr.length() - 1) {
                         String minuteKeyStr = keyStr.substring(colonIndex + 1);
                         try {
-                            Long minuteKey = Long.parseLong(minuteKeyStr);
+                            long minuteKey = Long.parseLong(minuteKeyStr);
 
-                            if (minuteKey >= startDateTime && minuteKey <= endDateTime) {
+                            if (isBetweenTimeRange(minuteKey, startDateTime, endDateTime)) {
                                 byte[] data = connection.stringCommands().get(rawKey);
                                 map.put(minuteKey, data);
                             }
@@ -179,5 +181,16 @@ public class DiscussionBitmapService {
             }
             return map;
         });
+    }
+
+    private boolean isBetweenTimeRange(long minuteKey, long startDateTime, long endDateTime) {
+        if (minuteKey < startDateTime || minuteKey > endDateTime) {
+            return false;
+        }
+
+        long timeRangeStart = startDateTime % 1440;
+        long timeRangeEnd = endDateTime % 1440;
+
+        return minuteKey % 1440 >= timeRangeStart && minuteKey % 1440 <= timeRangeEnd;
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/candidate_event/CandidateEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/candidate_event/CandidateEventServiceTest.java
@@ -1,0 +1,147 @@
+package endolphin.backend.domain.candidate_event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.when;
+
+import endolphin.backend.domain.candidate_event.dto.CalendarViewRequest;
+import endolphin.backend.domain.candidate_event.dto.CalendarViewResponse;
+import endolphin.backend.domain.candidate_event.dto.CandidateEventResponse;
+import endolphin.backend.domain.discussion.DiscussionParticipantService;
+import endolphin.backend.domain.discussion.DiscussionService;
+import endolphin.backend.domain.discussion.entity.Discussion;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@SpringBootTest
+@Import(CandidateEventServiceTest.TestConfig.class)
+public class CandidateEventServiceTest {
+
+    @Autowired
+    private CandidateEventService candidateEventService;
+
+    @Autowired
+    private RedisTemplate<String, byte[]> redisTemplate;
+
+    @Autowired
+    private DiscussionService discussionService;
+
+    @Autowired
+    private DiscussionParticipantService discussionParticipantService;
+
+    private final Long discussionId = 1L;
+    private final LocalDate testDate = LocalDate.now().plusDays(1);
+    private final LocalTime startTime = LocalTime.of(9, 0);
+    private final LocalTime endTime = LocalTime.of(17, 0);
+    private final int duration = 90;
+
+    @BeforeEach
+    public void setUp() {
+        // Discussion 객체 스텁 설정: 필드명은 service 코드에서 사용하는 getter에 맞춤 (예: getDateRangeStart 등)
+        Discussion discussion = Discussion.builder()
+            .dateStart(testDate)
+            .dateEnd(testDate)
+            .timeStart(startTime)
+            .timeEnd(endTime)
+            .duration(duration)
+            .build();
+        // Discussion의 ID 주입
+        ReflectionTestUtils.setField(discussion, "id", discussionId);
+        when(discussionService.getDiscussionById(discussionId)).thenReturn(discussion);
+
+        // 참가자 관련 스텁: 필터값과 사용자 목록 (여기서는 빈 리스트)
+        when(discussionParticipantService.getFilter(eq(discussionId), anyList()))
+            .thenReturn(0xFFFF);
+        when(discussionParticipantService.getUsersFromData(eq(discussionId), anyInt()))
+            .thenReturn(Collections.emptyList());
+
+        // 테스트 시작 전에 Redis에 이미 등록된 candidate event 관련 키 삭제
+        Set<String> keys = redisTemplate.keys(discussionId + ":*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+
+        LocalDateTime startDateTime = testDate.atTime(startTime);
+        LocalDateTime endDateTime = testDate.atTime(endTime);
+        long startMinute = startDateTime.toEpochSecond(ZoneOffset.UTC) / 60;
+        long endMinute = endDateTime.toEpochSecond(ZoneOffset.UTC) / 60;
+        int cnt = 0;
+        for (long minute = startMinute + 30; minute <= endMinute; minute += 30) {
+            int value = cnt++;
+            byte[] data = new byte[] {
+                (byte) ((value >> 8) & 0xFF),
+                (byte) (value & 0xFF)
+            };
+            redisTemplate.opsForValue().set(discussionId + ":" + minute, data);
+        }
+    }
+
+    @Test
+    @DisplayName("많은 Redis 데이터가 등록된 상황에서 getEventsOnCalendarView 검증")
+    public void testGetEventsOnCalendarView_WithMultipleData() {
+        // CalendarViewRequest: 요청 범위는 testDate 하루 전체, 요청 사이즈 10
+        CalendarViewRequest request = new CalendarViewRequest(
+            testDate, testDate, new ArrayList<>(), 10
+        );
+
+        // when
+        CalendarViewResponse response = candidateEventService.getEventsOnCalendarView(discussionId, request);
+
+        // then
+        assertThat(response).isNotNull();
+        List<CandidateEventResponse> events = response.events();
+        assertThat(events)
+            .as("캘린더 뷰 응답에 하나 이상의 후보 이벤트가 포함되어야 합니다.")
+            .isNotEmpty();
+
+        // 예시로 첫 번째 이벤트의 시작, 종료 시간을 검증
+        CandidateEventResponse firstEvent = events.get(0);
+        long expectedStartMinute = testDate.atTime(startTime).toEpochSecond(ZoneOffset.UTC) / 60;
+        LocalDateTime expectedStart = LocalDateTime.ofEpochSecond(expectedStartMinute * 60, 0, ZoneOffset.UTC);
+        LocalDateTime expectedEnd = LocalDateTime.ofEpochSecond((expectedStartMinute + duration) * 60, 0, ZoneOffset.UTC);
+
+        assertThat(firstEvent.startDateTime())
+            .as("첫 번째 이벤트의 시작 시간이 예상과 일치해야 합니다.")
+            .isEqualTo(expectedStart);
+        assertThat(firstEvent.endDateTime())
+            .as("첫 번째 이벤트의 종료 시간이 예상과 일치해야 합니다.")
+            .isEqualTo(expectedEnd);
+
+        // 참가자 목록은 스텁에 의해 빈 리스트로 설정되어 있음
+        assertThat(firstEvent.usersForAdjust()).isEmpty();
+
+        // 추가로, 여러 이벤트가 생성되었음을 확인 (예: 2개 이상)
+        assertThat(events.size()).isGreaterThanOrEqualTo(2);
+    }
+
+    @TestConfiguration
+    public static class TestConfig {
+
+        @Bean
+        public DiscussionService discussionService() {
+            return Mockito.mock(DiscussionService.class);
+        }
+
+        @Bean
+        public DiscussionParticipantService discussionParticipantService() {
+            return Mockito.mock(DiscussionParticipantService.class);
+        }
+    }
+}

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
@@ -1,0 +1,170 @@
+package endolphin.backend.domain.discussion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.error.exception.ApiException;
+import endolphin.backend.global.error.exception.ErrorCode;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DiscussionParticipantServiceTest {
+
+    @Mock
+    private DiscussionParticipantRepository discussionParticipantRepository;
+
+    @InjectMocks
+    private DiscussionParticipantService discussionParticipantService;
+
+    @Test
+    @DisplayName("논의 참여자 추가 - 성공")
+    void addDiscussionParticipant_ShouldAddSuccessfully() {
+        // Given
+        Discussion discussion = Discussion.builder()
+            .title("Test Discussion")
+            .dateStart(LocalDate.now())
+            .dateEnd(LocalDate.now().plusDays(1))
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(18, 0))
+            .duration(60)
+            .deadline(LocalDate.now().plusDays(2))
+            .build();
+
+        User user = User.builder()
+            .name("John Doe")
+            .email("john@example.com")
+            .picture("profile.jpg")
+            .build();
+
+        given(discussionParticipantRepository.findMaxOffsetByDiscussionId(discussion.getId()))
+            .willReturn(0L);
+
+        // When
+        discussionParticipantService.addDiscussionParticipant(discussion, user);
+
+        // Then
+        verify(discussionParticipantRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("논의 참여자 추가 - 최대 인원 초과 시 예외 발생")
+    void addDiscussionParticipant_ShouldThrowExceptionWhenExceedLimit() {
+        // Given
+        Discussion discussion = Discussion.builder()
+            .title("Full Discussion")
+            .dateStart(LocalDate.now())
+            .dateEnd(LocalDate.now().plusDays(1))
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(18, 0))
+            .duration(60)
+            .deadline(LocalDate.now().plusDays(2))
+            .build();
+
+        User user = User.builder()
+            .name("Jane Doe")
+            .email("jane@example.com")
+            .picture("profile.jpg")
+            .build();
+
+        given(discussionParticipantRepository.findMaxOffsetByDiscussionId(discussion.getId()))
+            .willReturn(15L); // 최대 인원 초과 상황
+
+        // When & Then
+        ApiException exception = assertThrows(ApiException.class, () -> {
+            discussionParticipantService.addDiscussionParticipant(discussion, user);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DISCUSSION_PARTICIPANT_EXCEED_LIMIT);
+    }
+
+    @Test
+    @DisplayName("논의 ID로 참여자 목록 조회")
+    void getUsersByDiscussionId_ShouldReturnUsers() {
+        // Given
+        Long discussionId = 1L;
+        User user1 = User.builder().name("Alice").email("alice@example.com").picture("alice.jpg").build();
+        User user2 = User.builder().name("Bob").email("bob@example.com").picture("bob.jpg").build();
+
+        given(discussionParticipantRepository.findUsersByDiscussionId(discussionId))
+            .willReturn(Arrays.asList(user1, user2));
+
+        // When
+        List<User> users = discussionParticipantService.getUsersByDiscussionId(discussionId);
+
+        // Then
+        assertThat(users).hasSize(2);
+        assertThat(users).containsExactly(user1, user2);
+    }
+
+    @Test
+    @DisplayName("사용자의 논의 참여자 Offset 조회 - 성공")
+    void getDiscussionParticipantOffset_ShouldReturnOffset() {
+        // Given
+        Long discussionId = 1L;
+        Long userId = 1L;
+        Long expectedOffset = 3L;
+
+        given(discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userId))
+            .willReturn(Optional.of(expectedOffset));
+
+        // When
+        Long offset = discussionParticipantService.getDiscussionParticipantOffset(discussionId, userId);
+
+        // Then
+        assertThat(offset).isEqualTo(expectedOffset);
+    }
+
+    @Test
+    @DisplayName("사용자의 논의 참여자 Offset 조회 - 존재하지 않을 경우 예외 발생")
+    void getDiscussionParticipantOffset_ShouldThrowExceptionIfNotFound() {
+        // Given
+        Long discussionId = 1L;
+        Long userId = 2L;
+
+        given(discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userId))
+            .willReturn(Optional.empty());
+
+        // When & Then
+        ApiException exception = assertThrows(ApiException.class, () -> {
+            discussionParticipantService.getDiscussionParticipantOffset(discussionId, userId);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("논의 참여자들의 Offset 기반 필터 반환")
+    void getFilter_ShouldReturnCorrectBitMask() {
+        // Given
+        Long discussionId = 1L;
+        List<Long> userIds = Arrays.asList(1L, 2L, 3L);
+        List<Long> offsets = Arrays.asList(0L, 3L, 8L); // Offset: 0, 3, 8
+
+        given(discussionParticipantRepository.findOffsetsByDiscussionIdAndUserIds(discussionId, userIds))
+            .willReturn(offsets);
+
+        // When
+        int filter = discussionParticipantService.getFilter(discussionId, userIds);
+
+        // Then
+        int expectedFilter = (1 << 15) | (1 << 12) | (1 << 7); // 0, 3, 8에 해당하는 비트만 1인 필터
+        assertThat(filter).isEqualTo(expectedFilter);
+    }
+}

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventPreprocessorTest.java
@@ -1,6 +1,5 @@
 package endolphin.backend.domain.personal_event;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import endolphin.backend.domain.discussion.DiscussionParticipantService;
@@ -41,7 +40,7 @@ class PersonalEventPreprocessorTest {
         Discussion discussion = getDiscussion();
         User user = getUser();
 
-        given(discussionParticipantService.getDiscussionParticipantIndex(anyLong(), anyLong()))
+        given(discussionParticipantService.getDiscussionParticipantOffset(anyLong(), anyLong()))
             .willReturn(participantIndex);
 
         // count : 2
@@ -67,7 +66,7 @@ class PersonalEventPreprocessorTest {
         Discussion discussion = getDiscussion();
         User user = getUser();
 
-        given(discussionParticipantService.getDiscussionParticipantIndex(anyLong(), anyLong()))
+        given(discussionParticipantService.getDiscussionParticipantOffset(anyLong(), anyLong()))
             .willReturn(participantIndex);
 
         // count : 0
@@ -93,7 +92,7 @@ class PersonalEventPreprocessorTest {
         Discussion discussion = getDiscussion();
         User user = getUser();
 
-        given(discussionParticipantService.getDiscussionParticipantIndex(anyLong(), anyLong()))
+        given(discussionParticipantService.getDiscussionParticipantOffset(anyLong(), anyLong()))
             .willReturn(participantIndex);
 
         // count : 6 + 6 + 2 = 14
@@ -119,7 +118,7 @@ class PersonalEventPreprocessorTest {
         Discussion discussion = getDiscussion();
         User user = getUser();
 
-        given(discussionParticipantService.getDiscussionParticipantIndex(anyLong(), anyLong()))
+        given(discussionParticipantService.getDiscussionParticipantOffset(anyLong(), anyLong()))
             .willReturn(participantIndex);
 
         // count : 6 * 11
@@ -145,7 +144,7 @@ class PersonalEventPreprocessorTest {
         Discussion discussion = getDiscussion();
         User user = getUser();
 
-        given(discussionParticipantService.getDiscussionParticipantIndex(anyLong(), anyLong()))
+        given(discussionParticipantService.getDiscussionParticipantOffset(anyLong(), anyLong()))
             .willReturn(participantIndex);
 
         // count : 3 + 6 * 5

--- a/backend/src/test/java/endolphin/backend/global/redis/DiscussionBitmapServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/redis/DiscussionBitmapServiceTest.java
@@ -3,7 +3,9 @@ package endolphin.backend.global.redis;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.BitSet;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
@@ -73,23 +75,67 @@ public class DiscussionBitmapServiceTest {
     }
 
     @Test
-    @DisplayName("비트 설정 테스트")
-    public void testSetPersonalEventBitToBitmap() {
+    @DisplayName("비트 설정 테스트 (16비트 빅 엔디안 데이터)")
+    public void testSetPersonalEventBitToBitmap_16Bit_BigEndian() {
         Long discussionId = 100L;
         LocalDateTime dateTime = LocalDateTime.now();
 
-        // 초기화 전
         byte[] bitmapData = bitmapService.getBitmapData(discussionId, dateTime);
-
         assertThat(bitmapData).isNull();
 
-        // bit 설정
-        Boolean result = bitmapService.setBitValue(discussionId, dateTime, 3, true);
+        Boolean result = bitmapService.setBitValue(discussionId, dateTime, 5, true);
         assertThat(result).isFalse();
 
         bitmapData = bitmapService.getBitmapData(discussionId, dateTime);
         assertThat(bitmapData).isNotNull();
+        assertThat(bitmapData.length).isEqualTo(2);
+
+        // BitSet.valueOf(byte[])는 각 바이트를 little-endian으로 해석함.
+        // 따라서, 첫 바이트의 빅 엔디안 오프셋 5는 little-endian 인덱스 7 - 5 = 2에 해당함.
         BitSet bs = BitSet.valueOf(bitmapData);
-        assertThat(bs.get(3 + 1)).isTrue();
+        assertThat(bs.get(2))
+            .as("빅 엔디안 기준 offset 5는 BitSet의 인덱스 2에 해당해야 합니다.")
+            .isTrue();
+    }
+
+
+    @DisplayName("getDataOfDiscussionId 메서드 테스트")
+    @Test
+    public void testGetDataOfDiscussionId() {
+        // given
+        Long discussionId = 300L;
+        // 특정 날짜 및 시각을 기준으로 테스트 (예: 2025-03-10 09:00)
+        LocalDateTime dateTime = LocalDateTime.of(2025, 3, 10, 9, 0);
+        // minute 단위로 변환
+        long minuteKey = dateTime.toEpochSecond(ZoneOffset.UTC) / 60;
+
+        // 해당 시각에 대해 비트맵 초기화 및 특정 비트 설정
+        bitmapService.initializeBitmap(discussionId, dateTime);
+        // 예시로 offset 2의 비트를 true로 설정
+        bitmapService.setBitValue(discussionId, dateTime, 2, true);
+
+        // 테스트할 시간 범위: minuteKey를 중심으로 ±10분
+        long startRange = minuteKey - 10;
+        long endRange = minuteKey + 10;
+
+        // when: getDataOfDiscussionId 호출
+        Map<Long, byte[]> dataMap = bitmapService.getDataOfDiscussionId(discussionId, startRange, endRange);
+
+        // then
+        assertThat(dataMap)
+            .as("데이터 맵은 비어있지 않아야 합니다")
+            .isNotEmpty();
+        assertThat(dataMap).containsKey(minuteKey);
+
+        byte[] data = dataMap.get(minuteKey);
+        assertThat(data).isNotNull();
+
+        // 비트 데이터에서 offset 5의 비트가 true인지 검증 (구현에 따라 인덱스 매핑이 달라질 수 있음)
+        BitSet bs = BitSet.valueOf(data);
+        assertThat(bs.get(5)).as("Offset 5의 비트는 true여야 합니다").isTrue();
+
+        // 범위 밖으로 호출 시 해당 key가 조회되지 않아야 함
+        Map<Long, byte[]> dataMapOut = bitmapService.getDataOfDiscussionId(discussionId, minuteKey + 1, minuteKey + 100);
+        assertThat(dataMapOut).doesNotContainKey(minuteKey);
     }
 }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #144 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 후보 일정 캘린더 뷰 api를 구현했습니다.
- 후보 일정 순위 뷰 api를 구현했습니다.
- CandidateEventService 생성하여 후보 일정 검색, 정렬 메서드 구현했습니다.
- 기타 db 조회 메서드 필요하여 추가했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 검색 로직의 가독성이 나쁠 수 있지만 검토해주시면 감사합니다
- 테스트 코드 관련해서 의견 주시면 감사합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new candidate event views that let users filter and visualize events in calendar and ranking modes.
  - Added endpoints for fetching event lists based on date ranges and user selections, with enhanced display of event details.
  - Implemented new DTOs for structured data transfer related to candidate events.
  - Added functionality to retrieve user ID and name information based on user selections.

- **Enhancements**
  - Improved discussion participant handling with stricter limits and clearer error messaging.
  - Optimized event filtering and data processing for a smoother and more responsive user experience. 
  - Enhanced bitmap data retrieval based on time ranges for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->