### PR TITLE
[BE-Feat] 논의 생성 api에 비밀번호 추가

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -13,6 +13,7 @@ import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
 import endolphin.backend.global.redis.DiscussionBitmapService;
+import endolphin.backend.global.security.PasswordEncoder;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -34,6 +35,7 @@ public class DiscussionService {
     private final SharedEventService sharedEventService;
     private final DiscussionParticipantService discussionParticipantService;
     private final DiscussionBitmapService discussionBitmapService;
+    private final PasswordEncoder passwordEncoder;
 
     public DiscussionResponse createDiscussion(CreateDiscussionRequest request) {
         User currentUser = userService.getCurrentUser();
@@ -51,6 +53,11 @@ public class DiscussionService {
             .build();
 
         discussion = discussionRepository.save(discussion);
+
+        if (request.password() != null) {
+            discussion.setPassword(passwordEncoder.encode(discussion.getId(), request.password()));
+            discussion = discussionRepository.save(discussion);
+        }
 
         discussionParticipantService.addDiscussionParticipant(discussion, currentUser);
         personalEventService.preprocessPersonalEvents(currentUser, discussion);

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/CreateDiscussionRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/CreateDiscussionRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -18,6 +19,7 @@ public record CreateDiscussionRequest(
     @NotNull @Min(30) @Max(180) Integer duration,
     MeetingMethod meetingMethod,
     String location,
-    @NotNull @Future LocalDate deadline) {
+    @NotNull @Future LocalDate deadline,
+    @Size(min = 4) String password) {
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/entity/Discussion.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/entity/Discussion.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 
 @Getter
@@ -51,10 +52,14 @@ public class Discussion extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDate deadline;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'ONGOING'")
     @Column(name = "status", nullable = false)
     private DiscussionStatus discussionStatus;
+
+    @Setter
+    private String password;
 
     @Builder
     public Discussion(String title, LocalDate dateStart, LocalDate dateEnd,

--- a/backend/src/main/java/endolphin/backend/domain/discussion/entity/Discussion.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/entity/Discussion.java
@@ -4,6 +4,7 @@ import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
 import endolphin.backend.global.base_entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
@@ -59,6 +60,8 @@ public class Discussion extends BaseTimeEntity {
     private DiscussionStatus discussionStatus;
 
     @Setter
+    @Column(length = 255)
+    @Size(min = 4, max = 100)
     private String password;
 
     @Builder

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
 
     // Discussion
     DISCUSSION_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "Discussion not found"),
+    DISCUSSION_NOT_ONGOING(HttpStatus.BAD_REQUEST, "D002", "Discussion not ongoing"),
 
     //SharedEvent
     SHARED_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "Shared Event not found"),

--- a/backend/src/main/java/endolphin/backend/global/security/PasswordEncoder.java
+++ b/backend/src/main/java/endolphin/backend/global/security/PasswordEncoder.java
@@ -1,0 +1,42 @@
+package endolphin.backend.global.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Base64;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordEncoder {
+
+    @Value("${endolphin.security.salt}")
+    private String salt;
+
+    public String encode(Long discussionId, String password) {
+        try {
+            KeySpec spec = new PBEKeySpec(password.toCharArray(), getSalt(discussionId), 10000,
+                128);
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+            byte[] hash = factory.generateSecret(spec).getEncoded();
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException("Error during password encryption", e);
+        }
+    }
+
+    private byte[] getSalt(Long discussionId) throws NoSuchAlgorithmException {
+        String discussionSalt = discussionId.toString() + salt;
+        MessageDigest digest = MessageDigest.getInstance("SHA-512");
+        byte[] keyBytes = discussionSalt.getBytes(StandardCharsets.UTF_8);
+        return digest.digest(keyBytes);
+    }
+
+    public boolean matches(Long discussionId, String password, String encodedPassword) {
+        return encode(discussionId, password).equals(encodedPassword);
+    }
+}

--- a/backend/src/main/java/endolphin/backend/global/security/PasswordEncoder.java
+++ b/backend/src/main/java/endolphin/backend/global/security/PasswordEncoder.java
@@ -1,5 +1,7 @@
 package endolphin.backend.global.security;
 
+import endolphin.backend.global.error.exception.ApiException;
+import endolphin.backend.global.error.exception.ErrorCode;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -25,7 +27,7 @@ public class PasswordEncoder {
             byte[] hash = factory.generateSecret(spec).getEncoded();
             return Base64.getEncoder().encodeToString(hash);
         } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-            throw new RuntimeException("Error during password encryption", e);
+            throw new ApiException(ErrorCode.INTERNAL_ERROR);
         }
     }
 

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionControllerTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionControllerTest.java
@@ -56,7 +56,8 @@ public class DiscussionControllerTest {
             60,
             MeetingMethod.ONLINE,
             null,
-            LocalDate.now().plusDays(10)
+            LocalDate.now().plusDays(10),
+            null
         );
 
         // given: 서비스가 반환할 응답 DTO 생성

--- a/backend/src/test/java/endolphin/backend/global/security/PasswordEncoderTest.java
+++ b/backend/src/test/java/endolphin/backend/global/security/PasswordEncoderTest.java
@@ -1,0 +1,52 @@
+package endolphin.backend.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class PasswordEncoderTest {
+
+    private PasswordEncoder passwordEncoder;
+    private final Long discussionId = 123L;
+    private final String password = "secretPassword";
+
+    @BeforeEach
+    public void setUp() {
+        passwordEncoder = new PasswordEncoder();
+        String testSalt = "test123salt";
+        ReflectionTestUtils.setField(passwordEncoder, "salt", testSalt);
+    }
+
+    @DisplayName("encode 테스트")
+    @Test
+    public void testEncodeReturnsNonNullAndNotPlainText() {
+        String encodedPassword = passwordEncoder.encode(discussionId, password);
+        assertThat(encodedPassword)
+            .as("Encoded password should not be null and should not equal the plain text")
+            .isNotNull()
+            .isNotEqualTo(password);
+    }
+
+    @DisplayName("올바른 비밀번호 입력 테스트")
+    @Test
+    public void testMatchesReturnsTrueForCorrectPassword() {
+        String encodedPassword = passwordEncoder.encode(discussionId, password);
+        boolean match = passwordEncoder.matches(discussionId, password, encodedPassword);
+        assertThat(match)
+            .as("matches() should return true for correct password")
+            .isTrue();
+    }
+
+    @DisplayName("잘못된 비밀번호 입력 테스트")
+    @Test
+    public void testMatchesReturnsFalseForIncorrectPassword() {
+        String encodedPassword = passwordEncoder.encode(discussionId, password);
+        boolean match = passwordEncoder.matches(discussionId, "wrongPassword", encodedPassword);
+        assertThat(match)
+            .as("matches() should return false for incorrect password")
+            .isFalse();
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -66,3 +66,7 @@ app:
 
   server:
     domain: "test"
+
+endolphin:
+  security:
+    salt: "test"


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #155 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 패스워드 해싱하는 PasswordEncoder 추가했습니다.
- 논의 확정 기능에 discussionStatus 변경이 누락되어 추가했습니다.
- 논의 생성 시 db에 password 해싱하여 저장합니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
패스워드 해싱 에러는 Internal server error로 하고 로그 보는게 맞는 것 같아서 일단 그냥 RuntimeException으로 했습니다. 의견 주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced secure password support for discussions, allowing users to protect discussions with a password.
  - Enhanced discussion scheduling by enforcing proper status validations to maintain appropriate state transitions.

- **Security Improvements**
  - Integrated advanced password encoding, ensuring that discussion passwords are processed securely.

- **Bug Fixes**
  - Added validation to prevent scheduling of discussions that are not ongoing, improving error handling. 

- **Tests**
  - Expanded test coverage for discussion creation and scheduling, focusing on password handling and state validation. 
  - Introduced new tests for password encoding and matching functionalities. 

- **Configuration**
  - Added a new security configuration for password handling, including a salt property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->