### PR TITLE
[BE-Feat] 논의 상태 변경 scheduler 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionRepository.java
@@ -1,10 +1,14 @@
 package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.discussion.enums.DiscussionStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
+
+    List<Discussion> findByDiscussionStatusNot(DiscussionStatus discussionStatus);
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventRepository.java
@@ -2,6 +2,7 @@ package endolphin.backend.domain.shared_event;
 
 import endolphin.backend.domain.shared_event.entity.SharedEvent;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface SharedEventRepository extends JpaRepository<SharedEvent, Long> {
 
     public List<SharedEvent> findByDiscussionIdIn(List<Long> discussionIds);
+
+    Optional<SharedEvent> findByDiscussionId(Long discussionId);
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
@@ -35,8 +35,8 @@ public class SharedEventService {
     }
 
     @Transactional(readOnly = true)
-    public SharedEventDto getSharedEvent(Long sharedEventId) {
-        SharedEvent sharedEvent = sharedEventRepository.findById(sharedEventId)
+    public SharedEventDto getSharedEvent(Long discussionId) {
+        SharedEvent sharedEvent = sharedEventRepository.findByDiscussionId(discussionId)
             .orElseThrow(() -> new ApiException(ErrorCode.SHARED_EVENT_NOT_FOUND));
 
         return SharedEventDto.of(sharedEvent);

--- a/backend/src/main/java/endolphin/backend/global/config/EnableSchedulingConfig.java
+++ b/backend/src/main/java/endolphin/backend/global/config/EnableSchedulingConfig.java
@@ -1,0 +1,10 @@
+package endolphin.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class EnableSchedulingConfig {
+
+}

--- a/backend/src/main/java/endolphin/backend/global/scheduler/DiscussionStatusScheduler.java
+++ b/backend/src/main/java/endolphin/backend/global/scheduler/DiscussionStatusScheduler.java
@@ -25,7 +25,8 @@ public class DiscussionStatusScheduler {
         LocalDate today = LocalDate.now();
         log.info("Scheduler 실행: {}. 논의 상태 업데이트 시작", today);
 
-        List<Discussion> discussions = discussionRepository.findAll();
+        List<Discussion> discussions = discussionRepository.findByDiscussionStatusNot(
+            DiscussionStatus.FINISHED);
 
         for (Discussion discussion : discussions) {
             try {

--- a/backend/src/main/java/endolphin/backend/global/scheduler/DiscussionStatusScheduler.java
+++ b/backend/src/main/java/endolphin/backend/global/scheduler/DiscussionStatusScheduler.java
@@ -1,0 +1,61 @@
+package endolphin.backend.global.scheduler;
+
+import endolphin.backend.domain.discussion.DiscussionRepository;
+import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.discussion.enums.DiscussionStatus;
+import endolphin.backend.domain.shared_event.SharedEventService;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DiscussionStatusScheduler {
+
+    private final DiscussionRepository discussionRepository;
+    private final SharedEventService sharedEventService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateDiscussionStatusAtMidnight() {
+        LocalDate today = LocalDate.now();
+        log.info("Scheduler 실행: {}. 논의 상태 업데이트 시작", today);
+
+        List<Discussion> discussions = discussionRepository.findAll();
+
+        for (Discussion discussion : discussions) {
+            try {
+                updateStatus(discussion, today);
+            } catch (Exception e) {
+                log.error("Discussion id {} 업데이트 실패: {}", discussion.getId(), e.getMessage());
+            }
+        }
+    }
+
+    @Transactional
+    public void updateStatus(Discussion discussion, LocalDate today) {
+        switch (discussion.getDiscussionStatus()) {
+            case ONGOING:
+                if (discussion.getDateRangeEnd().isBefore(today)) {
+                    discussion.setDiscussionStatus(DiscussionStatus.FINISHED);
+                    discussionRepository.save(discussion);
+                    log.info("Discussion id {} FINISHED", discussion.getId());
+                }
+                break;
+            case UPCOMING:
+                if (sharedEventService.getSharedEvent(discussion.getId()).endDateTime()
+                    .toLocalDate().isBefore(today)) {
+                    discussion.setDiscussionStatus(DiscussionStatus.FINISHED);
+                    discussionRepository.save(discussion);
+                    log.info("Discussion id {} FINISHED", discussion.getId());
+                }
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
@@ -80,20 +80,19 @@ class SharedEventServiceTest {
     @DisplayName("공유 일정 조회 성공")
     @Test
     void getSharedEvent_Success() {
-        when(sharedEventRepository.findById(100L)).thenReturn(Optional.of(sharedEvent));
+        when(sharedEventRepository.findByDiscussionId(100L)).thenReturn(Optional.of(sharedEvent));
 
         SharedEventDto response = sharedEventService.getSharedEvent(100L);
 
         assertThat(response).isNotNull();
-        assertThat(response.id()).isEqualTo(100L);
 
-        verify(sharedEventRepository, times(1)).findById(100L);
+        verify(sharedEventRepository, times(1)).findByDiscussionId(100L);
     }
 
     @DisplayName("존재하지 않는 공유 일정 조회에 대한 에러 응답 테스트")
     @Test
     void getSharedEvent_NotFound_ThrowsException() {
-        when(sharedEventRepository.findById(999L)).thenReturn(Optional.empty());
+        when(sharedEventRepository.findByDiscussionId(999L)).thenReturn(Optional.empty());
 
         ApiException exception = (ApiException) catchThrowable(() ->
             sharedEventService.getSharedEvent(999L)
@@ -106,7 +105,7 @@ class SharedEventServiceTest {
             ErrorCode.SHARED_EVENT_NOT_FOUND.getMessage());
         assertThat(errorResponse.code()).isEqualTo(ErrorCode.SHARED_EVENT_NOT_FOUND.getCode());
 
-        verify(sharedEventRepository, times(1)).findById(999L);
+        verify(sharedEventRepository, times(1)).findByDiscussionId(999L);
     }
 
     @DisplayName("공유 일정 삭제 성공")

--- a/backend/src/test/java/endolphin/backend/global/scheduler/DiscussionStatusSchedulerTest.java
+++ b/backend/src/test/java/endolphin/backend/global/scheduler/DiscussionStatusSchedulerTest.java
@@ -1,0 +1,152 @@
+package endolphin.backend.global.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import endolphin.backend.domain.discussion.DiscussionRepository;
+import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.discussion.enums.DiscussionStatus;
+import endolphin.backend.domain.discussion.enums.MeetingMethod;
+import endolphin.backend.domain.shared_event.SharedEventService;
+import endolphin.backend.domain.shared_event.dto.SharedEventDto;
+import endolphin.backend.global.error.exception.ApiException;
+import endolphin.backend.global.error.exception.ErrorCode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DiscussionStatusSchedulerTest {
+
+    @Mock
+    private DiscussionRepository discussionRepository;
+
+    @Mock
+    private SharedEventService sharedEventService;
+
+    @InjectMocks
+    private DiscussionStatusScheduler scheduler;
+
+    @DisplayName("ONGOING 논의의 날짜 범위가 오늘보다 이전인 경우 상태를 FINISHED로 변경")
+    @Test
+    void updateStatus_ongoingDiscussion_dateRangeEndBeforeToday_updatesStatusToFinished() {
+        LocalDate today = LocalDate.now();
+        Discussion discussion = Discussion.builder()
+            .title("Test Discussion")
+            .dateStart(today.minusDays(10))
+            .dateEnd(today.minusDays(1))
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(10, 0))
+            .duration(60)
+            .deadline(today.plusDays(1))
+            .meetingMethod(MeetingMethod.OFFLINE)
+            .location("Room 1")
+            .build();
+        discussion.setDiscussionStatus(DiscussionStatus.ONGOING);
+
+        scheduler.updateStatus(discussion, today);
+
+        assertEquals(DiscussionStatus.FINISHED, discussion.getDiscussionStatus());
+        verify(discussionRepository).save(discussion);
+    }
+
+    @DisplayName("UPCOMING 논의의 공유 일정 종료 시간이 오늘보다 이전인 경우 상태를 FINISHED로 변경")
+    @Test
+    void updateStatus_upcomingDiscussion_sharedEventEndDateBeforeToday_updatesStatusToFinished() {
+        // Arrange
+        LocalDate today = LocalDate.now();
+        Discussion discussion = Discussion.builder()
+            .title("Upcoming Discussion")
+            .dateStart(today.plusDays(1))
+            .dateEnd(today.plusDays(2))
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(10, 0))
+            .duration(60)
+            .deadline(today.plusDays(3))
+            .meetingMethod(MeetingMethod.ONLINE)
+            .location(null)
+            .build();
+        discussion.setDiscussionStatus(DiscussionStatus.UPCOMING);
+
+        SharedEventDto sharedEvent = mock(SharedEventDto.class);
+        when(sharedEvent.endDateTime()).thenReturn(LocalDateTime.of(today.minusDays(1), LocalTime.of(23, 59, 59)));
+        when(sharedEventService.getSharedEvent(discussion.getId())).thenReturn(sharedEvent);
+
+        scheduler.updateStatus(discussion, today);
+
+        assertEquals(DiscussionStatus.FINISHED, discussion.getDiscussionStatus());
+        verify(discussionRepository).save(discussion);
+    }
+
+    @Test
+    void updateStatus_discussionDoesNotMeetCriteria_noUpdate() {
+        // Arrange
+        LocalDate today = LocalDate.now();
+        Discussion discussion = Discussion.builder()
+            .title("Ongoing Discussion")
+            .dateStart(today.minusDays(5))
+            .dateEnd(today.plusDays(1)) // 종료일이 아직 도래하지 않음
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(10, 0))
+            .duration(60)
+            .deadline(today.plusDays(2))
+            .meetingMethod(MeetingMethod.OFFLINE)
+            .location("Room 1")
+            .build();
+        discussion.setDiscussionStatus(DiscussionStatus.ONGOING);
+
+        scheduler.updateStatus(discussion, today);
+
+        assertEquals(DiscussionStatus.ONGOING, discussion.getDiscussionStatus());
+        verify(discussionRepository, never()).save(discussion);
+    }
+
+    @DisplayName("에러 발생해도 다른 논의의 상태를 업데이트")
+    @Test
+    void updateDiscussionStatusAtMidnight_handlesExceptionAndContinues() {
+        LocalDate today = LocalDate.now();
+
+        Discussion discussion1 = Discussion.builder()
+            .title("Discussion 1")
+            .dateStart(today.minusDays(10))
+            .dateEnd(today.minusDays(1))
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(10, 0))
+            .duration(60)
+            .deadline(today.plusDays(1))
+            .meetingMethod(MeetingMethod.OFFLINE)
+            .location("Room 1")
+            .build();
+        discussion1.setDiscussionStatus(DiscussionStatus.ONGOING);
+
+        Discussion discussion2 = Discussion.builder()
+            .title("Discussion 2")
+            .dateStart(today.minusDays(10))
+            .dateEnd(today.minusDays(1))
+            .timeStart(LocalTime.of(10, 0))
+            .timeEnd(LocalTime.of(11, 0))
+            .duration(60)
+            .deadline(today.plusDays(1))
+            .meetingMethod(MeetingMethod.OFFLINE)
+            .location("Room 2")
+            .build();
+        discussion2.setDiscussionStatus(DiscussionStatus.ONGOING);
+
+        when(discussionRepository.findAll()).thenReturn(List.of(discussion1, discussion2));
+
+        doThrow(new ApiException(ErrorCode.SHARED_EVENT_NOT_FOUND)).when(discussionRepository).save(discussion1);
+
+        scheduler.updateDiscussionStatusAtMidnight();
+
+        assertEquals(DiscussionStatus.FINISHED, discussion2.getDiscussionStatus());
+        verify(discussionRepository).save(discussion1);
+        verify(discussionRepository).save(discussion2);
+    }
+}

--- a/backend/src/test/java/endolphin/backend/global/scheduler/DiscussionStatusSchedulerTest.java
+++ b/backend/src/test/java/endolphin/backend/global/scheduler/DiscussionStatusSchedulerTest.java
@@ -139,7 +139,7 @@ public class DiscussionStatusSchedulerTest {
             .build();
         discussion2.setDiscussionStatus(DiscussionStatus.ONGOING);
 
-        when(discussionRepository.findAll()).thenReturn(List.of(discussion1, discussion2));
+        when(discussionRepository.findByDiscussionStatusNot(DiscussionStatus.FINISHED)).thenReturn(List.of(discussion1, discussion2));
 
         doThrow(new ApiException(ErrorCode.SHARED_EVENT_NOT_FOUND)).when(discussionRepository).save(discussion1);
 


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #178 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- enableScheduling config 추가했습니다.
- DiscussionStatusScheduler에서 매일 자정 status 변경 수행합니다.
- 관련 테스트 코드 추가했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
논의 상태가 UPCOMING인데 sharedEvent가 존재하지 않는 경우가 발생할 수 있을까요? 의견 주시면 감사합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated background process that updates discussion statuses daily based on scheduled dates, ensuring conversations are managed accurately.
	- Added a new method to filter discussions by status in the discussion repository.
	- Added a method to retrieve shared events based on discussion IDs.

- **Bug Fixes**
	- Updated the shared event retrieval method to focus on discussion IDs, enhancing data accuracy.

- **Tests**
	- Added comprehensive tests to validate the new scheduling automation across multiple scenarios, including error handling, to enhance system reliability.
	- Updated tests to reflect changes in shared event retrieval logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->