### PR TITLE
[BE-Fix] 재로그인 버그 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -159,7 +159,8 @@ public class PersonalEventService {
                     }
                 },
                 () -> {
-                    PersonalEvent personalEvent = PersonalEvent.from(googleEvent, user);
+                    PersonalEvent personalEvent =
+                        PersonalEvent.fromGoogleEvent(googleEvent, user, googleCalendarId);
                     personalEventRepository.save(personalEvent);
                     // 비트맵 수정
                     discussions.forEach(discussion -> {

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
@@ -81,13 +81,15 @@ public class PersonalEvent extends BaseTimeEntity {
             .build();
     }
 
-    public static PersonalEvent from(GoogleEvent googleEvent, User user) {
+    public static PersonalEvent fromGoogleEvent(GoogleEvent googleEvent, User user,
+        String googleCalenderId) {
         return PersonalEvent.builder()
             .title(googleEvent.summary())
             .startTime(googleEvent.startDateTime())
             .endTime(googleEvent.endDateTime())
             .googleEventId(googleEvent.eventId())
             .isAdjustable(false)
+            .calendarId(googleCalenderId)
             .user(user)
             .build();
     }

--- a/backend/src/main/java/endolphin/backend/global/config/GoogleCalendarProperties.java
+++ b/backend/src/main/java/endolphin/backend/global/config/GoogleCalendarProperties.java
@@ -1,0 +1,10 @@
+package endolphin.backend.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "google.calendar.api")
+public record GoogleCalendarProperties(
+    int subscribeDuration
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/global/config/GoogleCalendarUrl.java
+++ b/backend/src/main/java/endolphin/backend/global/config/GoogleCalendarUrl.java
@@ -2,7 +2,7 @@ package endolphin.backend.global.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "google.calendar")
+@ConfigurationProperties(prefix = "google.calendar.url")
 public record GoogleCalendarUrl(
     String calendarListUrl,
     String subscribeUrl,

--- a/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import endolphin.backend.domain.calendar.CalendarService;
 import endolphin.backend.domain.calendar.entity.Calendar;
@@ -67,9 +68,9 @@ class GoogleCalendarServiceTest {
         // Then
         then(calendarService).should().isExistingCalendar(user.getId());
         then(calendarService).should().getCalendarByUserId(user.getId());
+        then(googleCalendarService).should(times(1)).subscribeToCalendar(any(), any());
 
         // 신규 캘린더 생성, 이벤트 동기화, 캘린더 채널 구독은 발생하지 않아야 합니다.
-        then(googleCalendarService).should(never()).subscribeToCalendar(any(), any());
         then(calendarService).should(never()).createCalendar(any(), eq(user));
         then(personalEventService).should(never()).syncWithGoogleEvents(any(), eq(user), anyString());
     }
@@ -118,7 +119,6 @@ class GoogleCalendarServiceTest {
         given(user.getId()).willReturn(1L);
         given(calendarService.isExistingCalendar(user.getId())).willReturn(true);
         Calendar calendar = Mockito.mock(Calendar.class);
-        given(calendar.getChannelExpiration()).willReturn(LocalDateTime.now().minusDays(1));
         given(calendarService.getCalendarByUserId(user.getId())).willReturn(calendar);
 
         doNothing().when(googleCalendarService).subscribeToCalendar(calendar, user);

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -33,12 +33,16 @@ google:
     client-secret: "test"
 
   calendar:
-    calendar-list-url: "test"
-    subscribe-url: "test"
-    unsubscribe-url: "test"
-    webhook-url: "test"
-    primary-calendar-url: "test"
-    events-url: "test"
+    url:
+      calendar-list-url: "test"
+      subscribe-url: "test"
+      unsubscribe-url: "test"
+      webhook-url: "test"
+      primary-calendar-url: "test"
+      events-url: "test"
+
+    api:
+      subscribe-duration: 0
 
 jwt:
   secret: "my-very-long-and-secure-secret-key-which-is-at-least-32-chars-test"


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #170 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 재로그인 시 구글 구독 채널 만료기간에 체크에서 null exception이 발생하던 에러 해결
- 구글 캘린더의 일정을 개인 일정에 반영할 때 구글 캘린더id가 저장되지 않던 문제 해결
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced personal event integration ensures events from your calendar now capture more accurate details.
  - The calendar subscription process has been streamlined to automatically refresh subscriptions using dynamic, configurable intervals.
  - Calendar settings have been reorganized for a clearer, more straightforward integration setup, resulting in a smoother and more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->