### PR TITLE
[BE-Feat] 후보 일정 상세 정보 보기 기능 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -5,6 +5,8 @@ import endolphin.backend.domain.candidate_event.dto.CalendarViewRequest;
 import endolphin.backend.domain.candidate_event.dto.CalendarViewResponse;
 import endolphin.backend.domain.candidate_event.dto.RankViewRequest;
 import endolphin.backend.domain.candidate_event.dto.RankViewResponse;
+import endolphin.backend.domain.discussion.dto.CandidateEventDetailsRequest;
+import endolphin.backend.domain.discussion.dto.CandidateEventDetailsResponse;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
@@ -112,6 +114,18 @@ public class DiscussionController {
 
         RankViewResponse response = candidateEventService.getEventsOnRankView(discussionId,
             request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "후보 일정 상세 정보", description = "후보 일정의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "후보 일정 상세 정보 조회 성공",
+            content = @Content(schema = @Schema(implementation = CandidateEventDetailsResponse.class)))
+    })
+    @PostMapping("/{discussionId}/candidate-event/details")
+    public ResponseEntity<CandidateEventDetailsResponse> getCandidateEventDetails(@PathVariable("discussionId") @Min(1) Long discussionId,
+        @Valid @RequestBody CandidateEventDetailsRequest request) {
+        CandidateEventDetailsResponse response = discussionService.retrieveCandidateEventDetails(discussionId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -61,7 +61,7 @@ public interface DiscussionParticipantRepository extends
         "WHERE dp.user.id = :userId")
     List<Discussion> findDiscussionsByUserId(@Param("userId") Long userId);
 
-    @Query("SELECT dp.user "
+    @Query("SELECT dp "
         + "FROM DiscussionParticipant dp "
         + "JOIN FETCH dp.user "
         + "WHERE dp.discussion.id = :discussionId "

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -60,4 +60,11 @@ public interface DiscussionParticipantRepository extends
         "JOIN FETCH dp.discussion d " +
         "WHERE dp.user.id = :userId")
     List<Discussion> findDiscussionsByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT dp.user "
+        + "FROM DiscussionParticipant dp "
+        + "JOIN FETCH dp.user "
+        + "WHERE dp.discussion.id = :discussionId "
+        + "ORDER BY dp.createdAt ASC")
+    List<User> findUserByDiscussionIdOrderByJoin(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -105,4 +105,9 @@ public class DiscussionParticipantService {
     public List<Discussion> getDiscussionsByUserId(Long userId) {
         return discussionParticipantRepository.findDiscussionsByUserId(userId);
     }
+
+    @Transactional(readOnly = true)
+    public List<User> getUsersByDiscussionIdOrderByCreatedAt(Long discussionId) {
+        return discussionParticipantRepository.findUserByDiscussionIdOrderByJoin(discussionId);
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -130,6 +130,10 @@ public class DiscussionService {
         Long discussionId, CandidateEventDetailsRequest request) {
         final int TIME_OFFSET = 4;
 
+        if (request.selectedUserIdList().isEmpty()) {
+            throw new ApiException(ErrorCode.EMPTY_SELECTED_USER_IDS);
+        }
+
         LocalDateTime startTime = request.startDateTime();
         LocalDateTime endTime = request.endDateTime();
 
@@ -145,7 +149,7 @@ public class DiscussionService {
             discussionId);
 
         if (!participants.contains(currentUser)) {
-            throw new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND);
+            throw new ApiException(ErrorCode.INVALID_DISCUSSION_PARTICIPANT);
         }
 
         Map<Long, Integer> selectedUserIdMap = new HashMap<>();

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/CandidateEventDetailsRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/CandidateEventDetailsRequest.java
@@ -1,0 +1,13 @@
+package endolphin.backend.domain.discussion.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CandidateEventDetailsRequest(
+    @NotNull LocalDateTime startDateTime,
+    @NotNull LocalDateTime endDateTime,
+    @NotNull List<Long> selectedUserIdList
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/CandidateEventDetailsResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/CandidateEventDetailsResponse.java
@@ -1,0 +1,15 @@
+package endolphin.backend.domain.discussion.dto;
+
+import endolphin.backend.domain.user.dto.UserInfoWithPersonalEvents;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CandidateEventDetailsResponse(
+    Long discussionId,
+    LocalDateTime startDateTime,
+    LocalDateTime endDateTime,
+    int numOfAdjustment,
+    List<UserInfoWithPersonalEvents> participants
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/CandidateEventDetailsResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/CandidateEventDetailsResponse.java
@@ -8,7 +8,6 @@ public record CandidateEventDetailsResponse(
     Long discussionId,
     LocalDateTime startDateTime,
     LocalDateTime endDateTime,
-    int numOfAdjustment,
     List<UserInfoWithPersonalEvents> participants
 ) {
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/entity/DiscussionParticipant.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/entity/DiscussionParticipant.java
@@ -1,6 +1,7 @@
 package endolphin.backend.domain.discussion.entity;
 
 import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.base_entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Entity
 @Table(name = "discussion_participant")
-public class DiscussionParticipant {
+public class DiscussionParticipant extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
@@ -4,7 +4,6 @@ import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.user.entity.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -30,4 +29,14 @@ public interface PersonalEventRepository extends JpaRepository<PersonalEvent, Lo
         @Param("endDate") LocalDate endDate);
 
     Optional<PersonalEvent> findByGoogleEventIdAndCalendarId(String googleEventId, String calendarId);
+
+    @Query("SELECT p "
+        + "FROM PersonalEvent p "
+        + "WHERE p.user.id = :userId "
+        + "AND (p.startTime BETWEEN :startDateTime AND :endDateTime "
+        + "OR p.endTime BETWEEN :startDateTime AND :endDateTime)")
+    List<PersonalEvent> findAllByUserAndDateTimeRange(
+        @Param("userId") Long userId,
+        @Param("startDateTime") LocalDateTime start,
+        @Param("endDateTime") LocalDateTime end);
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
@@ -32,11 +32,12 @@ public interface PersonalEventRepository extends JpaRepository<PersonalEvent, Lo
 
     @Query("SELECT p "
         + "FROM PersonalEvent p "
-        + "WHERE p.user.id = :userId "
+        + "JOIN FETCH p.user u "
+        + "WHERE u.id IN :userIds "
         + "AND p.startTime <= :endDateTime "
         + "AND p.endTime >= :startDateTime")
-    List<PersonalEvent> findAllByUserAndDateTimeRange(
-        @Param("userId") Long userId,
+    List<PersonalEvent> findAllByUsersAndDateTimeRange(
+        @Param("userIds") List<Long> userIds,
         @Param("startDateTime") LocalDateTime start,
         @Param("endDateTime") LocalDateTime end);
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
@@ -33,8 +33,8 @@ public interface PersonalEventRepository extends JpaRepository<PersonalEvent, Lo
     @Query("SELECT p "
         + "FROM PersonalEvent p "
         + "WHERE p.user.id = :userId "
-        + "AND (p.startTime BETWEEN :startDateTime AND :endDateTime "
-        + "OR p.endTime BETWEEN :startDateTime AND :endDateTime)")
+        + "AND p.startTime <= :endDateTime "
+        + "AND p.endTime >= :startDateTime")
     List<PersonalEvent> findAllByUserAndDateTimeRange(
         @Param("userId") Long userId,
         @Param("startDateTime") LocalDateTime start,

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -4,6 +4,7 @@ import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.personal_event.dto.PersonalEventRequest;
 import endolphin.backend.domain.personal_event.dto.PersonalEventResponse;
+import endolphin.backend.domain.personal_event.dto.PersonalEventWithStatus;
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.user.UserService;
@@ -176,5 +177,12 @@ public class PersonalEventService {
             return false;
         }
         return true;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PersonalEvent> findPersonalEventsByDateTimeRange(User user, LocalDateTime startTime,
+        LocalDateTime endTime) {
+        return personalEventRepository.findAllByUserAndDateTimeRange(
+            user.getId(), startTime, endTime);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/dto/PersonalEventWithStatus.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/dto/PersonalEventWithStatus.java
@@ -1,0 +1,13 @@
+package endolphin.backend.domain.personal_event.dto;
+
+import java.time.LocalDateTime;
+
+public record PersonalEventWithStatus(
+    Long id,
+    LocalDateTime startDateTime,
+    LocalDateTime endDateTime,
+    String title,
+    String status
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/dto/PersonalEventWithStatus.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/dto/PersonalEventWithStatus.java
@@ -1,5 +1,7 @@
 package endolphin.backend.domain.personal_event.dto;
 
+import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+import endolphin.backend.domain.personal_event.enums.PersonalEventStatus;
 import java.time.LocalDateTime;
 
 public record PersonalEventWithStatus(
@@ -7,7 +9,19 @@ public record PersonalEventWithStatus(
     LocalDateTime startDateTime,
     LocalDateTime endDateTime,
     String title,
-    String status
+    PersonalEventStatus status
 ) {
 
+    public static PersonalEventWithStatus from(PersonalEvent personalEvent, LocalDateTime startTime,
+        LocalDateTime endTime) {
+        PersonalEventStatus status = PersonalEventStatus.FIXED;
+        if (personalEvent.getIsAdjustable()) {
+            status = PersonalEventStatus.ADJUSTABLE;
+        }
+        if (personalEvent.getEndTime().isBefore(startTime) || personalEvent.getStartTime().isAfter(endTime)) {
+            status = PersonalEventStatus.OUT_OF_RANGE;
+        }
+        return new PersonalEventWithStatus(personalEvent.getId(), personalEvent.getStartTime(),
+            personalEvent.getEndTime(), personalEvent.getTitle(), status);
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/enums/PersonalEventStatus.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/enums/PersonalEventStatus.java
@@ -1,0 +1,15 @@
+package endolphin.backend.domain.personal_event.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum PersonalEventStatus {
+    ADJUSTABLE("adjustable"),
+    FIXED("fixed"),
+    OUT_OF_RANGE("outOfRange");
+
+    private final String value;
+    PersonalEventStatus(String value) {
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/endolphin/backend/domain/user/dto/UserInfoWithPersonalEvents.java
+++ b/backend/src/main/java/endolphin/backend/domain/user/dto/UserInfoWithPersonalEvents.java
@@ -8,6 +8,7 @@ public record UserInfoWithPersonalEvents(
     String name,
     String picture,
     boolean selected,
+    boolean requirementOfAdjustment,
     List<PersonalEventWithStatus> events
 ) {
 

--- a/backend/src/main/java/endolphin/backend/domain/user/dto/UserInfoWithPersonalEvents.java
+++ b/backend/src/main/java/endolphin/backend/domain/user/dto/UserInfoWithPersonalEvents.java
@@ -7,6 +7,7 @@ public record UserInfoWithPersonalEvents(
     Long id,
     String name,
     String picture,
+    boolean selected,
     List<PersonalEventWithStatus> events
 ) {
 

--- a/backend/src/main/java/endolphin/backend/domain/user/dto/UserInfoWithPersonalEvents.java
+++ b/backend/src/main/java/endolphin/backend/domain/user/dto/UserInfoWithPersonalEvents.java
@@ -1,0 +1,13 @@
+package endolphin.backend.domain.user.dto;
+
+import endolphin.backend.domain.personal_event.dto.PersonalEventWithStatus;
+import java.util.List;
+
+public record UserInfoWithPersonalEvents(
+    Long id,
+    String name,
+    String picture,
+    List<PersonalEventWithStatus> events
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -27,9 +27,8 @@ public enum ErrorCode {
     // DiscussionParticipant
     DISCUSSION_PARTICIPANT_EXCEED_LIMIT(HttpStatus.FORBIDDEN, "DP001", "Discussion participant exceed limit"),
     DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP002", "Discussion participant not found"),
-
-    DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP001", "Discussion participant not found"),
-    INVALID_DISCUSSION_PARTICIPANT(HttpStatus.BAD_REQUEST, "DP002", "Invalid Discussion participant"),
+    INVALID_DISCUSSION_PARTICIPANT(HttpStatus.BAD_REQUEST, "DP003", "Invalid Discussion participant"),
+    
     //Calendar
     CALENDAR_UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "CA001", "Unauthorized"),
     CALENDAR_FORBIDDEN_ERROR(HttpStatus.FORBIDDEN, "CA002", "Forbidden"),

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
     DISCUSSION_PARTICIPANT_EXCEED_LIMIT(HttpStatus.FORBIDDEN, "DP001", "Discussion participant exceed limit"),
     DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP002", "Discussion participant not found"),
     INVALID_DISCUSSION_PARTICIPANT(HttpStatus.BAD_REQUEST, "DP003", "Invalid Discussion participant"),
-    
+
     //Calendar
     CALENDAR_UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "CA001", "Unauthorized"),
     CALENDAR_FORBIDDEN_ERROR(HttpStatus.FORBIDDEN, "CA002", "Forbidden"),

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
 
     // Discussion
     DISCUSSION_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "Discussion not found"),
+    EMPTY_SELECTED_USER_IDS(HttpStatus.BAD_REQUEST, "D002", "Empty Selected User IDs"),
     DISCUSSION_NOT_ONGOING(HttpStatus.BAD_REQUEST, "D002", "Discussion not ongoing"),
 
     // PersonalEvent
@@ -27,6 +28,8 @@ public enum ErrorCode {
     DISCUSSION_PARTICIPANT_EXCEED_LIMIT(HttpStatus.FORBIDDEN, "DP001", "Discussion participant exceed limit"),
     DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP002", "Discussion participant not found"),
 
+    DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP001", "Discussion participant not found"),
+    INVALID_DISCUSSION_PARTICIPANT(HttpStatus.BAD_REQUEST, "DP002", "Invalid Discussion participant"),
     //Calendar
     CALENDAR_UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "CA001", "Unauthorized"),
     CALENDAR_FORBIDDEN_ERROR(HttpStatus.FORBIDDEN, "CA002", "Forbidden"),

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -2,14 +2,20 @@ package endolphin.backend.domain.discussion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import endolphin.backend.domain.discussion.dto.CandidateEventDetailsRequest;
+import endolphin.backend.domain.discussion.dto.CandidateEventDetailsResponse;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
@@ -21,6 +27,7 @@ import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.domain.user.UserService;
+import endolphin.backend.domain.user.dto.UserInfoWithPersonalEvents;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
@@ -30,14 +37,18 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -301,4 +312,161 @@ public class DiscussionServiceTest {
         verify(discussionRepository, atLeast(2)).save(any(Discussion.class));
     }
 
+    @Test
+    @DisplayName("후보 일정 상세 정보 가져오기 테스트 성공")
+    public void testRetrieveCandidateEventDetails() {
+        // Given
+        Long discussionId = 1L;
+        LocalDateTime startDateTime = LocalDateTime.of(2025, 2, 12, 10, 0);
+        LocalDateTime endDateTime = LocalDateTime.of(2025, 2, 12, 12, 0);
+        List<Long> selectedUserIdList = Arrays.asList(1L, 3L);
+        CandidateEventDetailsRequest request = new CandidateEventDetailsRequest(startDateTime,
+            endDateTime, selectedUserIdList);
+
+        User currentUser = Mockito.mock(User.class);
+        given(currentUser.getId()).willReturn(1L);
+        given(currentUser.getName()).willReturn("Alice");
+        given(currentUser.getPicture()).willReturn("alicePicUrl");
+
+        User otherUser = Mockito.mock(User.class);
+        given(otherUser.getId()).willReturn(2L);
+        given(otherUser.getName()).willReturn("Bob");
+        given(otherUser.getPicture()).willReturn("bobPicUrl");
+
+        given(userService.getCurrentUser()).willReturn(currentUser);
+        given(discussionParticipantService.getUsersByDiscussionIdOrderByCreatedAt(discussionId))
+            .willReturn(Arrays.asList(currentUser, otherUser));
+
+        // candidateEventDetailsService 내부에서 personalEventService.createUserInfoWithPersonalEvents()를 호출하므로,
+        // stub으로 dummy 객체를 반환하도록 설정합니다.
+        UserInfoWithPersonalEvents dummyUserInfo =
+            new UserInfoWithPersonalEvents(currentUser.getId(), currentUser.getName(),
+                currentUser.getPicture(), true, Collections.emptyList());
+        given(personalEventService.createUserInfoWithPersonalEvents(
+            eq(currentUser), any(LocalDateTime.class), any(LocalDateTime.class), anyList()))
+            .willReturn(dummyUserInfo);
+
+        UserInfoWithPersonalEvents dummyUserInfo2 =
+            new UserInfoWithPersonalEvents(otherUser.getId(), otherUser.getName(),
+                otherUser.getPicture(), true, Collections.emptyList());
+        given(personalEventService.createUserInfoWithPersonalEvents(
+            eq(otherUser), any(LocalDateTime.class), any(LocalDateTime.class), anyList()))
+            .willReturn(dummyUserInfo2);
+
+        // When
+        CandidateEventDetailsResponse response =
+            discussionService.retrieveCandidateEventDetails(discussionId, request);
+
+        // Then
+        assertThat(response)
+            .isNotNull()
+            .extracting("discussionId", "startDateTime", "endDateTime")
+            .containsExactly(discussionId, startDateTime, endDateTime);
+
+        List<UserInfoWithPersonalEvents> participantInfos = response.participants();
+
+        assertThat(participantInfos).hasSize(2);
+        assertThat(participantInfos)
+            .extracting(UserInfoWithPersonalEvents::id, UserInfoWithPersonalEvents::name,
+                UserInfoWithPersonalEvents::picture, UserInfoWithPersonalEvents::selected)
+            .containsExactlyInAnyOrder(
+                tuple(currentUser.getId(), currentUser.getName(), currentUser.getPicture(), true),
+                tuple(otherUser.getId(), otherUser.getName(), otherUser.getPicture(), true)
+            );
+
+        // 각 UserInfoWithPersonalEvents의 events 목록이 빈 리스트임을 확인
+        participantInfos.forEach(userInfo ->
+            assertThat(userInfo.events()).isNotNull().isEmpty()
+        );
+
+        // midTime 관련 검증
+        // candidateEventDetailsService 내부에서는 아래와 같이 계산됨:
+        //   midTime = startDateTime + (endDateTime - startDateTime) / 2
+        //   searchStartTime = midTime.minusHours(TIME_OFFSET)  (TIME_OFFSET = 4)
+        //   searchEndTime   = midTime.plusHours(TIME_OFFSET)
+        LocalDateTime expectedMidTime = startDateTime.plus(
+            Duration.between(startDateTime, endDateTime).dividedBy(2)
+        );
+        LocalDateTime expectedSearchStartTime = expectedMidTime.minusHours(4);
+        LocalDateTime expectedSearchEndTime = expectedMidTime.plusHours(4);
+
+        // ArgumentCaptor를 사용해  personalEventService.createUserInfoWithPersonalEvents의 인자를 캡처
+        ArgumentCaptor<LocalDateTime> startCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+
+        then(personalEventService).should(times(2))
+            .createUserInfoWithPersonalEvents(any(User.class), startCaptor.capture(),
+                endCaptor.capture(), anyList());
+
+        List<LocalDateTime> capturedStartTimes = startCaptor.getAllValues();
+        List<LocalDateTime> capturedEndTimes = endCaptor.getAllValues();
+
+        assertThat(capturedStartTimes)
+            .as("searchStartTime should be midTime minus 4 hours")
+            .allSatisfy(time -> assertThat(time).isEqualTo(expectedSearchStartTime));
+
+        assertThat(capturedEndTimes)
+            .as("searchEndTime should be midTime plus 4 hours")
+            .allSatisfy(time -> assertThat(time).isEqualTo(expectedSearchEndTime));
+
+        // personalEventService.createUserInfoWithPersonalEvents가 각 사용자에 대해 한 번씩 호출되었는지 검증
+        then(personalEventService).should()
+            .createUserInfoWithPersonalEvents(eq(currentUser), any(LocalDateTime.class),
+                any(LocalDateTime.class), anyList());
+        then(personalEventService).should()
+            .createUserInfoWithPersonalEvents(eq(otherUser), any(LocalDateTime.class),
+                any(LocalDateTime.class), anyList());
+    }
+
+    @Test
+    @DisplayName("후보 일정 가져오기 시간 범위 예외 발생")
+    public void testRetrieveCandidateEventDetails_error_timeRange() {
+        // Given
+        Long discussionId = 1L;
+        LocalDateTime startDateTime = LocalDateTime.of(2025, 2, 12, 10, 0);
+        LocalDateTime endDateTime = LocalDateTime.of(2025, 2, 12, 8, 0);
+        List<Long> selectedUserIdList = Arrays.asList(1L, 3L);
+        CandidateEventDetailsRequest request = new CandidateEventDetailsRequest(startDateTime,
+            endDateTime, selectedUserIdList);
+
+        // When & Then
+        assertThatThrownBy(
+            () -> discussionService.retrieveCandidateEventDetails(discussionId, request))
+            .isInstanceOf(ApiException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_DATE_TIME_RANGE);
+
+        // 날짜 범위 검증 단계에서 예외가 발생하므로 다른 서비스들은 호출되지 않아야 함
+        then(userService).shouldHaveNoInteractions();
+        then(discussionParticipantService).shouldHaveNoInteractions();
+        then(personalEventService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("후보 일정 가져오기, 논의에 포함되지 않는 사용자 예외")
+    public void testRetrieveCandidateEventDetails_error_userParticipant() {
+        // Given
+        Long discussionId = 1L;
+        LocalDateTime startDateTime = LocalDateTime.of(2025, 2, 12, 10, 0);
+        LocalDateTime endDateTime = LocalDateTime.of(2025, 2, 12, 12, 0);
+        List<Long> selectedUserIdList = Arrays.asList(1L, 3L);
+        CandidateEventDetailsRequest request = new CandidateEventDetailsRequest(startDateTime,
+            endDateTime, selectedUserIdList);
+
+        User currentUser = Mockito.mock(User.class);
+
+        User otherUser = Mockito.mock(User.class);
+
+        given(userService.getCurrentUser()).willReturn(currentUser);
+        given(discussionParticipantService.getUsersByDiscussionIdOrderByCreatedAt(discussionId))
+            .willReturn(Collections.singletonList(otherUser));
+
+        // When & Then
+        assertThatThrownBy(
+            () -> discussionService.retrieveCandidateEventDetails(discussionId, request))
+            .isInstanceOf(ApiException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND);
+
+        // 날짜 범위 검증 단계에서 예외가 발생하므로 다른 서비스들은 호출되지 않아야 함
+        then(personalEventService).shouldHaveNoInteractions();
+    }
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -436,7 +436,7 @@ public class DiscussionServiceTest {
         assertThatThrownBy(
             () -> discussionService.retrieveCandidateEventDetails(discussionId, request))
             .isInstanceOf(ApiException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND);
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_DISCUSSION_PARTICIPANT);
 
         // 날짜 범위 검증 단계에서 예외가 발생하므로 다른 서비스들은 호출되지 않아야 함
         then(personalEventService).shouldHaveNoInteractions();

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventRepositoryTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventRepositoryTest.java
@@ -7,8 +7,8 @@ import endolphin.backend.domain.user.UserRepository;
 import endolphin.backend.domain.user.entity.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -140,66 +140,171 @@ class PersonalEventRepositoryTest {
     }
 
     @Test
-    @DisplayName("findAllByUserAndDateTimeRange: 날짜 필터 조건에 맞는 PersonalEvent를 정렬해서 조회")
-    void testFindAllByUserAndDateTimeRange() {
-        // Given: 테스트용 사용자 생성 및 persist
-        entityManager.persist(testUser);
+    @DisplayName("사용자들의 특정 기간 내 개인 일정을 조회한다")
+    void findAllByUsersAndDateTimeRange() {
+        // given
+        // 테스트용 시간 설정
+        LocalDateTime baseTime = LocalDateTime.of(2024, 2, 13, 12, 0);
 
-        // 필터링 조건
-        // 날짜 조건: 2025-02-09 (단일 날짜 범위)
-        LocalDateTime filterStartDate = LocalDateTime.of(2025, 2, 9, 7, 0);
-        LocalDateTime filterEndDate = LocalDateTime.of(2025, 2, 9, 15, 0);
-
-        // PersonalEvent 생성
-        PersonalEvent matchingEvent1 = PersonalEvent.builder()
-            .user(testUser)
-            .title("Matching Event")
-            .startTime(LocalDateTime.of(2025, 2, 9, 9, 0))
-            .endTime(LocalDateTime.of(2025, 2, 9, 11, 0))
+        // 첫 번째 사용자 생성 및 저장
+        User user1 = User.builder()
+            .name("User 1")
+            .email("user1@example.com")
+            .picture("user1.png")
             .build();
+        entityManager.persist(user1);
 
-        PersonalEvent nonMatchingDateEvent = PersonalEvent.builder()
-            .user(testUser)
-            .title("Non Matching Date Event")
-            .startTime(LocalDateTime.of(2025, 2, 8, 10, 0))
-            .endTime(LocalDateTime.of(2025, 2, 8, 12, 0))
+        // 두 번째 사용자 생성 및 저장
+        User user2 = User.builder()
+            .name("User 2")
+            .email("user2@example.com")
+            .picture("user2.png")
             .build();
+        entityManager.persist(user2);
 
-        PersonalEvent matchingEvent2 = PersonalEvent.builder()
-            .user(testUser)
-            .title("Matching Time Event")
-            .startTime(LocalDateTime.of(2025, 2, 9, 8, 0))
-            .endTime(LocalDateTime.of(2025, 2, 20, 8, 30))
+        // user1의 일정 생성 및 저장
+        PersonalEvent event1 = PersonalEvent.builder()
+            .user(user1)
+            .startTime(baseTime.minusHours(1))
+            .endTime(baseTime.plusHours(1))
+            .title("Event 1")
             .build();
+        entityManager.persist(event1);
 
-
-        PersonalEvent matchingEvent3 = PersonalEvent.builder()
-            .user(testUser)
-            .title("Matching Event2")
-            .startTime(LocalDateTime.of(2025, 2, 9, 1, 0))
-            .endTime(LocalDateTime.of(2025, 2, 9, 7, 30))
+        // user2의 일정 생성 및 저장
+        PersonalEvent event2 = PersonalEvent.builder()
+            .user(user2)
+            .startTime(baseTime.minusHours(2))
+            .endTime(baseTime.plusHours(2))
+            .title("Event 2")
             .build();
+        entityManager.persist(event2);
 
-        PersonalEvent matchingEvent4 = PersonalEvent.builder()
-            .user(testUser)
-            .title("Matching Event3")
-            .startTime(LocalDateTime.of(2025, 2, 9, 14, 0))
-            .endTime(LocalDateTime.of(2025, 2, 9, 15, 0))
+        // 검색 범위 밖의 일정 생성 및 저장
+        PersonalEvent eventOutsideRange = PersonalEvent.builder()
+            .user(user1)
+            .startTime(baseTime.plusHours(5))
+            .endTime(baseTime.plusHours(6))
+            .title("Event Outside Range")
             .build();
+        entityManager.persist(eventOutsideRange);
 
-        entityManager.persist(matchingEvent1);
-        entityManager.persist(nonMatchingDateEvent);
-        entityManager.persist(matchingEvent2);
-        entityManager.persist(matchingEvent3);
-        entityManager.persist(matchingEvent4);
         entityManager.flush();
         entityManager.clear();
 
-        // When: 필터 조건에 따라 이벤트 조회
-        List<PersonalEvent> events = personalEventRepository.findAllByUserAndDateTimeRange(
-            testUser.getId(), filterStartDate, filterEndDate);
+        // when
+        List<PersonalEvent> events = personalEventRepository.findAllByUsersAndDateTimeRange(
+            List.of(user1.getId(), user2.getId()),
+            baseTime.minusHours(3),
+            baseTime.plusHours(3)
+        );
 
-        // Then: "Matching Event"만 조회되어야 한다.
-        assertThat(events.size()).isEqualTo(4);
+        // then
+        assertThat(events)
+            .isNotNull()
+            .hasSize(2)
+            .extracting(PersonalEvent::getTitle)
+            .containsExactlyInAnyOrder("Event 1", "Event 2");
+
+        // 연관된 사용자 정보가 함께 로드되었는지 확인 (N+1 문제 방지 검증)
+        assertThat(events)
+            .allSatisfy(event -> {
+                assertThat(Hibernate.isInitialized(event.getUser())).isTrue();
+                assertThat(event.getUser().getName()).isNotNull();
+            });
+    }
+
+    @Test
+    @DisplayName("특정 기간에 일정이 없는 경우 빈 리스트를 반환한다")
+    void findAllByUsersAndDateTimeRange_returnsEmptyList_whenNoEventsInRange() {
+        // given
+        LocalDateTime baseTime = LocalDateTime.of(2024, 2, 13, 12, 0);
+
+        User user = User.builder()
+            .name("User")
+            .email("user@example.com")
+            .picture("user.png")
+            .build();
+        entityManager.persist(user);
+
+        PersonalEvent event = PersonalEvent.builder()
+            .user(user)
+            .startTime(baseTime.plusHours(5))
+            .endTime(baseTime.plusHours(6))
+            .title("Event Outside Range")
+            .build();
+        entityManager.persist(event);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<PersonalEvent> events = personalEventRepository.findAllByUsersAndDateTimeRange(
+            List.of(user.getId()),
+            baseTime.minusHours(2),
+            baseTime.plusHours(2)
+        );
+
+        // then
+        assertThat(events).isEmpty();
+    }
+
+    @Test
+    @DisplayName("일정이 검색 기간과 겹치는 경우를 정확히 조회한다")
+    void findAllByUsersAndDateTimeRange_findsOverlappingEvents() {
+        // given
+        LocalDateTime baseTime = LocalDateTime.of(2024, 2, 13, 12, 0);
+        LocalDateTime searchStart = baseTime.minusHours(1);
+        LocalDateTime searchEnd = baseTime.plusHours(1);
+
+        User user = User.builder()
+            .name("User")
+            .email("user@example.com")
+            .picture("user.png")
+            .build();
+        entityManager.persist(user);
+
+        // 검색 기간과 완전히 겹치는 일정
+        PersonalEvent event1 = PersonalEvent.builder()
+            .user(user)
+            .startTime(searchStart)
+            .endTime(searchEnd)
+            .title("Exact Match")
+            .build();
+        entityManager.persist(event1);
+
+        // 검색 기간의 시작과 겹치는 일정
+        PersonalEvent event2 = PersonalEvent.builder()
+            .user(user)
+            .startTime(searchStart.minusHours(1))
+            .endTime(searchStart.plusMinutes(30))
+            .title("Overlap Start")
+            .build();
+        entityManager.persist(event2);
+
+        // 검색 기간의 끝과 겹치는 일정
+        PersonalEvent event3 = PersonalEvent.builder()
+            .user(user)
+            .startTime(searchEnd.minusMinutes(30))
+            .endTime(searchEnd.plusHours(1))
+            .title("Overlap End")
+            .build();
+        entityManager.persist(event3);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<PersonalEvent> events = personalEventRepository.findAllByUsersAndDateTimeRange(
+            List.of(user.getId()),
+            searchStart,
+            searchEnd
+        );
+
+        // then
+        assertThat(events)
+            .hasSize(3)
+            .extracting(PersonalEvent::getTitle)
+            .containsExactlyInAnyOrder("Exact Match", "Overlap Start", "Overlap End");
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventRepositoryTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventRepositoryTest.java
@@ -138,4 +138,68 @@ class PersonalEventRepositoryTest {
         assertThat(events)
             .hasSize(4);
     }
+
+    @Test
+    @DisplayName("findAllByUserAndDateTimeRange: 날짜 필터 조건에 맞는 PersonalEvent를 정렬해서 조회")
+    void testFindAllByUserAndDateTimeRange() {
+        // Given: 테스트용 사용자 생성 및 persist
+        entityManager.persist(testUser);
+
+        // 필터링 조건
+        // 날짜 조건: 2025-02-09 (단일 날짜 범위)
+        LocalDateTime filterStartDate = LocalDateTime.of(2025, 2, 9, 7, 0);
+        LocalDateTime filterEndDate = LocalDateTime.of(2025, 2, 9, 15, 0);
+
+        // PersonalEvent 생성
+        PersonalEvent matchingEvent1 = PersonalEvent.builder()
+            .user(testUser)
+            .title("Matching Event")
+            .startTime(LocalDateTime.of(2025, 2, 9, 9, 0))
+            .endTime(LocalDateTime.of(2025, 2, 9, 11, 0))
+            .build();
+
+        PersonalEvent nonMatchingDateEvent = PersonalEvent.builder()
+            .user(testUser)
+            .title("Non Matching Date Event")
+            .startTime(LocalDateTime.of(2025, 2, 8, 10, 0))
+            .endTime(LocalDateTime.of(2025, 2, 8, 12, 0))
+            .build();
+
+        PersonalEvent matchingEvent2 = PersonalEvent.builder()
+            .user(testUser)
+            .title("Matching Time Event")
+            .startTime(LocalDateTime.of(2025, 2, 9, 8, 0))
+            .endTime(LocalDateTime.of(2025, 2, 20, 8, 30))
+            .build();
+
+
+        PersonalEvent matchingEvent3 = PersonalEvent.builder()
+            .user(testUser)
+            .title("Matching Event2")
+            .startTime(LocalDateTime.of(2025, 2, 9, 1, 0))
+            .endTime(LocalDateTime.of(2025, 2, 9, 7, 30))
+            .build();
+
+        PersonalEvent matchingEvent4 = PersonalEvent.builder()
+            .user(testUser)
+            .title("Matching Event3")
+            .startTime(LocalDateTime.of(2025, 2, 9, 14, 0))
+            .endTime(LocalDateTime.of(2025, 2, 9, 15, 0))
+            .build();
+
+        entityManager.persist(matchingEvent1);
+        entityManager.persist(nonMatchingDateEvent);
+        entityManager.persist(matchingEvent2);
+        entityManager.persist(matchingEvent3);
+        entityManager.persist(matchingEvent4);
+        entityManager.flush();
+        entityManager.clear();
+
+        // When: 필터 조건에 따라 이벤트 조회
+        List<PersonalEvent> events = personalEventRepository.findAllByUserAndDateTimeRange(
+            testUser.getId(), filterStartDate, filterEndDate);
+
+        // Then: "Matching Event"만 조회되어야 한다.
+        assertThat(events.size()).isEqualTo(4);
+    }
 }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #145 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
후보 일정의 상세 정보를 보는 기능을 구현하였습니다.
<img width="434" alt="스크린샷 2025-02-13 오전 10 58 38" src="https://github.com/user-attachments/assets/a86abf25-8677-4b25-a491-f0f355f82778" />


## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint that returns detailed candidate event data for discussions.
	- Enhanced the event planning experience by presenting personal events with clear status indicators (e.g., adjustable, fixed, out-of-range).
	- Improved the ordering of discussion participants to facilitate better coordination.

- **Bug Fixes**
	- Added specific error codes for better handling of user-related and discussion-related errors.

- **Tests**
	- Added comprehensive tests to validate the new event detail retrieval, ensure accurate time-range handling, and verify participant access scenarios.
	- Expanded tests for personal event status retrieval and behavior when no events are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->