### PR TITLE
[BE-Feat] 논의 정보 조회, 초대장 정보 조회 API 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -8,6 +8,7 @@ import endolphin.backend.domain.candidate_event.dto.RankViewResponse;
 import endolphin.backend.domain.discussion.dto.CandidateEventDetailsRequest;
 import endolphin.backend.domain.discussion.dto.CandidateEventDetailsResponse;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
+import endolphin.backend.domain.discussion.dto.DiscussionInfo;
 import endolphin.backend.domain.discussion.dto.DiscussionParticipantsResponse;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
@@ -54,6 +55,13 @@ public class DiscussionController {
         DiscussionResponse response = discussionService.createDiscussion(request);
         URI location = URIUtil.buildResourceUri(response.id());
         return ResponseEntity.created(location).body(response);
+    }
+
+    @GetMapping("/{discussionId}")
+    public ResponseEntity<DiscussionInfo> getDiscussionInfo(
+        @PathVariable @Min(1) Long discussionId) {
+        DiscussionInfo discussionInfo = discussionService.getDiscussionInfo(discussionId);
+        return ResponseEntity.ok(discussionInfo);
     }
 
     @Operation(summary = "논의 확정", description = "후보 일정을 해당 논의의 공유 일정으로 확정합니다.")

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -11,6 +11,7 @@ import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionInfo;
 import endolphin.backend.domain.discussion.dto.DiscussionParticipantsResponse;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
+import endolphin.backend.domain.discussion.dto.InvitationInfo;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.global.error.ErrorResponse;
@@ -62,6 +63,13 @@ public class DiscussionController {
         @PathVariable @Min(1) Long discussionId) {
         DiscussionInfo discussionInfo = discussionService.getDiscussionInfo(discussionId);
         return ResponseEntity.ok(discussionInfo);
+    }
+
+    @GetMapping("/{discussionId}/invite")
+    public ResponseEntity<InvitationInfo> getInvitationInfo(
+        @PathVariable @Min(1) Long discussionId) {
+        InvitationInfo invitationInfo = discussionService.getInvitationInfo(discussionId);
+        return ResponseEntity.ok(invitationInfo);
     }
 
     @Operation(summary = "논의 확정", description = "후보 일정을 해당 논의의 공유 일정으로 확정합니다.")

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -58,6 +58,19 @@ public class DiscussionController {
         return ResponseEntity.created(location).body(response);
     }
 
+    @Operation(summary = "논의 정보 조회", description = "논의 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "논의 정보 조회 성공",
+            content = @Content(schema = @Schema(implementation = DiscussionInfo.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "해당 논의 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping("/{discussionId}")
     public ResponseEntity<DiscussionInfo> getDiscussionInfo(
         @PathVariable @Min(1) Long discussionId) {
@@ -65,6 +78,19 @@ public class DiscussionController {
         return ResponseEntity.ok(discussionInfo);
     }
 
+    @Operation(summary = "초대장 정보 조회", description = "논의 초대장 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "초대장 정보 조회 성공",
+            content = @Content(schema = @Schema(implementation = InvitationInfo.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "해당 논의 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping("/{discussionId}/invite")
     public ResponseEntity<InvitationInfo> getInvitationInfo(
         @PathVariable @Min(1) Long discussionId) {

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -74,4 +74,11 @@ public interface DiscussionParticipantRepository extends
         "AND dp.user.id = :userId")
     Optional<Boolean> findIsHostByDiscussionIdAndUserId(@Param("discussionId") Long discussionId,
         @Param("userId") Long userId);
+
+    @Query("SELECT u.name " +
+        "FROM DiscussionParticipant dp " +
+        "JOIN dp.user u " +
+        "WHERE dp.discussion.id = :discussionId " +
+        "AND dp.isHost = true")
+    Optional<String> findHostNameByDiscussionIdAndIsHost(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -21,6 +21,7 @@ public class DiscussionParticipantService {
 
     private final DiscussionParticipantRepository discussionParticipantRepository;
     private final UserService userService;
+    private static final int MAX_PARTICIPANT = 15;
 
     public void addDiscussionParticipant(Discussion discussion, User user) {
         Long offset = discussionParticipantRepository.findMaxOffsetByDiscussionId(
@@ -28,7 +29,7 @@ public class DiscussionParticipantService {
 
         offset += 1;
 
-        if (offset >= 15) {
+        if (offset >= MAX_PARTICIPANT) {
             throw new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_EXCEED_LIMIT);
         }
 
@@ -76,7 +77,7 @@ public class DiscussionParticipantService {
         int filter = 0;
 
         for (Long offset : userOffsets) {
-            filter |= (1 << 15 - offset);
+            filter |= (1 << MAX_PARTICIPANT - offset);
         }
 
         return filter;
@@ -90,8 +91,8 @@ public class DiscussionParticipantService {
 
         List<Long> userOffsets = new ArrayList<>();
 
-        for (int i = 0; i < 16; i++) {
-            if ((data & (1 << (15 - i))) != 0) {
+        for (int i = 0; i < MAX_PARTICIPANT + 1; i++) {
+            if ((data & (1 << (MAX_PARTICIPANT - i))) != 0) {
                 userOffsets.add((long) i);
             }
         }
@@ -134,6 +135,6 @@ public class DiscussionParticipantService {
     @Transactional(readOnly = true)
     public Boolean isFull(Long discussionId) {
         Long offset = discussionParticipantRepository.findMaxOffsetByDiscussionId(discussionId);
-        return offset >= 14;
+        return offset >= MAX_PARTICIPANT - 1;
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -124,4 +124,15 @@ public class DiscussionParticipantService {
         return discussionParticipantRepository.findIsHostByDiscussionIdAndUserId(discussionId, user.getId())
             .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND));
     }
+
+    @Transactional(readOnly = true)
+    public String getHostNameByDiscussionId(Long discussionId) {
+        return discussionParticipantRepository.findHostNameByDiscussionIdAndIsHost(discussionId)
+            .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_HOST_NOT_FOUND));
+    }
+
+    public Boolean isFull(Long discussionId) {
+        Long offset = discussionParticipantRepository.findMaxOffsetByDiscussionId(discussionId);
+        return offset >= 14;
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -131,6 +131,7 @@ public class DiscussionParticipantService {
             .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_HOST_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
     public Boolean isFull(Long discussionId) {
         Long offset = discussionParticipantRepository.findMaxOffsetByDiscussionId(discussionId);
         return offset >= 14;

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -3,6 +3,7 @@ package endolphin.backend.domain.discussion;
 import endolphin.backend.domain.discussion.dto.CandidateEventDetailsRequest;
 import endolphin.backend.domain.discussion.dto.CandidateEventDetailsResponse;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
+import endolphin.backend.domain.discussion.dto.DiscussionInfo;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.DiscussionStatus;
@@ -87,7 +88,7 @@ public class DiscussionService {
         Discussion discussion = discussionRepository.findById(discussionId)
             .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_NOT_FOUND));
 
-        if(discussion.getDiscussionStatus() != DiscussionStatus.ONGOING) {
+        if (discussion.getDiscussionStatus() != DiscussionStatus.ONGOING) {
             throw new ApiException(ErrorCode.DISCUSSION_NOT_ONGOING);
         }
 
@@ -120,6 +121,24 @@ public class DiscussionService {
             discussion.getMeetingMethodOrLocation(),
             sharedEventDto,
             participantPictures
+        );
+    }
+
+    public DiscussionInfo getDiscussionInfo(Long discussionId) {
+        Discussion discussion = getDiscussionById(discussionId);
+
+        return new DiscussionInfo(
+            discussionId,
+            discussion.getTitle(),
+            discussion.getDateRangeStart(),
+            discussion.getDateRangeEnd(),
+            discussion.getTimeRangeStart(),
+            discussion.getTimeRangeEnd(),
+            discussion.getMeetingMethod(),
+            discussion.getLocation(),
+            discussion.getDuration(),
+            discussion.getDeadline(),
+            calculateTimeLeft(discussion.getDeadline())
         );
     }
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -5,6 +5,7 @@ import endolphin.backend.domain.discussion.dto.CandidateEventDetailsResponse;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionInfo;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
+import endolphin.backend.domain.discussion.dto.InvitationInfo;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.personal_event.PersonalEventService;
@@ -139,6 +140,22 @@ public class DiscussionService {
             discussion.getDuration(),
             discussion.getDeadline(),
             calculateTimeLeft(discussion.getDeadline())
+        );
+    }
+
+    public InvitationInfo getInvitationInfo(Long discussionId) {
+        Discussion discussion = getDiscussionById(discussionId);
+
+        return new InvitationInfo(
+            discussionParticipantService.getHostNameByDiscussionId(discussionId),
+            discussion.getTitle(),
+            discussion.getDateRangeStart(),
+            discussion.getDateRangeEnd(),
+            discussion.getTimeRangeStart(),
+            discussion.getTimeRangeEnd(),
+            discussion.getDuration(),
+            discussionParticipantService.isFull(discussionId),
+            discussion.getPassword() != null
         );
     }
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/DiscussionInfo.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/DiscussionInfo.java
@@ -1,0 +1,20 @@
+package endolphin.backend.domain.discussion.dto;
+
+import endolphin.backend.domain.discussion.enums.MeetingMethod;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record DiscussionInfo(
+    Long id,
+    String title,
+    LocalDate dateRangeStart,
+    LocalDate dateRangeEnd,
+    LocalTime timeRangeStart,
+    LocalTime timeRangeEnd,
+    MeetingMethod meetingMethod,
+    String location,
+    Integer duration,
+    LocalDate deadline,
+    Long timeLeft) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/InvitationInfo.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/InvitationInfo.java
@@ -1,0 +1,18 @@
+package endolphin.backend.domain.discussion.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record InvitationInfo(
+    String host,
+    String title,
+    LocalDate dateRangeStart,
+    LocalDate dateRangeEnd,
+    LocalTime timeRangeStart,
+    LocalTime timeRangeEnd,
+    Integer duration,
+    Boolean isFull,
+    Boolean requirePassword
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     DISCUSSION_PARTICIPANT_EXCEED_LIMIT(HttpStatus.FORBIDDEN, "DP001", "Discussion participant exceed limit"),
     DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP002", "Discussion participant not found"),
     INVALID_DISCUSSION_PARTICIPANT(HttpStatus.BAD_REQUEST, "DP003", "Invalid Discussion participant"),
+    DISCUSSION_HOST_NOT_FOUND(HttpStatus.NOT_FOUND, "DP003", "Discussion host not found"),
 
     //Calendar
     CALENDAR_UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "CA001", "Unauthorized"),

--- a/backend/src/main/java/endolphin/backend/global/security/JwtAuthFilter.java
+++ b/backend/src/main/java/endolphin/backend/global/security/JwtAuthFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import java.util.Arrays;
@@ -67,7 +68,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             "/h2-console" // prod profile에서는 h2-console 접근 불가
         );
 
+        Pattern invitePattern = Pattern.compile("^/api/v1/discussion/\\d+/invite$");
+
         return "OPTIONS".equalsIgnoreCase(request.getMethod()) ||
-            excludedPaths.stream().anyMatch(path::startsWith);
+            excludedPaths.stream().anyMatch(path::startsWith) ||
+            invitePattern.matcher(path).matches();
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
@@ -199,4 +199,55 @@ class DiscussionParticipantServiceTest {
         // Then
         assertThat(result).isEqualTo(dtos);
     }
+
+    @Test
+    @DisplayName("호스트 이름 조회 - 성공")
+    void getHostNameByDiscussionId_ShouldReturnHostName() {
+        Long discussionId = 1L;
+        String hostName = "HostName";
+        given(discussionParticipantRepository.findHostNameByDiscussionIdAndIsHost(discussionId))
+            .willReturn(Optional.of(hostName));
+
+        String result = discussionParticipantService.getHostNameByDiscussionId(discussionId);
+
+        assertThat(result).isEqualTo(hostName);
+    }
+
+    @Test
+    @DisplayName("호스트 이름 조회 - 존재하지 않을 경우 예외 발생")
+    void getHostNameByDiscussionId_ShouldThrowExceptionIfNotFound() {
+        Long discussionId = 1L;
+        given(discussionParticipantRepository.findHostNameByDiscussionIdAndIsHost(discussionId))
+            .willReturn(Optional.empty());
+
+        ApiException exception = assertThrows(ApiException.class, () ->
+            discussionParticipantService.getHostNameByDiscussionId(discussionId)
+        );
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DISCUSSION_HOST_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("논의가 꽉 차지 않았을 때 isFull이 false를 반환")
+    void isFull_ShouldReturnFalseWhenOffsetLessThanLimit() {
+        Long discussionId = 1L;
+        given(discussionParticipantRepository.findMaxOffsetByDiscussionId(discussionId))
+            .willReturn(10L);
+
+        Boolean result = discussionParticipantService.isFull(discussionId);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("논의가 꽉 찼을 때 isFull이 true를 반환")
+    void isFull_ShouldReturnTrueWhenOffsetAtOrAboveLimit() {
+        Long discussionId = 1L;
+        given(discussionParticipantRepository.findMaxOffsetByDiscussionId(discussionId))
+            .willReturn(14L);
+
+        Boolean result = discussionParticipantService.isFull(discussionId);
+
+        assertThat(result).isTrue();
+    }
+
 }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #143 
- #177 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 논의 정보 조회 api 구현했습니다.
- 초대장 정보 조회 api 구현했습니다.
- users join하여 host 이름 조회하는 메서드 추가했습니다.
- 관련 테스트 코드 추가했습니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new methods for retrieving detailed discussion and invitation information, including host identification and scheduling details.
	- Enhanced security to allow invitation requests to bypass standard authentication checks.
	- Improved error messaging for scenarios where discussion host information is missing.

- **Tests**
	- Expanded test coverage for discussion and invitation functionalities to ensure reliable behavior under various scenarios.
	- Added tests for host name retrieval and discussion fullness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->