### PR TITLE
[BE-Feat] 확정되지 않은 일정 조회 api 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -2,10 +2,13 @@ package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
+import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.user.dto.UserIdNameDto;
 import endolphin.backend.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,7 +21,8 @@ public interface DiscussionParticipantRepository extends
     @Query("SELECT u.picture " +
         "FROM DiscussionParticipant dp " +
         "JOIN dp.user u " +
-        "WHERE dp.discussion.id = :discussionId")
+        "WHERE dp.discussion.id = :discussionId " +
+        "ORDER BY dp.userOffset ASC")
     List<String> findUserPicturesByDiscussionId(@Param("discussionId") Long discussionId);
 
     @Query("SELECT dp.user " +
@@ -81,4 +85,15 @@ public interface DiscussionParticipantRepository extends
         "WHERE dp.discussion.id = :discussionId " +
         "AND dp.isHost = true")
     Optional<String> findHostNameByDiscussionIdAndIsHost(@Param("discussionId") Long discussionId);
+
+    @Query("SELECT d " +
+        "FROM DiscussionParticipant dp " +
+        "JOIN dp.discussion d " +
+        "WHERE dp.user.id = :userId " +
+        "AND d.discussionStatus = 'ONGOING' " +
+        "AND (:isHost IS NULL OR dp.isHost = :isHost) " +
+        "ORDER BY d.deadline ASC")
+    Page<Discussion> findOngoingDiscussions(@Param("userId") Long userId,
+        @Param("isHost") Boolean isHost,
+        Pageable pageable);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -1,10 +1,10 @@
 package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.dto.DiscussionParticipantsResponse;
-import endolphin.backend.domain.discussion.dto.OngoingDiscussionResponse;
+import endolphin.backend.domain.discussion.dto.OngoingDiscussion;
+import endolphin.backend.domain.discussion.dto.OngoingDiscussionsResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.entity.DiscussionParticipant;
-import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.dto.UserIdNameDto;
 import endolphin.backend.domain.user.entity.User;
@@ -14,7 +14,6 @@ import endolphin.backend.global.util.TimeCalculator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -128,15 +127,15 @@ public class DiscussionParticipantService {
     }
 
     @Transactional(readOnly = true)
-    public List<OngoingDiscussionResponse> getOngoingDiscussions(Long userId, int page, int size,
+    public OngoingDiscussionsResponse getOngoingDiscussions(Long userId, int page, int size,
         Boolean isHost) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Discussion> discussionPage = discussionParticipantRepository.findOngoingDiscussions(
             userId, isHost, pageable);
         List<Discussion> discussions = discussionPage.getContent();
 
-        return discussions.stream()
-            .map(discussion -> new OngoingDiscussionResponse(
+        List<OngoingDiscussion> ongoingDiscussions = discussions.stream()
+            .map(discussion -> new OngoingDiscussion(
                 discussion.getId(),
                 discussion.getTitle(),
                 discussion.getDateRangeStart(),
@@ -145,6 +144,9 @@ public class DiscussionParticipantService {
                 discussionParticipantRepository.findUserPicturesByDiscussionId(discussion.getId())
             ))
             .collect(Collectors.toList());
+
+        return new OngoingDiscussionsResponse(page + 1, discussionPage.getTotalPages(),
+            discussionPage.hasNext(), discussionPage.hasPrevious(), ongoingDiscussions);
     }
 
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -8,7 +8,8 @@ import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.dto.JoinDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.InvitationInfo;
 import endolphin.backend.domain.discussion.dto.JoinDiscussionResponse;
-import endolphin.backend.domain.discussion.dto.OngoingDiscussionResponse;
+import endolphin.backend.domain.discussion.dto.OngoingDiscussion;
+import endolphin.backend.domain.discussion.dto.OngoingDiscussionsResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.AttendType;
 import endolphin.backend.domain.discussion.enums.DiscussionStatus;
@@ -27,8 +28,6 @@ import endolphin.backend.global.redis.PasswordCountService;
 import endolphin.backend.global.security.PasswordEncoder;
 import endolphin.backend.global.util.TimeCalculator;
 import endolphin.backend.global.util.Validator;
-import java.time.Duration;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.el.stream.Stream;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -212,7 +210,7 @@ public class DiscussionService {
     }
 
     @Transactional(readOnly = true)
-    public List<OngoingDiscussionResponse> getOngoingDiscussions(int page, int size,
+    public OngoingDiscussionsResponse getOngoingDiscussions(int page, int size,
         AttendType type) {
         User currentUser = userService.getCurrentUser();
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussion.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussion.java
@@ -3,7 +3,7 @@ package endolphin.backend.domain.discussion.dto;
 import java.time.LocalDate;
 import java.util.List;
 
-public record OngoingDiscussionResponse(
+public record OngoingDiscussion(
     Long discussionId,
     String title,
     LocalDate dateRangeStart,

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussionResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussionResponse.java
@@ -8,6 +8,7 @@ public record OngoingDiscussionResponse(
     String title,
     LocalDate dateRangeStart,
     LocalDate dateRangeEnd,
+    Long timeLeft,
     List<String> participantPictureUrls
 ) {
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussionResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussionResponse.java
@@ -1,0 +1,14 @@
+package endolphin.backend.domain.discussion.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record OngoingDiscussionResponse(
+    Long discussionId,
+    String title,
+    LocalDate dateRangeStart,
+    LocalDate dateRangeEnd,
+    List<String> participantPictureUrls
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussionsResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussionsResponse.java
@@ -1,0 +1,13 @@
+package endolphin.backend.domain.discussion.dto;
+
+import java.util.List;
+
+public record OngoingDiscussionsResponse(
+    int currentPage,
+    int totalPages,
+    Boolean hasNext,
+    Boolean hasPrevious,
+    List<OngoingDiscussion> ongoingDiscussions
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/discussion/enums/AttendType.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/enums/AttendType.java
@@ -1,0 +1,5 @@
+package endolphin.backend.domain.discussion.enums;
+
+public enum AttendType {
+    HOST, ATTENDEE, ALL
+}

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
@@ -1,0 +1,53 @@
+package endolphin.backend.domain.shared_event;
+
+import endolphin.backend.domain.discussion.DiscussionService;
+import endolphin.backend.domain.discussion.dto.OngoingDiscussionResponse;
+import endolphin.backend.domain.discussion.enums.AttendType;
+import endolphin.backend.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Main View", description = "메인 뷰 API")
+@RestController
+@RequestMapping("/api/v1/schedules")
+@RequiredArgsConstructor
+public class SharedEventController {
+
+    private final DiscussionService discussionService;
+
+    @Operation(summary = "진행 중인 논의 조회", description = "진행 중인 논의를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "논의 조회 성공",
+            content = @Content(
+                array = @ArraySchema(
+                    schema = @Schema(implementation = OngoingDiscussionResponse.class)))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/ongoing")
+    public ResponseEntity<List<OngoingDiscussionResponse>> getOngoingDiscussion(
+        @Min(1) @RequestParam int page,
+        @Min(1) @RequestParam int size,
+        @RequestParam AttendType attendType
+    ) {
+        return ResponseEntity.ok(discussionService.getOngoingDiscussions(page, size, attendType));
+    }
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
@@ -1,7 +1,8 @@
 package endolphin.backend.domain.shared_event;
 
 import endolphin.backend.domain.discussion.DiscussionService;
-import endolphin.backend.domain.discussion.dto.OngoingDiscussionResponse;
+import endolphin.backend.domain.discussion.dto.OngoingDiscussion;
+import endolphin.backend.domain.discussion.dto.OngoingDiscussionsResponse;
 import endolphin.backend.domain.discussion.enums.AttendType;
 import endolphin.backend.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,9 +32,7 @@ public class SharedEventController {
     @Operation(summary = "진행 중인 논의 조회", description = "진행 중인 논의를 조회합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "논의 조회 성공",
-            content = @Content(
-                array = @ArraySchema(
-                    schema = @Schema(implementation = OngoingDiscussionResponse.class)))),
+            content = @Content(schema = @Schema(implementation = OngoingDiscussionsResponse.class))),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "인증 실패",
@@ -42,7 +41,7 @@ public class SharedEventController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/ongoing")
-    public ResponseEntity<List<OngoingDiscussionResponse>> getOngoingDiscussion(
+    public ResponseEntity<OngoingDiscussionsResponse> getOngoingDiscussion(
         @Min(1) @RequestParam int page,
         @Min(1) @RequestParam int size,
         @RequestParam AttendType attendType

--- a/backend/src/main/java/endolphin/backend/global/util/TimeCalculator.java
+++ b/backend/src/main/java/endolphin/backend/global/util/TimeCalculator.java
@@ -1,0 +1,23 @@
+package endolphin.backend.global.util;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class TimeCalculator {
+
+    public static long calculateTimeLeft(LocalDate deadline) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime deadlineDateTime = deadline.atTime(23, 59, 59);
+        Duration duration = Duration.between(now, deadlineDateTime);
+
+        return duration.toMillis();
+    }
+
+    public static LocalDateTime calculateMidTime(LocalDateTime startTime, LocalDateTime endTime) {
+        Duration duration = Duration.between(startTime, endTime);
+        duration = duration.dividedBy(2);
+
+        return startTime.plus(duration);
+    }
+}

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
@@ -6,7 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-import endolphin.backend.domain.discussion.dto.OngoingDiscussionResponse;
+import endolphin.backend.domain.discussion.dto.OngoingDiscussion;
+import endolphin.backend.domain.discussion.dto.OngoingDiscussionsResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.user.UserService;
@@ -102,7 +103,8 @@ class DiscussionParticipantServiceTest {
             discussionParticipantService.addDiscussionParticipant(discussion, user);
         });
 
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DISCUSSION_PARTICIPANT_EXCEED_LIMIT);
+        assertThat(exception.getErrorCode()).isEqualTo(
+            ErrorCode.DISCUSSION_PARTICIPANT_EXCEED_LIMIT);
     }
 
     @Test
@@ -110,7 +112,8 @@ class DiscussionParticipantServiceTest {
     void getUsersByDiscussionId_ShouldReturnUsers() {
         // Given
         Long discussionId = 1L;
-        User user1 = User.builder().name("Alice").email("alice@example.com").picture("alice.jpg").build();
+        User user1 = User.builder().name("Alice").email("alice@example.com").picture("alice.jpg")
+            .build();
         User user2 = User.builder().name("Bob").email("bob@example.com").picture("bob.jpg").build();
 
         given(discussionParticipantRepository.findUsersByDiscussionId(discussionId))
@@ -132,11 +135,13 @@ class DiscussionParticipantServiceTest {
         Long userId = 1L;
         Long expectedOffset = 3L;
 
-        given(discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userId))
+        given(
+            discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userId))
             .willReturn(Optional.of(expectedOffset));
 
         // When
-        Long offset = discussionParticipantService.getDiscussionParticipantOffset(discussionId, userId);
+        Long offset = discussionParticipantService.getDiscussionParticipantOffset(discussionId,
+            userId);
 
         // Then
         assertThat(offset).isEqualTo(expectedOffset);
@@ -149,7 +154,8 @@ class DiscussionParticipantServiceTest {
         Long discussionId = 1L;
         Long userId = 2L;
 
-        given(discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userId))
+        given(
+            discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userId))
             .willReturn(Optional.empty());
 
         // When & Then
@@ -168,7 +174,8 @@ class DiscussionParticipantServiceTest {
         List<Long> userIds = Arrays.asList(1L, 2L, 3L);
         List<Long> offsets = Arrays.asList(0L, 3L, 8L);
 
-        given(discussionParticipantRepository.findOffsetsByDiscussionIdAndUserIds(discussionId, userIds))
+        given(discussionParticipantRepository.findOffsetsByDiscussionIdAndUserIds(discussionId,
+            userIds))
             .willReturn(offsets);
 
         // When
@@ -189,7 +196,8 @@ class DiscussionParticipantServiceTest {
         // 위의 data를 바탕으로, 내부에서 생성되는 userOffsets는 [0, 3, 8]이어야 함.
         List<Long> expectedOffsets = Arrays.asList(0L, 3L, 8L);
         List<Long> userIds = Arrays.asList(10L, 20L, 30L);
-        given(discussionParticipantRepository.findUserIdsByDiscussionIdAndOffset(discussionId, expectedOffsets))
+        given(discussionParticipantRepository.findUserIdsByDiscussionIdAndOffset(discussionId,
+            expectedOffsets))
             .willReturn(userIds);
 
         List<UserIdNameDto> dtos = Arrays.asList(
@@ -200,7 +208,8 @@ class DiscussionParticipantServiceTest {
         given(userService.getUserIdNameInIds(userIds)).willReturn(dtos);
 
         // When
-        List<UserIdNameDto> result = discussionParticipantService.getUsersFromData(discussionId, data);
+        List<UserIdNameDto> result = discussionParticipantService.getUsersFromData(discussionId,
+            data);
 
         // Then
         assertThat(result).isEqualTo(dtos);
@@ -260,7 +269,7 @@ class DiscussionParticipantServiceTest {
     @Test
     public void testGetOngoingDiscussions_Pagination() {
         Long userId = 1L;
-        int page = 1;  // 두 번째 페이지 (0-based index)
+        int page = 1;  // 두 번째 페이지
         int size = 1;  // 한 건씩 반환
         Boolean isHost = true;
 
@@ -299,7 +308,8 @@ class DiscussionParticipantServiceTest {
             2 // 전체 결과 건수
         );
 
-        given(discussionParticipantRepository.findOngoingDiscussions(userId, isHost, PageRequest.of(page, size)))
+        given(discussionParticipantRepository.findOngoingDiscussions(userId, isHost,
+            PageRequest.of(page, size)))
             .willReturn(pagedDiscussionPage);
 
         // 두 번째 Discussion에 대한 참여자 사진 설정
@@ -308,16 +318,24 @@ class DiscussionParticipantServiceTest {
             .willReturn(pictures2);
 
         // When: Service 메서드 호출
-        List<OngoingDiscussionResponse> responses = discussionParticipantService.getOngoingDiscussions(userId, page, size, isHost);
 
+        OngoingDiscussionsResponse response = discussionParticipantService.getOngoingDiscussions(
+            userId, page, size, isHost);
+
+        List<OngoingDiscussion> ods = response.ongoingDiscussions();
+
+        assertThat(response.currentPage()).isEqualTo(page + 1);
+        assertThat(response.totalPages()).isEqualTo(2);
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.hasPrevious()).isTrue();
         // Then: 페이징 결과가 두 번째 Discussion만 포함하는지 검증
-        assertThat(responses).hasSize(1);
-        OngoingDiscussionResponse response = responses.get(0);
-        assertThat(response.discussionId()).isEqualTo(101L);
-        assertThat(response.title()).isEqualTo("Discussion 2");
-        assertThat(response.dateRangeStart()).isEqualTo(LocalDate.of(2025, 2, 1));
-        assertThat(response.dateRangeEnd()).isEqualTo(LocalDate.of(2025, 3, 5));
-        assertThat(response.participantPictureUrls()).isEqualTo(pictures2);
+        assertThat(ods).hasSize(1);
+        OngoingDiscussion od = ods.get(0);
+        assertThat(od.discussionId()).isEqualTo(101L);
+        assertThat(od.title()).isEqualTo("Discussion 2");
+        assertThat(od.dateRangeStart()).isEqualTo(LocalDate.of(2025, 2, 1));
+        assertThat(od.dateRangeEnd()).isEqualTo(LocalDate.of(2025, 3, 5));
+        assertThat(od.participantPictureUrls()).isEqualTo(pictures2);
     }
 
 }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #187 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- pageable 사용하여 확정되지 않은 논의 조회하는 쿼리 작성했습니다.
- TimeCalculator 생성하여 시간 계산하는 메서드 분리했습니다.
- 확정되지 않은 일정 조회에 필요한 메서드 추가했습니다.
- 관련 테스트 코드 추가했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
Controller 이름을 뭘로 작업중이신가요? 일단 SharedEventController로 만들어서 작업했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Launched an ongoing discussions feature with a dedicated API endpoint for users. Now view discussions with details such as event title, schedule, remaining time until deadlines, and participant images, with filtering options based on roles.
  
- **Refactor**
  - Centralized time calculation logic and improved sorting for participant data for a more consistent display.
  
- **Tests**
  - Expanded automated tests covering pagination, filtering, and ordering, ensuring robust and reliable ongoing discussions functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->