### PR TITLE
[BE-Feat] 논의 참여(초대 수락) API 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -166,7 +166,7 @@ public class DiscussionController {
     @Operation(summary = "논의 참가", description = "논의에 참가합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "참가 성공",
-            content = @Content(schema = @Schema(implementation = Boolean.class))),
+            content = @Content(schema = @Schema(implementation = JoinDiscussionResponse.class))),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "인증 실패",

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -13,6 +13,7 @@ import endolphin.backend.domain.discussion.dto.DiscussionParticipantsResponse;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.dto.InvitationInfo;
 import endolphin.backend.domain.discussion.dto.JoinDiscussionRequest;
+import endolphin.backend.domain.discussion.dto.JoinDiscussionResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.global.error.ErrorResponse;
@@ -178,9 +179,9 @@ public class DiscussionController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/{discussionId}/join")
-    public ResponseEntity<Boolean> joinInDiscussion(@PathVariable @Min(1) Long discussionId,
+    public ResponseEntity<JoinDiscussionResponse> joinInDiscussion(@PathVariable @Min(1) Long discussionId,
         @Valid @RequestBody JoinDiscussionRequest request) {
-        Boolean isSuccess = discussionService.joinDiscussion(discussionId, request);
+        JoinDiscussionResponse isSuccess = discussionService.joinDiscussion(discussionId, request);
         return ResponseEntity.ok(isSuccess);
     }
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -161,6 +161,28 @@ public class DiscussionController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "논의 참가", description = "논의에 참가합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "참가 성공",
+            content = @Content(schema = @Schema(implementation = Boolean.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "비밀번호 인증 5회 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "해당 논의 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/{discussionId}/join")
+    public ResponseEntity<Boolean> joinInDiscussion(@PathVariable @Min(1) Long discussionId,
+        @RequestBody String password) {
+        Boolean isSuccess = discussionService.joinDiscussion(discussionId, password);
+        return ResponseEntity.ok(isSuccess);
+    }
+
     @Operation(summary = "후보 일정 상세 정보", description = "후보 일정의 상세 정보를 조회합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "후보 일정 상세 정보 조회 성공",

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -12,6 +12,7 @@ import endolphin.backend.domain.discussion.dto.DiscussionInfo;
 import endolphin.backend.domain.discussion.dto.DiscussionParticipantsResponse;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.dto.InvitationInfo;
+import endolphin.backend.domain.discussion.dto.JoinDiscussionRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.global.error.ErrorResponse;
@@ -178,8 +179,8 @@ public class DiscussionController {
     })
     @PostMapping("/{discussionId}/join")
     public ResponseEntity<Boolean> joinInDiscussion(@PathVariable @Min(1) Long discussionId,
-        @RequestBody String password) {
-        Boolean isSuccess = discussionService.joinDiscussion(discussionId, password);
+        @Valid @RequestBody JoinDiscussionRequest request) {
+        Boolean isSuccess = discussionService.joinDiscussion(discussionId, request);
         return ResponseEntity.ok(isSuccess);
     }
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -171,7 +171,7 @@ public class DiscussionController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "인증 실패",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-        @ApiResponse(responseCode = "403", description = "비밀번호 인증 5회 실패",
+        @ApiResponse(responseCode = "403", description = "참가자 초과",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "해당 논의 없음",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -196,7 +196,8 @@ public class DiscussionService {
 
         List<UserInfoWithPersonalEvents> result0 =
             personalEventService.findUserInfoWithPersonalEventsByUsers(
-                participants, searchStartTime, searchEndTime, startTime, endTime, selectedUserIdMap);
+                participants, searchStartTime, searchEndTime, startTime, endTime,
+                selectedUserIdMap);
 
         List<UserInfoWithPersonalEvents> sortedResult = getSortedUserInfoWithPersonalEvents(
             result0, currentUser);
@@ -214,6 +215,10 @@ public class DiscussionService {
     public boolean joinDiscussion(Long discussionId, JoinDiscussionRequest request) {
         Discussion discussion = discussionRepository.findById(discussionId)
             .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_NOT_FOUND));
+
+        if (discussion.getDiscussionStatus() != DiscussionStatus.ONGOING) {
+            throw new ApiException(ErrorCode.DISCUSSION_NOT_ONGOING);
+        }
 
         User currentUser = userService.getCurrentUser();
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -5,6 +5,7 @@ import endolphin.backend.domain.discussion.dto.CandidateEventDetailsResponse;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionInfo;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
+import endolphin.backend.domain.discussion.dto.JoinDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.InvitationInfo;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.DiscussionStatus;
@@ -210,13 +211,13 @@ public class DiscussionService {
             .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_NOT_FOUND));
     }
 
-    public boolean joinDiscussion(Long discussionId, String password) {
+    public boolean joinDiscussion(Long discussionId, JoinDiscussionRequest request) {
         Discussion discussion = discussionRepository.findById(discussionId)
             .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_NOT_FOUND));
 
         User currentUser = userService.getCurrentUser();
 
-        if (hasDiscussionPassword(discussionId) && !checkPassword(discussion, password)) {
+        if (hasDiscussionPassword(discussionId) && !checkPassword(discussion, request.password())) {
             passwordCountService.increaseCount(currentUser.getId(), discussionId);
             return false;
         }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -216,7 +216,7 @@ public class DiscussionService {
 
         User currentUser = userService.getCurrentUser();
 
-        if(!checkPassword(discussion, password)) {
+        if (hasDiscussionPassword(discussionId) && !checkPassword(discussion, password)) {
             passwordCountService.increaseCount(currentUser.getId(), discussionId);
             return false;
         }
@@ -267,10 +267,18 @@ public class DiscussionService {
     }
 
     private boolean checkPassword(Discussion discussion, String password) {
-        if(password == null || password.isBlank()) {
+        if (password == null || password.isBlank()) {
             throw new ApiException(ErrorCode.PASSWORD_REQUIRED);
         }
 
         return passwordEncoder.matches(discussion.getId(), password, discussion.getPassword());
+    }
+
+    @Transactional(readOnly = true)
+    protected boolean hasDiscussionPassword(Long discussionId) {
+        Discussion discussion = discussionRepository.findById(discussionId)
+            .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_NOT_FOUND));
+
+        return discussion.getPassword() != null;
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/CreateDiscussionRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/CreateDiscussionRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -20,6 +21,6 @@ public record CreateDiscussionRequest(
     MeetingMethod meetingMethod,
     String location,
     @NotNull @Future LocalDate deadline,
-    @Size(min = 4) String password) {
+    @Size(min = 4, max = 6) @Pattern(regexp = "\\d+") String password) {
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/JoinDiscussionRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/JoinDiscussionRequest.java
@@ -1,0 +1,10 @@
+package endolphin.backend.domain.discussion.dto;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record JoinDiscussionRequest(
+    @Size(min = 4, max = 6) @Pattern(regexp = "\\d+") String password
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/JoinDiscussionResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/JoinDiscussionResponse.java
@@ -1,0 +1,8 @@
+package endolphin.backend.domain.discussion.dto;
+
+public record JoinDiscussionResponse(
+    boolean isSuccess,
+    int failedCount
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/global/config/RedisConfig.java
+++ b/backend/src/main/java/endolphin/backend/global/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -39,5 +40,13 @@ public class RedisConfig {
         template.setHashValueSerializer(RedisSerializer.byteArray());
         template.afterPropertiesSet();
         return template;
+    }
+
+    /**
+     * StringRedisTemplate for simple string data (논의 참가 시 인증 실패 횟수 관리)
+     */
+    @Bean
+    public StringRedisTemplate redisStringTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
     }
 }

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     DISCUSSION_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "Discussion not found"),
     EMPTY_SELECTED_USER_IDS(HttpStatus.BAD_REQUEST, "D002", "Empty Selected User IDs"),
     DISCUSSION_NOT_ONGOING(HttpStatus.BAD_REQUEST, "D002", "Discussion not ongoing"),
+    TOO_MANY_FAILED_ATTEMPTS(HttpStatus.FORBIDDEN, "D003", "Too many failed attempts"),
+    PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "D004", "Password required"),
 
     // PersonalEvent
     PERSONAL_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "Personal Event not found"),

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -15,9 +15,9 @@ public enum ErrorCode {
     // Discussion
     DISCUSSION_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "Discussion not found"),
     EMPTY_SELECTED_USER_IDS(HttpStatus.BAD_REQUEST, "D002", "Empty Selected User IDs"),
-    DISCUSSION_NOT_ONGOING(HttpStatus.BAD_REQUEST, "D002", "Discussion not ongoing"),
-    TOO_MANY_FAILED_ATTEMPTS(HttpStatus.FORBIDDEN, "D003", "Too many failed attempts"),
-    PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "D004", "Password required"),
+    DISCUSSION_NOT_ONGOING(HttpStatus.BAD_REQUEST, "D003", "Discussion not ongoing"),
+    TOO_MANY_FAILED_ATTEMPTS(HttpStatus.FORBIDDEN, "D004", "Too many failed attempts"),
+    PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "D005", "Password required"),
 
     // PersonalEvent
     PERSONAL_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "Personal Event not found"),
@@ -30,7 +30,7 @@ public enum ErrorCode {
     DISCUSSION_PARTICIPANT_EXCEED_LIMIT(HttpStatus.FORBIDDEN, "DP001", "Discussion participant exceed limit"),
     DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP002", "Discussion participant not found"),
     INVALID_DISCUSSION_PARTICIPANT(HttpStatus.BAD_REQUEST, "DP003", "Invalid Discussion participant"),
-    DISCUSSION_HOST_NOT_FOUND(HttpStatus.NOT_FOUND, "DP003", "Discussion host not found"),
+    DISCUSSION_HOST_NOT_FOUND(HttpStatus.NOT_FOUND, "DP004", "Discussion host not found"),
 
     //Calendar
     CALENDAR_UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "CA001", "Unauthorized"),

--- a/backend/src/main/java/endolphin/backend/global/redis/PasswordCountService.java
+++ b/backend/src/main/java/endolphin/backend/global/redis/PasswordCountService.java
@@ -1,0 +1,34 @@
+package endolphin.backend.global.redis;
+
+import endolphin.backend.global.error.exception.ApiException;
+import endolphin.backend.global.error.exception.ErrorCode;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordCountService {
+
+    private final StringRedisTemplate redisStringTemplate;
+
+    private static final int MAX_FAILED_ATTEMPTS = 5;
+    private static final long LOCKOUT_DURATION_MS = 5 * 60 * 1000;
+
+    public void increaseCount(Long userId, Long discussionId) {
+        String redisKey = "failedAttempts:" + discussionId + ":" + userId;
+
+        String countStr = redisStringTemplate.opsForValue().get(redisKey);
+        int failedAttemptsCount = countStr != null ? Integer.parseInt(countStr) : 0;
+
+        if (failedAttemptsCount >= MAX_FAILED_ATTEMPTS) {
+            throw new ApiException(ErrorCode.TOO_MANY_FAILED_ATTEMPTS);
+        }
+
+        Long updatedCount = redisStringTemplate.opsForValue().increment(redisKey);
+        if (updatedCount != null) {
+            redisStringTemplate.expire(redisKey, LOCKOUT_DURATION_MS, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -588,7 +588,7 @@ public class DiscussionServiceTest {
         Discussion discussion = Discussion.builder()
             .title("Test Discussion")
             .build();
-
+        ReflectionTestUtils.setField(discussion, "discussionStatus", DiscussionStatus.ONGOING);
         ReflectionTestUtils.setField(discussion, "id", 1L);
 
         discussion.setPassword(encodedPassword);
@@ -621,6 +621,7 @@ public class DiscussionServiceTest {
         Discussion discussion = Discussion.builder()
             .title("Test Discussion")
             .build();
+        ReflectionTestUtils.setField(discussion, "discussionStatus", DiscussionStatus.ONGOING);
 
         discussion.setPassword(encodedPassword);
 
@@ -654,6 +655,7 @@ public class DiscussionServiceTest {
         Discussion discussion = Discussion.builder()
             .title("Test Discussion")
             .build();
+        ReflectionTestUtils.setField(discussion, "discussionStatus", DiscussionStatus.ONGOING);
 
         discussion.setPassword("encodedPassword123");
 

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +34,7 @@ import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
 import endolphin.backend.global.redis.DiscussionBitmapService;
+import endolphin.backend.global.redis.PasswordCountService;
 import endolphin.backend.global.security.PasswordEncoder;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -76,6 +78,9 @@ public class DiscussionServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private PasswordCountService passwordCountService;
 
     @InjectMocks
     private DiscussionService discussionService;
@@ -571,4 +576,106 @@ public class DiscussionServiceTest {
         // 날짜 범위 검증 단계에서 예외가 발생하므로 다른 서비스들은 호출되지 않아야 함
         then(personalEventService).shouldHaveNoInteractions();
     }
+    @DisplayName("비밀번호가 일치할 때 논의 참여 성공")
+    @Test
+    public void joinDiscussion_withCorrectPassword_returnsTrue() {
+        // Given
+        Long discussionId = 1L;
+        String correctPassword = "password123";
+        String encodedPassword = "encodedPassword123";
+
+        Discussion discussion = Discussion.builder()
+            .title("Test Discussion")
+            .build();
+
+        ReflectionTestUtils.setField(discussion, "id", 1L);
+
+        discussion.setPassword(encodedPassword);
+
+        User currentUser = new User();
+        ReflectionTestUtils.setField(currentUser, "id", 1L);
+
+        when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
+        when(userService.getCurrentUser()).thenReturn(currentUser);
+        when(passwordEncoder.matches(discussionId, correctPassword, encodedPassword)).thenReturn(
+            true);
+
+        // When
+        boolean result = discussionService.joinDiscussion(discussionId, correctPassword);
+
+        // Then
+        assertThat(result).isTrue();
+        verify(discussionParticipantService).addDiscussionParticipant(discussion, currentUser);
+        verify(personalEventService).preprocessPersonalEvents(currentUser, discussion);
+    }
+
+    @DisplayName("비밀번호가 틀릴 때 논의 참여 실패")
+    @Test
+    public void joinDiscussion_withIncorrectPassword_returnsFalse() {
+        // Given
+        Long discussionId = 1L;
+        String incorrectPassword = "wrongPassword";
+        String encodedPassword = "encodedPassword123";
+
+        Discussion discussion = Discussion.builder()
+            .title("Test Discussion")
+            .build();
+
+        discussion.setPassword(encodedPassword);
+
+        ReflectionTestUtils.setField(discussion, "id", 1L);
+
+        User currentUser = new User();
+        ReflectionTestUtils.setField(currentUser, "id", 1L);
+
+        when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
+        when(userService.getCurrentUser()).thenReturn(currentUser);
+        when(passwordEncoder.matches(discussionId, incorrectPassword, encodedPassword)).thenReturn(
+            false);
+
+        // When
+        boolean result = discussionService.joinDiscussion(discussionId, incorrectPassword);
+
+        // Then
+        assertThat(result).isFalse();
+        verify(passwordCountService).increaseCount(currentUser.getId(), discussionId);
+        verify(discussionParticipantService, org.mockito.Mockito.never()).addDiscussionParticipant(
+            any(), any());
+        verify(personalEventService, org.mockito.Mockito.never()).preprocessPersonalEvents(any(),
+            any());
+    }
+
+    @DisplayName("비밀번호가 없을 때 예외 발생")
+    @Test
+    public void joinDiscussion_withNullPassword_throwsApiException() {
+        // Given
+        Long discussionId = 1L;
+        Discussion discussion = Discussion.builder()
+            .title("Test Discussion")
+            .build();
+
+        discussion.setPassword("encodedPassword123");
+
+        when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
+
+        // When & Then
+        assertThatThrownBy(() -> discussionService.joinDiscussion(discussionId, null))
+            .isInstanceOf(ApiException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_REQUIRED);
+    }
+
+    @DisplayName("존재하지 않는 논의 ID로 참여할 때 예외 발생")
+    @Test
+    public void joinDiscussion_withInvalidDiscussionId_throwsApiException() {
+        // Given
+        Long discussionId = 999L;
+        when(discussionRepository.findById(discussionId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> discussionService.joinDiscussion(discussionId, "password123"))
+            .isInstanceOf(ApiException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DISCUSSION_NOT_FOUND);
+    }
+
+
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -20,6 +20,7 @@ import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionInfo;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.dto.InvitationInfo;
+import endolphin.backend.domain.discussion.dto.JoinDiscussionRequest;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
@@ -601,7 +602,7 @@ public class DiscussionServiceTest {
             true);
 
         // When
-        boolean result = discussionService.joinDiscussion(discussionId, correctPassword);
+        boolean result = discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(correctPassword));
 
         // Then
         assertThat(result).isTrue();
@@ -634,7 +635,7 @@ public class DiscussionServiceTest {
             false);
 
         // When
-        boolean result = discussionService.joinDiscussion(discussionId, incorrectPassword);
+        boolean result = discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(incorrectPassword));
 
         // Then
         assertThat(result).isFalse();
@@ -659,7 +660,7 @@ public class DiscussionServiceTest {
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
 
         // When & Then
-        assertThatThrownBy(() -> discussionService.joinDiscussion(discussionId, null))
+        assertThatThrownBy(() -> discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(null)))
             .isInstanceOf(ApiException.class)
             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_REQUIRED);
     }
@@ -672,7 +673,7 @@ public class DiscussionServiceTest {
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> discussionService.joinDiscussion(discussionId, "password123"))
+        assertThatThrownBy(() -> discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest("password123")))
             .isInstanceOf(ApiException.class)
             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DISCUSSION_NOT_FOUND);
     }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -602,7 +602,7 @@ public class DiscussionServiceTest {
             true);
 
         // When
-        boolean result = discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(correctPassword));
+        boolean result = discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(correctPassword)).isSuccess();
 
         // Then
         assertThat(result).isTrue();
@@ -636,7 +636,7 @@ public class DiscussionServiceTest {
             false);
 
         // When
-        boolean result = discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(incorrectPassword));
+        boolean result = discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(incorrectPassword)).isSuccess();
 
         // Then
         assertThat(result).isFalse();

--- a/backend/src/test/java/endolphin/backend/global/redis/PasswordCountServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/redis/PasswordCountServiceTest.java
@@ -1,0 +1,79 @@
+package endolphin.backend.global.redis;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import endolphin.backend.global.error.exception.ApiException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+public class PasswordCountServiceTest {
+
+    @Mock
+    private StringRedisTemplate redisStringTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private PasswordCountService passwordCountService;
+
+    @BeforeEach
+    public void setUp() {
+        // StringRedisTemplate의 opsForValue() 호출 시 mock ValueOperations 반환
+        when(redisStringTemplate.opsForValue()).thenReturn(valueOperations);
+        passwordCountService = new PasswordCountService(redisStringTemplate);
+    }
+
+    @Test
+    public void testIncreaseCount_Success_FirstFailure() {
+        Long userId = 1L;
+        Long discussionId = 1L;
+        String redisKey = "failedAttempts:" + discussionId + ":" + userId;
+
+        // 이전에 값이 없으면 null 반환 (즉, 첫 실패)
+        when(valueOperations.get(redisKey)).thenReturn(null);
+        // 증가 후 값으로 1 반환
+        when(valueOperations.increment(redisKey)).thenReturn(1L);
+
+        passwordCountService.increaseCount(userId, discussionId);
+
+        // 첫 실패시 expire가 설정되어야 함 (5분 = 5*60*1000 밀리초)
+        verify(redisStringTemplate).expire(eq(redisKey), eq(5 * 60 * 1000L), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testIncreaseCount_Success_SubsequentFailure() {
+        Long userId = 2L;
+        Long discussionId = 10L;
+        String redisKey = "failedAttempts:" + discussionId + ":" + userId;
+
+        when(valueOperations.get(redisKey)).thenReturn("2");
+
+        when(valueOperations.increment(redisKey)).thenReturn(3L);
+
+        passwordCountService.increaseCount(userId, discussionId);
+    }
+
+    @Test
+    public void testIncreaseCount_ExceedsMaxAttempts() {
+        Long userId = 3L;
+        Long discussionId = 20L;
+        String redisKey = "failedAttempts:" + discussionId + ":" + userId;
+
+        when(valueOperations.get(redisKey)).thenReturn("5");
+
+        ApiException exception = assertThrows(ApiException.class, () ->
+            passwordCountService.increaseCount(userId, discussionId)
+        );
+
+    }
+}


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #174 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- password 인증 실패 횟수를 redis에 저장하고 사용합니다.
- joinDiscussion 메서드 구현하였습니다.
- DiscussionController에 초대 수락 api 매핑했습니다.
- 관련 테스트 코드 추가했습니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
5번 실패시 403 forbidden으로 처리했습니다. 검토 부탁드려요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new discussion join option that enables users to participate in discussions using password verification.
	- Updated password requirements to enforce a valid 4-6 digit numeric password.
	- Enhanced error handling to notify users after excessive failed attempts, improving the overall join experience.
	- Added new data transfer objects for join discussion requests and responses.

- **Bug Fixes**
	- Improved handling of invalid discussion IDs and null passwords, ensuring appropriate error messages are returned.

- **Tests**
	- Added comprehensive unit tests for discussion joining functionality and password handling scenarios, including edge cases for failed attempts.

- **Documentation**
	- Updated error codes to include specific messages for failed attempts and password requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->