### PR TITLE
[BE-Fix] 개인 일정 조회 파라미터를 api명세에 맞게 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventController.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.net.URI;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -52,10 +53,10 @@ public class PersonalEventController {
     })
     @GetMapping
     public ResponseEntity<ListResponse<PersonalEventResponse>> getPersonalEvents(
-        @Valid @NotNull @RequestParam LocalDateTime startDateTime,
-        @Valid @NotNull @RequestParam LocalDateTime endDateTime) {
+        @Valid @NotNull @RequestParam LocalDate startDate,
+        @Valid @NotNull @RequestParam LocalDate endDate) {
         ListResponse<PersonalEventResponse> response = personalEventService.listPersonalEvents(
-            startDateTime, endDateTime);
+            startDate, endDate);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -14,6 +14,7 @@ import endolphin.backend.global.error.exception.ErrorCode;
 import endolphin.backend.global.google.dto.GoogleEvent;
 import endolphin.backend.global.google.enums.GoogleEventStatus;
 import endolphin.backend.global.util.Validator;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -31,14 +32,14 @@ public class PersonalEventService {
     private final DiscussionParticipantService discussionParticipantService;
 
     @Transactional(readOnly = true)
-    public ListResponse<PersonalEventResponse> listPersonalEvents(LocalDateTime startDateTime,
-        LocalDateTime endDateTime) {
+    public ListResponse<PersonalEventResponse> listPersonalEvents(LocalDate startDate,
+        LocalDate endDate) {
         User user = userService.getCurrentUser();
 
-        Validator.validateDateTimeRange(startDateTime, endDateTime);
+        Validator.validateDateTimeRange(startDate, endDate);
 
         List<PersonalEventResponse> personalEventResponseList = personalEventRepository.findByUserAndStartTimeBetween(
-                user, startDateTime, endDateTime)
+                user, startDate.atStartOfDay(), endDate.atTime(23, 59))
             .stream().map(PersonalEventResponse::fromEntity).toList();
         return new ListResponse<>(personalEventResponseList);
     }

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -9,6 +9,7 @@ import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.dto.ListResponse;
+import java.time.LocalDate;
 import endolphin.backend.global.google.dto.GoogleEvent;
 import endolphin.backend.global.google.enums.GoogleEventStatus;
 import java.util.List;
@@ -66,8 +67,8 @@ class PersonalEventServiceTest {
         // Given
         given(userService.getCurrentUser()).willReturn(testUser);
 
-        LocalDateTime startDateTime = LocalDateTime.of(2025, 2, 2, 10, 0);
-        LocalDateTime endDateTime = LocalDateTime.of(2025, 2, 9, 10, 0);
+        LocalDate startDate = LocalDate.of(2025, 2, 2);
+        LocalDate endDate = LocalDate.of(2025, 2, 9);
 
         PersonalEvent personalEvent1 = createPersonalEvent("Meeting1", 2, testUser);
 
@@ -76,12 +77,12 @@ class PersonalEventServiceTest {
             personalEvent1, personalEvent2
         );
 
-        given(personalEventRepository.findByUserAndStartTimeBetween(testUser, startDateTime,
-            endDateTime)).willReturn(eventList);
+        given(personalEventRepository.findByUserAndStartTimeBetween(testUser, startDate.atStartOfDay(),
+            endDate.atTime(23, 59))).willReturn(eventList);
 
         // When
         ListResponse<PersonalEventResponse> response = personalEventService.listPersonalEvents(
-            startDateTime, endDateTime);
+            startDate, endDate);
 
         // Then
         assertThat(response.data().size()).isEqualTo(2);


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
기존 코드가 시간정보까지 받아오는 것으로 작성되어있어서 날짜만 받아오도록 수정했습니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the event retrieval process to use date-only inputs for filtering personal events instead of requiring specific times, streamlining how events are queried.
- **Tests**
  - Adjusted related tests to ensure compatibility with the new date-based filtering approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->