### PR TITLE
[BE-Fix] DiscussionParticipant 레포지토리의 fetch join 삭제

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -55,9 +55,8 @@ public interface DiscussionParticipantRepository extends
         @Param("offset") List<Long> offsets
     );
 
-    @Query("SELECT dp " +
+    @Query("SELECT DISTINCT dp.discussion " +
         "FROM DiscussionParticipant dp " +
-        "JOIN FETCH dp.discussion d " +
         "WHERE dp.user.id = :userId")
     List<Discussion> findDiscussionsByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -20,10 +20,10 @@ public interface DiscussionParticipantRepository extends
         "WHERE dp.discussion.id = :discussionId")
     List<String> findUserPicturesByDiscussionId(@Param("discussionId") Long discussionId);
 
-    @Query("select dp " +
-        "from DiscussionParticipant dp " +
-        "join fetch dp.user " +
-        "where dp.discussion.id = :discussionId")
+    @Query("SELECT DISTINCT dp.user " +
+        "FROM DiscussionParticipant dp " +
+        "where dp.discussion.id = :discussionId " +
+        "ORDER BY dp.userOffset ASC")
     List<User> findUsersByDiscussionId(@Param("discussionId") Long discussionId);
 
     @Query("SELECT dp.userOffset " +
@@ -60,11 +60,4 @@ public interface DiscussionParticipantRepository extends
         "JOIN FETCH dp.discussion d " +
         "WHERE dp.user.id = :userId")
     List<Discussion> findDiscussionsByUserId(@Param("userId") Long userId);
-
-    @Query("SELECT dp "
-        + "FROM DiscussionParticipant dp "
-        + "JOIN FETCH dp.user "
-        + "WHERE dp.discussion.id = :discussionId "
-        + "ORDER BY dp.createdAt ASC")
-    List<User> findUserByDiscussionIdOrderByJoin(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -105,9 +105,4 @@ public class DiscussionParticipantService {
     public List<Discussion> getDiscussionsByUserId(Long userId) {
         return discussionParticipantRepository.findDiscussionsByUserId(userId);
     }
-
-    @Transactional(readOnly = true)
-    public List<User> getUsersByDiscussionIdOrderByCreatedAt(Long discussionId) {
-        return discussionParticipantRepository.findUserByDiscussionIdOrderByJoin(discussionId);
-    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -143,7 +143,7 @@ public class DiscussionService {
         LocalDateTime searchEndTime = midTime.plusHours(TIME_OFFSET);
 
         User currentUser = userService.getCurrentUser();
-        List<User> participants = discussionParticipantService.getUsersByDiscussionIdOrderByCreatedAt(
+        List<User> participants = discussionParticipantService.getUsersByDiscussionId(
             discussionId);
 
         if (!participants.contains(currentUser)) {

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -396,7 +396,7 @@ public class DiscussionServiceTest {
         );
 
         given(userService.getCurrentUser()).willReturn(currentUser);
-        given(discussionParticipantService.getUsersByDiscussionIdOrderByCreatedAt(eq(discussionId)))
+        given(discussionParticipantService.getUsersByDiscussionId(eq(discussionId)))
             .willReturn(participants);
         given(personalEventService.findUserInfoWithPersonalEventsByUsers(
             anyList(), any(LocalDateTime.class), any(LocalDateTime.class), any(LocalDateTime.class), any(LocalDateTime.class), any(Map.class)))
@@ -466,7 +466,7 @@ public class DiscussionServiceTest {
         User otherUser = mock(User.class);
 
         given(userService.getCurrentUser()).willReturn(currentUser);
-        given(discussionParticipantService.getUsersByDiscussionIdOrderByCreatedAt(discussionId))
+        given(discussionParticipantService.getUsersByDiscussionId(discussionId))
             .willReturn(Collections.singletonList(otherUser));
 
         // When & Then


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- fetch join은 엔티티 전체를 반환하는데 현재 작성되어 있는 return type과 달라서 수정했습니다.
- 현재 구조에서는 N+1 문제가 발생하지 않을 것 같아서 fetch join을 삭제했습니다.
- 기존 createdAt 기준 정렬된 유저 리스트를 반환하는 메서드를 정렬 수행하지 않고 반환하던 메서드와 통합했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 현재 구조에서는 fetch join이 불필요할 것 같은데 확인해주시면 감사하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the display of discussion participants by ensuring unique and consistently ordered entries for a smoother discussion experience.
  
- **Tests**
  - Enhanced validations for discussion creation and participant retrieval, including improved checks for secure password handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->