### PR TITLE
[BE-Feat] 논의 참여자 목록 조회 api, 내가 호스트인가요? api 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -8,6 +8,7 @@ import endolphin.backend.domain.candidate_event.dto.RankViewResponse;
 import endolphin.backend.domain.discussion.dto.CandidateEventDetailsRequest;
 import endolphin.backend.domain.discussion.dto.CandidateEventDetailsResponse;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
+import endolphin.backend.domain.discussion.dto.DiscussionParticipantsResponse;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 public class DiscussionController {
 
     private final DiscussionService discussionService;
+    private final DiscussionParticipantService discussionParticipantService;
     private final CandidateEventService candidateEventService;
 
     @Operation(summary = "논의 생성", description = "새 논의를 생성합니다.")
@@ -123,9 +125,25 @@ public class DiscussionController {
             content = @Content(schema = @Schema(implementation = CandidateEventDetailsResponse.class)))
     })
     @PostMapping("/{discussionId}/candidate-event/details")
-    public ResponseEntity<CandidateEventDetailsResponse> getCandidateEventDetails(@PathVariable("discussionId") @Min(1) Long discussionId,
+    public ResponseEntity<CandidateEventDetailsResponse> getCandidateEventDetails(
+        @PathVariable("discussionId") @Min(1) Long discussionId,
         @Valid @RequestBody CandidateEventDetailsRequest request) {
-        CandidateEventDetailsResponse response = discussionService.retrieveCandidateEventDetails(discussionId, request);
+        CandidateEventDetailsResponse response = discussionService.retrieveCandidateEventDetails(
+            discussionId, request);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "논의 참여자 조회", description = "해당 논의의 참여자 목록을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "참여자 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = DiscussionParticipantsResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{discussionId}/participants")
+    public ResponseEntity<DiscussionParticipantsResponse> getDiscussionParticipants(
+        @PathVariable("discussionId") @Min(1) Long discussionId) {
+        return ResponseEntity.ok(
+            discussionParticipantService.getDiscussionParticipants(discussionId));
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -138,6 +138,12 @@ public class DiscussionController {
         @ApiResponse(responseCode = "200", description = "참여자 목록 조회 성공",
             content = @Content(schema = @Schema(implementation = DiscussionParticipantsResponse.class))),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "논의 참여자 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/{discussionId}/participants")

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -152,4 +152,23 @@ public class DiscussionController {
         return ResponseEntity.ok(
             discussionParticipantService.getDiscussionParticipants(discussionId));
     }
+
+    @Operation(summary = "내가 호스트인가요?", description = "현재 사용자가 논의의 호스트인지 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "호스트 여부 조회 성공",
+            content = @Content(schema = @Schema(implementation = Boolean.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "논의 참여자 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{discussionId}/role")
+    public ResponseEntity<Boolean> amIHost(
+        @PathVariable("discussionId") @Min(1) Long discussionId) {
+        return ResponseEntity.ok(discussionParticipantService.amIHost(discussionId));
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -67,4 +67,11 @@ public interface DiscussionParticipantRepository extends
         "WHERE dp.discussion.id = :discussionId " +
         "ORDER BY dp.userOffset ASC")
     List<UserIdNameDto> findUserIdNameDtosByDiscussionId(@Param("discussionId") Long discussionId);
+
+    @Query("SELECT dp.isHost " +
+        "FROM DiscussionParticipant dp " +
+        "WHERE dp.discussion.id = :discussionId " +
+        "AND dp.user.id = :userId")
+    Optional<Boolean> findIsHostByDiscussionIdAndUserId(@Param("discussionId") Long discussionId,
+        @Param("userId") Long userId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -21,7 +21,7 @@ public interface DiscussionParticipantRepository extends
         "WHERE dp.discussion.id = :discussionId")
     List<String> findUserPicturesByDiscussionId(@Param("discussionId") Long discussionId);
 
-    @Query("SELECT DISTINCT dp.user " +
+    @Query("SELECT dp.user " +
         "FROM DiscussionParticipant dp " +
         "WHERE dp.discussion.id = :discussionId " +
         "ORDER BY dp.userOffset ASC")
@@ -56,7 +56,7 @@ public interface DiscussionParticipantRepository extends
         @Param("offset") List<Long> offsets
     );
 
-    @Query("SELECT DISTINCT dp.discussion " +
+    @Query("SELECT dp.discussion " +
         "FROM DiscussionParticipant dp " +
         "WHERE dp.user.id = :userId")
     List<Discussion> findDiscussionsByUserId(@Param("userId") Long userId);

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -2,6 +2,7 @@ package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
+import endolphin.backend.domain.user.dto.UserIdNameDto;
 import endolphin.backend.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
@@ -22,7 +23,7 @@ public interface DiscussionParticipantRepository extends
 
     @Query("SELECT DISTINCT dp.user " +
         "FROM DiscussionParticipant dp " +
-        "where dp.discussion.id = :discussionId " +
+        "WHERE dp.discussion.id = :discussionId " +
         "ORDER BY dp.userOffset ASC")
     List<User> findUsersByDiscussionId(@Param("discussionId") Long discussionId);
 
@@ -59,4 +60,11 @@ public interface DiscussionParticipantRepository extends
         "FROM DiscussionParticipant dp " +
         "WHERE dp.user.id = :userId")
     List<Discussion> findDiscussionsByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT new endolphin.backend.domain.user.dto.UserIdNameDto(u.id, u.name) " +
+        "FROM DiscussionParticipant dp " +
+        "JOIN dp.user u " +
+        "WHERE dp.discussion.id = :discussionId " +
+        "ORDER BY dp.userOffset ASC")
+    List<UserIdNameDto> findUserIdNameDtosByDiscussionId(@Param("discussionId") Long discussionId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -117,4 +117,11 @@ public class DiscussionParticipantService {
         }
         return new DiscussionParticipantsResponse(participants);
     }
+
+    @Transactional(readOnly = true)
+    public Boolean amIHost(Long discussionId) {
+        User user = userService.getCurrentUser();
+        return discussionParticipantRepository.findIsHostByDiscussionIdAndUserId(discussionId, user.getId())
+            .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND));
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -1,5 +1,6 @@
 package endolphin.backend.domain.discussion;
 
+import endolphin.backend.domain.discussion.dto.DiscussionParticipantsResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
 import endolphin.backend.domain.user.UserService;
@@ -65,7 +66,7 @@ public class DiscussionParticipantService {
     @Transactional(readOnly = true)
     public int getFilter(Long discussionId, List<Long> userIds) {
 
-        if(userIds == null || userIds.isEmpty()) {
+        if (userIds == null || userIds.isEmpty()) {
             return 0;
         }
 
@@ -83,7 +84,7 @@ public class DiscussionParticipantService {
 
     @Transactional(readOnly = true)
     public List<UserIdNameDto> getUsersFromData(Long discussionId, int data) {
-        if(data == 0) {
+        if (data == 0) {
             return new ArrayList<>();
         }
 
@@ -104,5 +105,13 @@ public class DiscussionParticipantService {
     @Transactional(readOnly = true)
     public List<Discussion> getDiscussionsByUserId(Long userId) {
         return discussionParticipantRepository.findDiscussionsByUserId(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public DiscussionParticipantsResponse getDiscussionParticipants(Long discussionId) {
+        List<UserIdNameDto> participants = discussionParticipantRepository.findUserIdNameDtosByDiscussionId(
+            discussionId);
+
+        return new DiscussionParticipantsResponse(participants);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -112,6 +112,9 @@ public class DiscussionParticipantService {
         List<UserIdNameDto> participants = discussionParticipantRepository.findUserIdNameDtosByDiscussionId(
             discussionId);
 
+        if(participants.isEmpty()) {
+            throw new ApiException(ErrorCode.DISCUSSION_PARTICIPANT_NOT_FOUND);
+        }
         return new DiscussionParticipantsResponse(participants);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/DiscussionParticipantsResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/DiscussionParticipantsResponse.java
@@ -1,0 +1,10 @@
+package endolphin.backend.domain.discussion.dto;
+
+import endolphin.backend.domain.user.dto.UserIdNameDto;
+import java.util.List;
+
+public record DiscussionParticipantsResponse(
+    List<UserIdNameDto> participants
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/discussion/entity/DiscussionParticipant.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/entity/DiscussionParticipant.java
@@ -10,7 +10,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Entity
-@Table(name = "discussion_participant")
+@Table(name = "discussion_participant", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"discussion_id", "user_id"})
+})
 public class DiscussionParticipant extends BaseTimeEntity {
 
     @Id
@@ -34,7 +36,8 @@ public class DiscussionParticipant extends BaseTimeEntity {
     private Long userOffset;
 
     @Builder
-    public DiscussionParticipant(Discussion discussion, User user, boolean isHost, Long userOffset) {
+    public DiscussionParticipant(Discussion discussion, User user, boolean isHost,
+        Long userOffset) {
         this.discussion = discussion;
         this.user = user;
         this.isHost = isHost;

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantRepositoryTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantRepositoryTest.java
@@ -1,0 +1,169 @@
+package endolphin.backend.domain.discussion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import endolphin.backend.domain.discussion.entity.Discussion;
+import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
+import endolphin.backend.domain.discussion.enums.DiscussionStatus;
+import endolphin.backend.domain.user.dto.UserIdNameDto;
+import endolphin.backend.domain.user.entity.User;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+public class DiscussionParticipantRepositoryTest {
+
+    @Autowired
+    private DiscussionParticipantRepository discussionParticipantRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Discussion discussion;
+    private User user1;
+    private User user2;
+    private User user3;
+
+    @BeforeEach
+    public void setup() {
+        // Create a Discussion
+        discussion = Discussion.builder()
+            .title("Test Discussion")
+            .dateStart(LocalDate.now())
+            .dateEnd(LocalDate.now().plusDays(1))
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(17, 0))
+            .duration(60)
+            .deadline(LocalDate.now().plusDays(2))
+            .location("Test Location")
+            .build();
+        ReflectionTestUtils.setField(discussion, "discussionStatus", DiscussionStatus.ONGOING);
+        entityManager.persist(discussion);
+
+        // Create Users
+        user1 = User.builder()
+            .name("Alice")
+            .email("alice@example.com")
+            .picture("alice.jpg")
+            .build();
+        entityManager.persist(user1);
+
+        user2 = User.builder()
+            .name("Bob")
+            .email("bob@example.com")
+            .picture("bob.jpg")
+            .build();
+        entityManager.persist(user2);
+
+        user3 = User.builder()
+            .name("Charlie")
+            .email("charlie@example.com")
+            .picture("charlie.jpg")
+            .build();
+        entityManager.persist(user3);
+
+        // Create DiscussionParticipants with userOffset values
+        DiscussionParticipant dp1 = DiscussionParticipant.builder()
+            .discussion(discussion)
+            .user(user1)
+            .isHost(true)
+            .userOffset(0L)
+            .build();
+        entityManager.persist(dp1);
+
+        DiscussionParticipant dp2 = DiscussionParticipant.builder()
+            .discussion(discussion)
+            .user(user2)
+            .isHost(false)
+            .userOffset(1L)
+            .build();
+        entityManager.persist(dp2);
+
+        DiscussionParticipant dp3 = DiscussionParticipant.builder()
+            .discussion(discussion)
+            .user(user3)
+            .isHost(false)
+            .userOffset(2L)
+            .build();
+        entityManager.persist(dp3);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @DisplayName("discussionId로 참여자 목록 조회")
+    @Test
+    public void testFindUsersByDiscussionId() {
+        List<User> users = discussionParticipantRepository.findUsersByDiscussionId(discussion.getId());
+        assertThat(users).hasSize(3);
+        // 사용자 offset 순서대로 반환되어야 함: user1, user2, user3
+        assertThat(users.get(0).getId()).isEqualTo(user1.getId());
+        assertThat(users.get(1).getId()).isEqualTo(user2.getId());
+        assertThat(users.get(2).getId()).isEqualTo(user3.getId());
+    }
+
+    @DisplayName("discussionId, userId로 userOffset 조회")
+    @Test
+    public void testFindOffsetByDiscussionIdAndUserId() {
+        Optional<Long> offsetOpt = discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussion.getId(), user2.getId());
+        assertThat(offsetOpt).isPresent();
+        assertThat(offsetOpt.get()).isEqualTo(1L);
+    }
+
+    @DisplayName("유저 offset 최대값 조회")
+    @Test
+    public void testFindMaxOffsetByDiscussionId() {
+        Long maxOffset = discussionParticipantRepository.findMaxOffsetByDiscussionId(discussion.getId());
+        assertThat(maxOffset).isEqualTo(2L);
+    }
+
+    @DisplayName("discussionId, userIds로 userOffset 조회")
+    @Test
+    public void testFindOffsetsByDiscussionIdAndUserIds() {
+        List<Long> userIds = Arrays.asList(user1.getId(), user3.getId());
+        List<Long> offsets = discussionParticipantRepository.findOffsetsByDiscussionIdAndUserIds(discussion.getId(), userIds);
+        assertThat(offsets).containsExactlyInAnyOrder(0L, 2L);
+    }
+
+    @DisplayName("discussionId, offsets로 user ID 조회")
+    @Test
+    public void testFindUserIdsByDiscussionIdAndOffset() {
+        List<Long> offsets = Arrays.asList(1L, 2L);
+        List<Long> userIds = discussionParticipantRepository.findUserIdsByDiscussionIdAndOffset(discussion.getId(), offsets);
+        // 예상: user2와 user3의 ID
+        assertThat(userIds).containsExactlyInAnyOrder(user2.getId(), user3.getId());
+    }
+
+    @DisplayName("userId로 참여한 논의 목록 조회")
+    @Test
+    public void testFindDiscussionsByUserId() {
+        List<Discussion> discussions = discussionParticipantRepository.findDiscussionsByUserId(user1.getId());
+        assertThat(discussions).hasSize(1);
+        assertThat(discussions.get(0).getId()).isEqualTo(discussion.getId());
+    }
+
+    @DisplayName("discussionId로 참여자 ID, 이름 목록 조회")
+    @Test
+    public void testFindUserIdNameDtosByDiscussionId() {
+        List<UserIdNameDto> dtos = discussionParticipantRepository.findUserIdNameDtosByDiscussionId(discussion.getId());
+        assertThat(dtos).hasSize(3);
+        // 순서: user1 (offset 0), user2 (offset 1), user3 (offset 2)
+        assertThat(dtos.get(0).id()).isEqualTo(user1.getId());
+        assertThat(dtos.get(0).name()).isEqualTo(user1.getName());
+        assertThat(dtos.get(1).id()).isEqualTo(user2.getId());
+        assertThat(dtos.get(1).name()).isEqualTo(user2.getName());
+        assertThat(dtos.get(2).id()).isEqualTo(user3.getId());
+        assertThat(dtos.get(2).name()).isEqualTo(user3.getName());
+    }
+}

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantRepositoryTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantRepositoryTest.java
@@ -166,4 +166,22 @@ public class DiscussionParticipantRepositoryTest {
         assertThat(dtos.get(2).id()).isEqualTo(user3.getId());
         assertThat(dtos.get(2).name()).isEqualTo(user3.getName());
     }
+
+    @DisplayName("discussionId, userId로 호스트 여부 조회(true)")
+    @Test
+    public void testFindIsHostByDiscussionIdAndUserId_returnsTrue() {
+        Optional<Boolean> result = discussionParticipantRepository.findIsHostByDiscussionIdAndUserId(
+            discussion.getId(), user1.getId());
+        assertThat(result).isPresent();
+        assertThat(result.get()).isTrue();
+    }
+
+    @DisplayName("discussionId, userId로 호스트 여부 조회(false)")
+    @Test
+    public void testFindIsHostByDiscussionIdAndUserId_returnsFalse() {
+        Optional<Boolean> result = discussionParticipantRepository.findIsHostByDiscussionIdAndUserId(
+            discussion.getId(), user2.getId());
+        assertThat(result).isPresent();
+        assertThat(result.get()).isFalse();
+    }
 }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #185 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- discussionId로 논의 참여자 목록 조회하는 api 구현했습니다.
- select distinct가 h2 환경에서 문제를 일으켜서 삭제했습니다.
   - discussionParticipant 테이블에 {user_id, discussion_id} unique 제약 조건 걸면 문제 없을 것 같습니다.
- discussionParticipantsRepository 에 jpql 테스트가 필요할 것 같아서 추가했습니다.
- 내가 호스트인가요? api 관련 메서드 추가했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an endpoint that allows users to retrieve discussion participants, providing structured participant details for enhanced discussion interactions.
  - Added functionality to check if the current user is the host of a discussion.
  
- **Bug Fixes**
  - Improved data integrity by enforcing uniqueness on the combination of discussion and user IDs in the database.

- **Tests**
  - Added comprehensive unit tests for the discussion participant repository, validating various functionalities related to discussion participants and host status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->