### PR TITLE
[BE-Fix] 필요없는 googleEventId 삭제

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/personal_event/dto/PersonalEventResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/dto/PersonalEventResponse.java
@@ -9,7 +9,6 @@ public record PersonalEventResponse(
     LocalDateTime startDateTime,
     LocalDateTime endDateTime,
     Boolean isAdjustable,
-    String googleEventId,
     String calendarId
 ) {
     public static PersonalEventResponse fromEntity(PersonalEvent event) {
@@ -19,7 +18,6 @@ public record PersonalEventResponse(
             event.getStartTime(),
             event.getEndTime(),
             event.getIsAdjustable(),
-            event.getGoogleEventId(),
             event.getCalendarId()
         );
     }

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventControllerTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventControllerTest.java
@@ -50,7 +50,7 @@ class PersonalEventControllerTest {
         PersonalEventResponse personalEventResponse = new PersonalEventResponse(1L, "title",
             LocalDateTime.of(2025, 2, 2, 10, 0),
             LocalDateTime.of(2025, 2, 2, 12, 0),
-            false, "testEventId", "testCalendarId");
+            false, "testCalendarId");
         given(personalEventService.createPersonalEvent(any())).willReturn(personalEventResponse);
         MvcResult result = mockMvc.perform(post("/api/v1/personal-event").
                 contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #45 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
필요없는 값인 googleEventId를 응답에서 삭제했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the personal event details response by removing unnecessary information.
- **Tests**
	- Updated tests to align with the adjusted event response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->