### PR TITLE
[FE-Feat] 내 일정 관리 페이지 개인 일정 수정, 삭제

### DIFF
--- a/frontend/src/components/Calendar/Table/CalendarDetailCell.tsx
+++ b/frontend/src/components/Calendar/Table/CalendarDetailCell.tsx
@@ -12,7 +12,6 @@ export const CalendarDetailCell = ({ date }: { date: Date }) => {
     handleMouseDown,
     handleMouseEnter,
     handleMouseUp,
-    handleClick,
   } = useTimeTableContext();
   const OFFSET = 15 * 60 * 1000;
   const formatEndTime = (endTime: Date | null) => {
@@ -28,11 +27,10 @@ export const CalendarDetailCell = ({ date }: { date: Date }) => {
     return 'default';
   })();
 
-  return (
+  return(
     <div
       className={cellDetailStyle({ state: stateStyle })}
       key={date.getTime()}
-      onClick={()=>handleClick(date)}
       onMouseDown={()=>handleMouseDown(date)}
       onMouseEnter={()=>handleMouseEnter(date)}
       onMouseUp={()=>handleMouseUp()}

--- a/frontend/src/components/Calendar/Table/index.tsx
+++ b/frontend/src/components/Calendar/Table/index.tsx
@@ -1,10 +1,7 @@
-
-import { useClickOutside } from '@/hooks/useClickOutside';
 import type { TimeInfo } from '@/hooks/useSelectTime';
 import { isSameDate } from '@/utils/date';
 
 import { useCalendarContext } from '../context/CalendarContext';
-import { useTimeTableContext } from '../context/TimeTableContext';
 import { TimeTableProvider } from '../context/TimeTableProvider';
 import { CalendarDay } from './CalendarDay';
 import { CalendarSide } from './CalendarSide';
@@ -12,11 +9,9 @@ import { containerStyle, contentsStyle } from './index.css';
 
 const CalendarContents = () => {
   const { selected, dates } = useCalendarContext();
-  const { reset } = useTimeTableContext();
-  const ref = useClickOutside<HTMLDivElement>(reset);
 
   return (
-    <div className={contentsStyle} ref={ref}>
+    <div className={contentsStyle}>
       {dates.map((date) => 
         <CalendarDay
           date={date}

--- a/frontend/src/components/Calendar/Table/index.tsx
+++ b/frontend/src/components/Calendar/Table/index.tsx
@@ -1,8 +1,10 @@
 
+import { useClickOutside } from '@/hooks/useClickOutside';
 import type { TimeInfo } from '@/hooks/useSelectTime';
 import { isSameDate } from '@/utils/date';
 
 import { useCalendarContext } from '../context/CalendarContext';
+import { useTimeTableContext } from '../context/TimeTableContext';
 import { TimeTableProvider } from '../context/TimeTableProvider';
 import { CalendarDay } from './CalendarDay';
 import { CalendarSide } from './CalendarSide';
@@ -10,9 +12,11 @@ import { containerStyle, contentsStyle } from './index.css';
 
 const CalendarContents = () => {
   const { selected, dates } = useCalendarContext();
+  const { reset } = useTimeTableContext();
+  const ref = useClickOutside<HTMLDivElement>(reset);
 
   return (
-    <div className={contentsStyle} >
+    <div className={contentsStyle} ref={ref}>
       {dates.map((date) => 
         <CalendarDay
           date={date}

--- a/frontend/src/components/Checkbox/CheckboxInput.tsx
+++ b/frontend/src/components/Checkbox/CheckboxInput.tsx
@@ -1,0 +1,34 @@
+import type { ChangeEvent } from 'react';
+
+import { inputStyle } from './index.css';
+import type { CheckboxProps } from './type';
+
+export const CheckboxInput = ({
+  checked,
+  handleClickCheck,
+  id,
+  inputProps = {},
+}: {
+  checked: boolean;
+  handleClickCheck: () => void;
+  id: string;
+  inputProps?: CheckboxProps['inputProps'];
+}) => {
+  const { onChange, checked: inputChecked, ...restInputProps } = inputProps;
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    handleClickCheck();
+    onChange?.(e);
+  };
+
+  return (
+    <input 
+      checked={inputChecked ?? checked}
+      className={inputStyle}
+      id={id}
+      onChange={handleChange}
+      type='checkbox'
+      {...restInputProps}
+    />
+  );
+};

--- a/frontend/src/components/Checkbox/CheckboxLabel.tsx
+++ b/frontend/src/components/Checkbox/CheckboxLabel.tsx
@@ -1,9 +1,9 @@
 import type { PropsWithChildren } from 'react';
 
 import type { Typo } from '../Text';
-import { Text  } from '../Text';
-import type { Size } from '.';
+import { Text } from '../Text';
 import { labelStyle } from './index.css';
+import type { Size } from './type';
 
 interface CheckboxLabelProps extends PropsWithChildren {
   size: Size;

--- a/frontend/src/components/Checkbox/index.tsx
+++ b/frontend/src/components/Checkbox/index.tsx
@@ -1,23 +1,12 @@
-import type { InputHTMLAttributes, PropsWithChildren, SetStateAction }  from 'react';
 import { useId } from 'react';
 
 import { useCheckbox } from '@/hooks/useCheckbox';
 
 import { Check } from '../Icon';
+import { CheckboxInput } from './CheckboxInput';
 import { CheckboxLabel } from './CheckboxLabel';
-import { checkboxStyle, containerStyle, inputStyle } from './index.css';
-
-export type Size = 'sm' | 'md';
-
-interface CheckboxProps extends PropsWithChildren {
-  value?: number;
-  isChecked?: boolean;
-  onToggleCheck?: (prev: SetStateAction<boolean>) => void;
-  type?: 'all' | 'single';
-  size?: Size;
-  defaultChecked?: boolean;
-  inputProps?: InputHTMLAttributes<HTMLInputElement>;
-}
+import { checkboxStyle, containerStyle } from './index.css';
+import type { CheckboxProps } from './type';
 
 /**
  * @description Checkbox 컴포넌트.
@@ -38,7 +27,7 @@ export const Checkbox = ({
   type = 'single', 
   size = 'md', 
   defaultChecked, 
-  inputProps, 
+  inputProps = {}, 
   children, 
 }: CheckboxProps) => {
   const defaultId = `checkbox-${useId()}`;
@@ -46,27 +35,24 @@ export const Checkbox = ({
 
   const { handleClickCheck, checked } = 
     useCheckbox({ value, defaultChecked, type, isChecked, onToggleCheck });
-  const checkStyleName = checked ? 'selected' : 'rest';
 
   return(
-    <div className={containerStyle} onClick={handleClickCheck}>
-      <span className={checkboxStyle({ size, style: checkStyleName })}>
+    <div className={containerStyle}>
+      <span className={checkboxStyle({ size, style: checked ? 'selected' : 'rest' })}>
         {checked && <Check clickable width={16} />}
       </span>
       <CheckboxLabel
         id={id}
         size={size}
-        style={checkStyleName}
+        style={checked ? 'selected' : 'rest'}
       >
         {children}
       </CheckboxLabel>
-      <input 
+      <CheckboxInput
         checked={checked}
-        className={inputStyle}
+        handleClickCheck={handleClickCheck}
         id={id}
-        type='checkbox'
-        {...inputProps}
-        onChange={handleClickCheck}
+        inputProps={inputProps}
       />
     </div>
   ); 

--- a/frontend/src/components/Checkbox/type.ts
+++ b/frontend/src/components/Checkbox/type.ts
@@ -1,0 +1,13 @@
+import type { InputHTMLAttributes, PropsWithChildren, SetStateAction } from 'react';
+
+export type Size = 'sm' | 'md';
+
+export interface CheckboxProps extends PropsWithChildren {
+  value?: number;
+  isChecked?: boolean;
+  onToggleCheck?: (prev: SetStateAction<boolean>) => void;
+  type?: 'all' | 'single';
+  size?: Size;
+  defaultChecked?: boolean;
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
+}

--- a/frontend/src/features/login/api/mutations.ts
+++ b/frontend/src/features/login/api/mutations.ts
@@ -11,7 +11,7 @@ interface JWTMutationProps extends JWTRequest {
 export const useJWTMutation = () => {
   const navigate = useNavigate();
   
-  const { mutate, isPending } = useMutation({
+  const { mutate } = useMutation({
     mutationFn: ({ code }: JWTMutationProps) => loginApi.getJWT(code),
     onSuccess: ({ accessToken }, { lastPath }) => {
       localStorage.setItem('accessToken', accessToken);
@@ -26,5 +26,5 @@ export const useJWTMutation = () => {
     },
   });
 
-  return { loginMutate: mutate, isPending };
+  return { loginMutate: mutate };
 };

--- a/frontend/src/features/my-calendar/api/hooks.ts
+++ b/frontend/src/features/my-calendar/api/hooks.ts
@@ -1,0 +1,40 @@
+import type { FormValues } from '@/hooks/useFormRef';
+
+import type { PersonalEventRequest } from '../model';
+import { 
+  usePersonalEventDeleteMutation, 
+  usePersonalEventMutation, 
+  usePersonalEventUpdateMutation, 
+} from './mutations';
+
+export const useSchedulePopover = ({
+  setIsOpen,
+  scheduleId,
+  valuesRef,
+}: {
+  setIsOpen: (isOpen: boolean) => void;
+  scheduleId?: number;
+  valuesRef: { current: FormValues<PersonalEventRequest> };
+}) => {
+  const { mutate: createMutate } = usePersonalEventMutation();
+  const { mutate: editMutate } = usePersonalEventUpdateMutation();
+  const { mutate: deleteMutate } = usePersonalEventDeleteMutation();
+  
+  const handleClickCreate = () => {
+    createMutate(valuesRef.current);
+    setIsOpen(false);
+  };
+  
+  const handleClickEdit = () => {
+    if (scheduleId) editMutate({ id: scheduleId, body: valuesRef.current });
+    setIsOpen(false);
+  };
+  
+  const handleClickDelete = () => {
+    if (scheduleId) deleteMutate(scheduleId);
+    setIsOpen(false);
+  };
+  
+  return { handleClickCreate, handleClickEdit, handleClickDelete };
+};
+  

--- a/frontend/src/features/my-calendar/api/hooks.ts
+++ b/frontend/src/features/my-calendar/api/hooks.ts
@@ -9,10 +9,12 @@ import {
 
 export const useSchedulePopover = ({
   setIsOpen,
+  reset,
   scheduleId,
   valuesRef,
 }: {
   setIsOpen: (isOpen: boolean) => void;
+  reset?: () => void;
   scheduleId?: number;
   valuesRef: { current: FormValues<PersonalEventRequest> };
 }) => {
@@ -22,16 +24,19 @@ export const useSchedulePopover = ({
   
   const handleClickCreate = () => {
     createMutate(valuesRef.current);
+    reset?.();
     setIsOpen(false);
   };
   
   const handleClickEdit = () => {
     if (scheduleId) editMutate({ id: scheduleId, body: valuesRef.current });
+    reset?.();
     setIsOpen(false);
   };
   
   const handleClickDelete = () => {
     if (scheduleId) deleteMutate(scheduleId);
+    reset?.();
     setIsOpen(false);
   };
   

--- a/frontend/src/features/my-calendar/api/index.ts
+++ b/frontend/src/features/my-calendar/api/index.ts
@@ -21,4 +21,7 @@ export const personalEventApi = {
     const response = await request.put(`/api/v1/personal-event/${id}`, { body });
     return response;
   },
+  deletePersonalEvent: async (id: number): Promise<void> => {
+    await request.delete(`/api/v1/personal-event/${id}`);
+  },
 };

--- a/frontend/src/features/my-calendar/api/index.ts
+++ b/frontend/src/features/my-calendar/api/index.ts
@@ -15,4 +15,10 @@ export const personalEventApi = {
     const response = await request.post('/api/v1/personal-event', { body });
     return response;
   },
+  putPersonalEvent: async (
+    id: number, body: PersonalEventRequest,
+  ): Promise<PersonalEventResponse> => {
+    const response = await request.put(`/api/v1/personal-event/${id}`, { body });
+    return response;
+  },
 };

--- a/frontend/src/features/my-calendar/api/index.ts
+++ b/frontend/src/features/my-calendar/api/index.ts
@@ -1,16 +1,13 @@
 import { request } from '@/utils/fetch';
 
-import type { PersonalEventDTO, PersonalEventRequest, PersonalEventResponse } from '../model';
+import type { DateRangeParams, PersonalEventRequest, PersonalEventResponse } from '../model';
 
 export const personalEventApi = {
   getPersonalEvent: async (
-    { startDateTime, endDateTime }: Pick<PersonalEventDTO, 'startDateTime' | 'endDateTime'>,
+    { startDate, endDate }: DateRangeParams,
   ): Promise<PersonalEventResponse[]> => {
     const response = await request.get('/api/v1/personal-event', {
-      params: { 
-        startDateTime: `${startDateTime}T00:00:00`, 
-        endDateTime: `${endDateTime}T00:00:00`,
-      },
+      params: { startDate, endDate },
     });
     return response.data;
   },

--- a/frontend/src/features/my-calendar/api/keys.ts
+++ b/frontend/src/features/my-calendar/api/keys.ts
@@ -1,7 +1,7 @@
-import type { PersonalEventDTO } from '../model';
+import type { DateRangeParams } from '../model';
 
 export const personalEventKeys = {
   all: ['personalEvents'],
-  detail: (data: Pick<PersonalEventDTO, 'startDateTime' | 'endDateTime'>) => 
+  detail: (data: DateRangeParams) => 
     [...personalEventKeys.all, data],
 };

--- a/frontend/src/features/my-calendar/api/mutations.ts
+++ b/frontend/src/features/my-calendar/api/mutations.ts
@@ -18,3 +18,23 @@ export const usePersonalEventMutation = () => {
 
   return { mutate };
 };
+
+export const usePersonalEventUpdateMutation = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: (
+      { id, body }: { id: number; body: PersonalEventRequest },
+    ) => personalEventApi.putPersonalEvent(id, body),
+    onSuccess: ({ startDateTime, endDateTime }) => {
+      queryClient.invalidateQueries({
+        queryKey: personalEventKeys.detail({
+          startDate: startDateTime,
+          endDate: endDateTime,
+        }),
+      });
+    },
+  });
+
+  return { mutate };
+};

--- a/frontend/src/features/my-calendar/api/mutations.ts
+++ b/frontend/src/features/my-calendar/api/mutations.ts
@@ -26,12 +26,9 @@ export const usePersonalEventUpdateMutation = () => {
     mutationFn: (
       { id, body }: { id: number; body: PersonalEventRequest },
     ) => personalEventApi.putPersonalEvent(id, body),
-    onSuccess: ({ startDateTime, endDateTime }) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: personalEventKeys.detail({
-          startDate: startDateTime,
-          endDate: endDateTime,
-        }),
+        queryKey: personalEventKeys.all,
       });
     },
   });

--- a/frontend/src/features/my-calendar/api/mutations.ts
+++ b/frontend/src/features/my-calendar/api/mutations.ts
@@ -35,3 +35,18 @@ export const usePersonalEventUpdateMutation = () => {
 
   return { mutate };
 };
+
+export const usePersonalEventDeleteMutation = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: (id: number) => personalEventApi.deletePersonalEvent(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: personalEventKeys.all,
+      });
+    },
+  });
+
+  return { mutate };
+};

--- a/frontend/src/features/my-calendar/api/queries.ts
+++ b/frontend/src/features/my-calendar/api/queries.ts
@@ -1,15 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
-import type { PersonalEventDTO, PersonalEventResponse } from '../model';
+import type { DateRangeParams, PersonalEventResponse } from '../model';
 import { personalEventApi } from '.';
 import { personalEventKeys } from './keys';
 
-export const usePersonalEventsQuery = (
-  data: Pick<PersonalEventDTO, 'startDateTime' | 'endDateTime'>,
-) => {
+export const usePersonalEventsQuery = (params: DateRangeParams) => {
   const { data: personalEvents, isLoading } = useQuery<PersonalEventResponse[]>({
-    queryKey: personalEventKeys.detail(data), 
-    queryFn: () => personalEventApi.getPersonalEvent(data),
+    queryKey: personalEventKeys.detail(params), 
+    queryFn: () => personalEventApi.getPersonalEvent(params),
   });
 
   return { personalEvents, isLoading };

--- a/frontend/src/features/my-calendar/model/index.ts
+++ b/frontend/src/features/my-calendar/model/index.ts
@@ -20,4 +20,9 @@ export type PersonalEventDTO = z.infer<typeof PersonalEventDTO>;
 export type PersonalEventResponse = z.infer<typeof PersonalEventResponse>;
 export type PersonalEventRequest = z.infer<typeof PersonalEventRequest>;
 
+export interface DateRangeParams {
+  startDate: string;
+  endDate: string;
+}
+
 export type PopoverType = 'add' | 'edit';

--- a/frontend/src/features/my-calendar/ui/CalendarCard/Card.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/Card.tsx
@@ -13,6 +13,7 @@ export const Card = ({
   status,
   style,
   title,
+  calendarId,
 }: CalendarCardProps & { handleClickEdit: () => void }) => (
   <div
     className={cardContainerStyle({ status, size })}
@@ -25,6 +26,7 @@ export const Card = ({
       justify='flex-start'
     >
       <CardContents
+        calendarId={calendarId}
         endTime={endTime}
         size={size}
         startTime={startTime}

--- a/frontend/src/features/my-calendar/ui/CalendarCard/Card.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/Card.tsx
@@ -1,0 +1,38 @@
+import { Flex } from '@/components/Flex';
+
+import { CardBottom } from './CardBottom';
+import { CardContents } from './CardContents';
+import { cardBackgroundStyle, cardContainerStyle } from './index.css';
+import type { CalendarCardProps } from './type';
+
+export const Card = ({
+  endTime,
+  handleClickEdit,
+  size,
+  startTime,
+  status,
+  style,
+  title,
+}: CalendarCardProps & { handleClickEdit: () => void }) => (
+  <div
+    className={cardContainerStyle({ status, size })}
+    onClick={handleClickEdit}
+    style={style}
+  >
+    <Flex
+      className={cardBackgroundStyle({ size })}
+      direction={size === 'lg' ? 'column' : 'row'}
+      justify='flex-start'
+    >
+      <CardContents
+        endTime={endTime}
+        size={size}
+        startTime={startTime}
+        status={status}
+        title={title}
+      />
+      <CardBottom onClickEdit={handleClickEdit} size={size} />
+    </Flex>
+  </div>
+);
+  

--- a/frontend/src/features/my-calendar/ui/CalendarCard/Card.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/Card.tsx
@@ -33,7 +33,7 @@ export const Card = ({
         status={status}
         title={title}
       />
-      <CardBottom onClickEdit={handleClickEdit} size={size} />
+      {calendarId && <CardBottom />}
     </Flex>
   </div>
 );

--- a/frontend/src/features/my-calendar/ui/CalendarCard/CardBottom.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/CardBottom.tsx
@@ -1,31 +1,17 @@
 import { Flex } from '@/components/Flex';
-import { GoogleCalendar, Pencil } from '@/components/Icon';
-import { vars } from '@/theme/index.css';
+import { GoogleCalendar } from '@/components/Icon';
 
 import { cardBottomStyle } from './index.css';
-import type { CalendarCardProps } from './type';
 
-export const CardBottom = ({
-  size,
-  onClickEdit,
-}: Pick<CalendarCardProps, 'size' | 'onClickEdit'>) => {
-  if (size !== 'lg') return null;
-  
-  return(
-    <Flex
-      align='flex-end'
-      className={cardBottomStyle}
-      gap={200}
-      height='100%'
-      justify='flex-end'
-      width='full'
-    >
-      <GoogleCalendar />
-      <Pencil
-        clickable
-        fill={vars.color.Ref.Netural[600]}
-        onClick={onClickEdit}
-      />
-    </Flex>
-  );
-};
+export const CardBottom = () => (
+  <Flex
+    align='flex-end'
+    className={cardBottomStyle}
+    gap={200}
+    height='100%'
+    justify='flex-end'
+    width='full'
+  >
+    <GoogleCalendar />
+  </Flex>
+);

--- a/frontend/src/features/my-calendar/ui/CalendarCard/CardBottom.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/CardBottom.tsx
@@ -2,15 +2,14 @@ import { Flex } from '@/components/Flex';
 import { GoogleCalendar, Pencil } from '@/components/Icon';
 import { vars } from '@/theme/index.css';
 
-import type { CalendarCardProps } from '.';
 import { cardBottomStyle } from './index.css';
+import type { CalendarCardProps } from './type';
 
 export const CardBottom = ({
   size,
   onClickEdit,
-  onClickGoogle,
-}: Pick<CalendarCardProps, 'size' | 'onClickEdit' | 'onClickGoogle'>) => {
-  if (size === 'sm' || size === 'md') return null;
+}: Pick<CalendarCardProps, 'size' | 'onClickEdit'>) => {
+  if (size !== 'lg') return null;
   
   return(
     <Flex
@@ -21,7 +20,7 @@ export const CardBottom = ({
       justify='flex-end'
       width='full'
     >
-      <GoogleCalendar clickable onClick={onClickGoogle} />
+      <GoogleCalendar />
       <Pencil
         clickable
         fill={vars.color.Ref.Netural[600]}

--- a/frontend/src/features/my-calendar/ui/CalendarCard/CardContents.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/CardContents.tsx
@@ -3,7 +3,7 @@ import { Flex } from '@/components/Flex';
 import { Text } from '@/components/Text';
 import { adjustmentStatusMap } from '@/constants/statusMap';
 import { vars } from '@/theme/index.css';
-import { formatDateToTimeString } from '@/utils/date';
+import { formatDateToTimeString } from '@/utils/date/format';
 
 import { cardContentStyle, cardTextStyle, cardTitleStyle } from './index.css';
 import type { CalendarCardProps } from './type';

--- a/frontend/src/features/my-calendar/ui/CalendarCard/CardContents.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/CardContents.tsx
@@ -29,7 +29,8 @@ const CalendarCardTimezone = (
 );
   
 export const CardContents = (
-  { status, size, title, endTime, startTime }: Omit<CalendarCardProps, 'id' | 'style'>,
+  { status, size, title, endTime, startTime }: 
+  Omit<CalendarCardProps, 'id' | 'style' | 'syncWithGoogleCalendar'>,
 ) => (
   <Flex
     className={cardContentStyle({ status, size })}

--- a/frontend/src/features/my-calendar/ui/CalendarCard/CardContents.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/CardContents.tsx
@@ -1,0 +1,57 @@
+import { Chip } from '@/components/Chip';
+import { Flex } from '@/components/Flex';
+import { Text } from '@/components/Text';
+import { adjustmentStatusMap } from '@/constants/statusMap';
+import { vars } from '@/theme/index.css';
+import { formatDateToTimeString } from '@/utils/date';
+
+import { cardContentStyle, cardTextStyle, cardTitleStyle } from './index.css';
+import type { CalendarCardProps } from './type';
+
+const CalendarCardChip = ({ status, size }: Pick<CalendarCardProps, 'status' | 'size'>) => {
+  if (size === 'sm' || size === 'md') return null;
+  
+  return (
+    <Chip color={adjustmentStatusMap[status].color}>
+      {adjustmentStatusMap[status].label}
+    </Chip>
+  );
+};
+  
+const CalendarCardTimezone = (
+  { startTime, endTime }: Pick<CalendarCardProps, 'startTime' | 'endTime'>,
+) => (
+  <Text color={vars.color.Ref.Netural[600]} typo='b3R'>
+    {formatDateToTimeString(startTime)}
+    -
+    {formatDateToTimeString(endTime)}
+  </Text>
+);
+  
+export const CardContents = (
+  { status, size, title, endTime, startTime }: Omit<CalendarCardProps, 'id' | 'style'>,
+) => (
+  <Flex
+    className={cardContentStyle({ status, size })}
+    direction='column'
+    gap={size === 'lg' ? 200 : 100}
+  >
+    <CalendarCardChip size={size} status={status} />
+    <Flex 
+      align={size === 'sm' ? 'center' : 'flex-start'}
+      className={cardTextStyle}
+      direction={size === 'sm' ? 'row' : 'column'} 
+      gap={size === 'sm' ? 200 : 50}
+    >
+      <CalendarCardTimezone endTime={endTime} startTime={startTime} />
+      <Text
+        className={cardTitleStyle({ size })}
+        color={vars.color.Ref.Netural[800]}
+        typo={size === 'sm' ? 't3' : 't1'}
+      >
+        {title}
+      </Text>
+    </Flex>
+  </Flex>
+);
+    

--- a/frontend/src/features/my-calendar/ui/CalendarCard/index.css.ts
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/index.css.ts
@@ -6,6 +6,7 @@ import { vars } from '@/theme/index.css';
 export const cardContainerStyle = recipe({
   base: {
     padding: vars.spacing[200],
+    cursor: 'pointer',
   },
   variants: {
     status: {

--- a/frontend/src/features/my-calendar/ui/CalendarCard/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/index.tsx
@@ -1,47 +1,40 @@
-import { Flex } from '@/components/Flex';
+import { useState } from 'react';
 
-import { CardBottom } from './CardBottom';
-import { CardContents } from './CardContents';
-import {
-  cardBackgroundStyle, 
-  cardContainerStyle, 
-} from './index.css';
+import { formatDateToDateTimeString } from '@/utils/date/format';
+
+import { SchedulePopover } from '../SchedulePopover';
+import { Card } from './Card';
 import type { CalendarCardProps } from './type';
 
 export const CalendarCard = ({ 
   id,
-  status, 
   size = 'lg', 
-  title, 
   startTime, 
   endTime, 
-  style, 
+  ...props
 }: CalendarCardProps) => {
-
+  const [open, setOpen] = useState(false);
   const handleClickEdit = () => {
-    // console.log(id);
+    setOpen(true);
   };
-
   return (
-    <div
-      className={cardContainerStyle({ status, size })}
-      onClick={handleClickEdit}
-      style={style}
-    >
-      <Flex
-        className={cardBackgroundStyle({ size })}
-        direction={size === 'lg' ? 'column' : 'row'}
-        justify='flex-start'
-      >
-        <CardContents
-          endTime={endTime}
-          size={size}
-          startTime={startTime}
-          status={status}
-          title={title}
-        />
-        <CardBottom onClickEdit={handleClickEdit} size={size} />
-      </Flex>
-    </div>
+    <>
+      {open && 
+      <SchedulePopover
+        endDateTime={formatDateToDateTimeString(endTime)}
+        scheduleId={id}
+        setIsOpen={setOpen}
+        startDateTime={formatDateToDateTimeString(startTime)}
+        type='edit'
+      />}
+      <Card
+        endTime={endTime}
+        handleClickEdit={handleClickEdit}
+        id={id}
+        size={size}
+        startTime={startTime}
+        {...props}
+      />
+    </>
   );
 };

--- a/frontend/src/features/my-calendar/ui/CalendarCard/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/index.tsx
@@ -26,6 +26,11 @@ export const CalendarCard = ({
         setIsOpen={setOpen}
         startDateTime={formatDateToDateTimeString(startTime)}
         type='edit'
+        values={{
+          title: props.title,
+          isAdjustable: props.status === 'adjustable',
+          syncWithGoogleCalendar: props.syncWithGoogleCalendar,
+        }}
       />}
       <Card
         endTime={endTime}

--- a/frontend/src/features/my-calendar/ui/CalendarCard/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/index.tsx
@@ -29,7 +29,7 @@ export const CalendarCard = ({
         values={{
           title: props.title,
           isAdjustable: props.status === 'adjustable',
-          syncWithGoogleCalendar: props.syncWithGoogleCalendar,
+          syncWithGoogleCalendar: !!props.calendarId,
         }}
       />}
       <Card

--- a/frontend/src/features/my-calendar/ui/CalendarCard/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/index.tsx
@@ -1,100 +1,47 @@
-import type { CSSProperties } from 'react';
-
-import { Chip } from '@/components/Chip';
 import { Flex } from '@/components/Flex';
-import { Text } from '@/components/Text';
-import type { AdjustmentStatus } from '@/constants/statusMap';
-import { adjustmentStatusMap } from '@/constants/statusMap';
-import { vars } from '@/theme/index.css';
-import { formatDateToTimeString } from '@/utils/date/format';
 
 import { CardBottom } from './CardBottom';
+import { CardContents } from './CardContents';
 import {
   cardBackgroundStyle, 
   cardContainerStyle, 
-  cardContentStyle,
-  cardTextStyle,
-  cardTitleStyle, 
 } from './index.css';
+import type { CalendarCardProps } from './type';
 
-export interface CalendarCardProps {
-  status: AdjustmentStatus; 
-  size?: 'sm' | 'md' | 'lg';
-  title: string;
-  startTime: Date | null;
-  endTime: Date | null;
-  style: CSSProperties;
-  onClickGoogle?: () => void;
-  onClickEdit?: () => void;
-}
-
-const CalendarCardChip = ({ status, size }: Pick<CalendarCardProps, 'status' | 'size'>) => {
-  if (size === 'sm' || size === 'md') return null;
-
-  return (
-    <Chip color={adjustmentStatusMap[status].color}>
-      {adjustmentStatusMap[status].label}
-    </Chip>
-  );
-};
-
-const CalendarCardTimezone = (
-  { startTime, endTime }: Pick<CalendarCardProps, 'startTime' | 'endTime'>,
-) => (
-  <Text color={vars.color.Ref.Netural[600]} typo='b3R'>
-    {formatDateToTimeString(startTime)}
-    -
-    {formatDateToTimeString(endTime)}
-  </Text>
-);
-
-const CalendarTitle = ({ size, title }: Pick<CalendarCardProps, 'title' | 'size'>) => (
-  <Text
-    className={cardTitleStyle({ size })}
-    color={vars.color.Ref.Netural[800]}
-    typo={size === 'sm' ? 't3' : 't1'}
-  >
-    {title}
-  </Text>
-);
-  
 export const CalendarCard = ({ 
+  id,
   status, 
   size = 'lg', 
   title, 
   startTime, 
   endTime, 
-  onClickEdit, 
-  onClickGoogle, 
   style, 
-}: CalendarCardProps) => (
-  <div className={cardContainerStyle({ status, size })} style={style}>
-    <Flex
-      className={cardBackgroundStyle({ size })}
-      direction={size === 'lg' ? 'column' : 'row'}
-      justify='flex-start'
+}: CalendarCardProps) => {
+
+  const handleClickEdit = () => {
+    // console.log(id);
+  };
+
+  return (
+    <div
+      className={cardContainerStyle({ status, size })}
+      onClick={handleClickEdit}
+      style={style}
     >
       <Flex
-        className={cardContentStyle({ status, size })}
-        direction='column'
-        gap={size === 'lg' ? 200 : 100}
+        className={cardBackgroundStyle({ size })}
+        direction={size === 'lg' ? 'column' : 'row'}
+        justify='flex-start'
       >
-        <CalendarCardChip size={size} status={status} />
-        <Flex 
-          align={size === 'sm' ? 'center' : 'flex-start'}
-          className={cardTextStyle}
-          direction={size === 'sm' ? 'row' : 'column'} 
-          gap={size === 'sm' ? 200 : 50}
-        >
-          <CalendarCardTimezone endTime={endTime} startTime={startTime} />
-          <CalendarTitle size={size} title={title} />
-        </Flex>
+        <CardContents
+          endTime={endTime}
+          size={size}
+          startTime={startTime}
+          status={status}
+          title={title}
+        />
+        <CardBottom onClickEdit={handleClickEdit} size={size} />
       </Flex>
-      <CardBottom
-        onClickEdit={onClickEdit}
-        onClickGoogle={onClickGoogle}
-        size={size}
-      />
-    </Flex>
-  </div>
-);
+    </div>
+  );
+};

--- a/frontend/src/features/my-calendar/ui/CalendarCard/type.ts
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/type.ts
@@ -9,6 +9,7 @@ export interface CalendarCardProps {
   title: string;
   startTime: Date | null;
   endTime: Date | null;
+  syncWithGoogleCalendar: boolean;
   style: CSSProperties;
   onClickEdit?: () => void;
 }

--- a/frontend/src/features/my-calendar/ui/CalendarCard/type.ts
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/type.ts
@@ -1,0 +1,14 @@
+import type { CSSProperties } from 'react';
+
+import type { AdjustmentStatus } from '@/constants/statusMap';
+
+export interface CalendarCardProps {
+  id: number;
+  status: AdjustmentStatus; 
+  size?: 'sm' | 'md' | 'lg';
+  title: string;
+  startTime: Date | null;
+  endTime: Date | null;
+  style: CSSProperties;
+  onClickEdit?: () => void;
+}

--- a/frontend/src/features/my-calendar/ui/CalendarCard/type.ts
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/type.ts
@@ -9,7 +9,7 @@ export interface CalendarCardProps {
   title: string;
   startTime: Date | null;
   endTime: Date | null;
-  syncWithGoogleCalendar: boolean;
+  calendarId: string;
   style: CSSProperties;
   onClickEdit?: () => void;
 }

--- a/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
@@ -1,7 +1,7 @@
 import { TIME_HEIGHT } from '@/constants/date';
 import { calcPositionByDate } from '@/utils/date/position';
 
-import type { PersonalEventDTO } from '../../model';
+import type { PersonalEventResponse } from '../../model';
 import { CalendarCard } from '../CalendarCard';
 
 const calcSize = (height: number) => {
@@ -10,7 +10,7 @@ const calcSize = (height: number) => {
   return 'lg';
 };
 
-export const CalendarCardList = ({ cards }: { cards: PersonalEventDTO[] }) => (
+export const CalendarCardList = ({ cards }: { cards: PersonalEventResponse[] }) => (
   <>
     {cards.map((card) => {
       const start = new Date(card.startDateTime);

--- a/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
@@ -10,9 +10,7 @@ const calcSize = (height: number) => {
   return 'lg';
 };
 
-export const CalendarCardList = (
-  { cards }: { cards: Omit<PersonalEventDTO, 'syncWithGoogleCalendar'>[] },
-) => (
+export const CalendarCardList = ({ cards }: { cards: PersonalEventDTO[] }) => (
   <>
     {cards.map((card) => {
       const start = new Date(card.startDateTime);
@@ -23,6 +21,7 @@ export const CalendarCardList = (
 
       return (
         <CalendarCard
+          calendarId={card.calendarId}
           endTime={end}
           id={card.id}
           key={card.id}

--- a/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
@@ -20,10 +20,11 @@ export const CalendarCardList = (
       const { x: sx, y: sy } = calcPositionByDate(start);
       const { y: ey } = calcPositionByDate(end);
       const height = ey - sy;
-          
+
       return (
         <CalendarCard
           endTime={end}
+          id={card.id}
           key={card.id}
           size={calcSize(height)}
           startTime={start}

--- a/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
@@ -55,7 +55,7 @@ export const MyCalendar = () => {
     <Calendar {...calendar} className={calendarStyle}>
       <Calendar.Core />
       <Calendar.Header />
-      {isLoading ? <div>로딩중...</div> : <CalendarTable personalEvents={personalEvents} />}
+      {<CalendarTable personalEvents={isLoading ? [] : personalEvents} />}
     </Calendar>
   );
 };

--- a/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
@@ -47,8 +47,8 @@ export const MyCalendar = () => {
   const { startDate, endDate } = formatDateToWeekRange(calendar.selectedDate);
 
   const { personalEvents, isLoading } = usePersonalEventsQuery({ 
-    startDateTime: formatDateToBarString(startDate), 
-    endDateTime: formatDateToBarString(endDate),
+    startDate: formatDateToBarString(startDate), 
+    endDate: formatDateToBarString(endDate),
   });
 
   return (

--- a/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 
 import { Calendar } from '@/components/Calendar';
 import { useSharedCalendarContext } from '@/components/Calendar/context/SharedCalendarContext';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import { useSelectTime } from '@/hooks/useSelectTime';
 import { formatDateToWeekRange } from '@/utils/date';
 import { formatDateToBarString, formatDateToDateTimeString } from '@/utils/date/format';

--- a/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { Calendar } from '@/components/Calendar';
 import { useSharedCalendarContext } from '@/components/Calendar/context/SharedCalendarContext';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { useSelectTime } from '@/hooks/useSelectTime';
 import { formatDateToWeekRange } from '@/utils/date';
 import { formatDateToBarString, formatDateToDateTimeString } from '@/utils/date/format';
@@ -15,7 +16,7 @@ import { calendarStyle, containerStyle } from './index.css';
 const CalendarTable = (
   { personalEvents = [] }: { personalEvents?: PersonalEventResponse[] },
 ) => {
-  const { handleMouseUp, ...time } = useSelectTime();
+  const { handleMouseUp, reset, ...time } = useSelectTime();
   const [open, setOpen] = useState(false);
 
   const handleMouseUpAddSchedule = () => {
@@ -27,6 +28,7 @@ const CalendarTable = (
       {open && 
       <SchedulePopover
         endDateTime={formatDateToDateTimeString(time.doneEndTime)}
+        reset={reset}
         setIsOpen={setOpen}
         startDateTime={formatDateToDateTimeString(time.doneStartTime)}
         type='add'
@@ -35,6 +37,10 @@ const CalendarTable = (
       <Calendar.Table 
         context={{
           handleMouseUp: () => handleMouseUp(handleMouseUpAddSchedule),
+          reset: () => {
+            setOpen(false);
+            reset();
+          },
           ...time,
         }}
       />

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverButton.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverButton.tsx
@@ -6,12 +6,13 @@ import { buttonStyle } from './index.css';
 
 interface PopoverButtonProps {
   type: PopoverType;
-  onClickSave: () => void;
+  onClickCreate: () => void;
+  onClickEdit: () => void;
   onClickDelete: () => void;
 }
 
 export const PopoverButton = ({ type, ...handlers }: PopoverButtonProps)=>(
-  type === 'add' ? <Button className={buttonStyle} onClick={handlers.onClickSave}>저장</Button> : (
+  type === 'add' ? <Button className={buttonStyle} onClick={handlers.onClickCreate}>저장</Button> : (
     <Flex
       gap={100}
       justify='flex-end'
@@ -25,7 +26,7 @@ export const PopoverButton = ({ type, ...handlers }: PopoverButtonProps)=>(
       >
         삭제
       </Button>
-      <Button className={buttonStyle} onClick={handlers.onClickSave}>저장</Button>
+      <Button className={buttonStyle} onClick={handlers.onClickEdit}>저장</Button>
     </Flex>
   )
 );

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
@@ -11,12 +11,11 @@ import type { PersonalEventRequest } from '../../model';
 import { cardStyle, inputStyle } from './index.css';
 
 // TODO: Form Context 관리
-const AdjustableCheckbox = ({ handleChange, valuesRef }: FormRef<PersonalEventRequest>) => (
+const AdjustableCheckbox = ({ handleChange }: FormRef<PersonalEventRequest>) => (
   <Checkbox
     inputProps={{
       name: 'isAdjustable',
-      checked: valuesRef.current.isAdjustable,
-      onChange: handleChange,
+      onChange: (e) => handleChange({ name: 'isAdjustable', value: e.target.checked }),
     }}
     size='sm'
   >
@@ -25,13 +24,12 @@ const AdjustableCheckbox = ({ handleChange, valuesRef }: FormRef<PersonalEventRe
 );
 
 const GoogleCalendarToggle = (
-  { handleChange, valuesRef }: FormRef<PersonalEventRequest>,
+  { handleChange }: FormRef<PersonalEventRequest>,
 ) =>
   <Toggle
     inputProps={{
       name: 'syncWithGoogleCalendar',
-      checked: valuesRef.current.syncWithGoogleCalendar,
-      onChange: handleChange,
+      onChange: (e) => handleChange({ name: 'syncWithGoogleCalendar', value: e.target.checked }),
     }}
   />;
 
@@ -46,7 +44,7 @@ export const PopoverForm = ({ valuesRef, handleChange }: FormRef<PersonalEventRe
       <input
         className={inputStyle}
         name='title'
-        onChange={handleChange}
+        onChange={(e) => handleChange({ name: 'title', value: e.target.value })}
         placeholder='새 일정'
       />
       <Input.Multi

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
@@ -15,8 +15,8 @@ const AdjustableCheckbox = (
   { valuesRef, handleChange }: FormRef<PersonalEventRequest>,
 ) => (
   <Checkbox
+    defaultChecked={valuesRef.current.isAdjustable}
     inputProps={{
-      defaultChecked: valuesRef.current.isAdjustable,
       name: 'isAdjustable',
       onChange: (e) => handleChange({ name: 'isAdjustable', value: e.target.checked }),
     }}

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
@@ -11,9 +11,12 @@ import type { PersonalEventRequest } from '../../model';
 import { cardStyle, inputStyle } from './index.css';
 
 // TODO: Form Context 관리
-const AdjustableCheckbox = ({ handleChange }: FormRef<PersonalEventRequest>) => (
+const AdjustableCheckbox = (
+  { valuesRef, handleChange }: FormRef<PersonalEventRequest>,
+) => (
   <Checkbox
     inputProps={{
+      defaultChecked: valuesRef.current.isAdjustable,
       name: 'isAdjustable',
       onChange: (e) => handleChange({ name: 'isAdjustable', value: e.target.checked }),
     }}
@@ -24,9 +27,10 @@ const AdjustableCheckbox = ({ handleChange }: FormRef<PersonalEventRequest>) => 
 );
 
 const GoogleCalendarToggle = (
-  { handleChange }: FormRef<PersonalEventRequest>,
+  { valuesRef, handleChange }: FormRef<PersonalEventRequest>,
 ) =>
   <Toggle
+    defaultChecked={valuesRef.current.syncWithGoogleCalendar}
     inputProps={{
       name: 'syncWithGoogleCalendar',
       onChange: (e) => handleChange({ name: 'syncWithGoogleCalendar', value: e.target.checked }),
@@ -43,6 +47,7 @@ export const PopoverForm = ({ valuesRef, handleChange }: FormRef<PersonalEventRe
     >
       <input
         className={inputStyle}
+        defaultValue={valuesRef.current.title}
         name='title'
         onChange={(e) => handleChange({ name: 'title', value: e.target.value })}
         placeholder='새 일정'

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.css.ts
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.css.ts
@@ -57,3 +57,13 @@ export const buttonStyle = style({
   alignSelf: 'flex-end',
   marginTop: vars.spacing[200],
 });
+
+export const backgroundStyle = style({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+
+  zIndex: 2,
+});

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.css.ts
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.css.ts
@@ -20,7 +20,7 @@ export const containerStyle = style({
   border: `1px solid ${vars.color.Ref.Netural[200]}`,
   borderRadius: vars.radius[500],
 
-  zIndex: 1,
+  zIndex: 3,
 });
 
 export const titleStyle = style({

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
@@ -1,10 +1,9 @@
 import { Flex } from '@/components/Flex';
-import type { FormValues } from '@/hooks/useFormRef';
 import { useFormRef } from '@/hooks/useFormRef';
 import { isSaturday } from '@/utils/date';
 import { calcPositionByDate } from '@/utils/date/position';
 
-import { usePersonalEventMutation, usePersonalEventUpdateMutation } from '../../api/mutations';
+import { useSchedulePopover } from '../../api/hooks';
 import type { PersonalEventRequest, PopoverType } from '../../model';
 import { backgroundStyle, containerStyle } from './index.css';
 import { PopoverButton } from './PopoverButton';
@@ -27,36 +26,6 @@ const initEvent = (values?: DefaultEvent): DefaultEvent => {
     isAdjustable: false,
     syncWithGoogleCalendar: true,
   };
-};
-
-const useSchedulePopover = ({
-  setIsOpen,
-  scheduleId,
-  valuesRef,
-}: {
-  setIsOpen: (isOpen: boolean) => void;
-  scheduleId?: number;
-  valuesRef: { current: FormValues<PersonalEventRequest> };
-}) => {
-  const { mutate: createMutate } = usePersonalEventMutation();
-  const { mutate: editMutate } = usePersonalEventUpdateMutation();
-
-  const handleClickCreate = () => {
-    createMutate(valuesRef.current);
-    setIsOpen(false);
-  };
-
-  const handleClickEdit = () => {
-    if (scheduleId) editMutate({ id: scheduleId, body: valuesRef.current });
-    setIsOpen(false);
-  };
-
-  const handleClickDelete = () => {
-    // if (scheduleId) mutate({ ...valuesRef.current, id: scheduleId });
-    setIsOpen(false);
-  };
-
-  return { handleClickCreate, handleClickEdit, handleClickDelete };
 };
 
 export const SchedulePopover = (

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
@@ -17,6 +17,7 @@ interface SchedulePopoverProps extends Pick<PersonalEventRequest, 'endDateTime' 
   values?: DefaultEvent;
   setIsOpen: (isOpen: boolean) => void;
   type: PopoverType;
+  reset?: () => void;
 }
 
 const initEvent = (values?: DefaultEvent): DefaultEvent => {
@@ -28,8 +29,18 @@ const initEvent = (values?: DefaultEvent): DefaultEvent => {
   };
 };
 
+const Background = ({ setIsOpen, reset }: Pick<SchedulePopoverProps, 'setIsOpen' | 'reset'>) => (
+  <Flex
+    className={backgroundStyle}
+    onClick={() => {
+      setIsOpen(false);
+      reset?.();
+    }}
+  />
+);
+
 export const SchedulePopover = (
-  { setIsOpen, scheduleId, type, values, ...event }: SchedulePopoverProps,
+  { setIsOpen, reset, scheduleId, type, values, ...event }: SchedulePopoverProps,
 ) => {
   const startDate = new Date(event.startDateTime);
   const { x: sx, y: sy } = calcPositionByDate(startDate);
@@ -40,6 +51,7 @@ export const SchedulePopover = (
   });
   const { handleClickCreate, handleClickEdit, handleClickDelete } = useSchedulePopover({
     setIsOpen,
+    reset,
     scheduleId,
     valuesRef,
   });
@@ -63,7 +75,7 @@ export const SchedulePopover = (
           type={type}
         />
       </dialog>
-      <Flex className={backgroundStyle} onClick={() => setIsOpen(false)} />
+      <Background reset={reset} setIsOpen={setIsOpen} />
     </>
   ); 
 };

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
@@ -38,7 +38,6 @@ export const SchedulePopover = (
   const handleClickDelete = () => {
     // do something
   };
-
   return(
     <dialog
       className={containerStyle}

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
@@ -1,5 +1,4 @@
 import { Flex } from '@/components/Flex';
-import { useClickOutside } from '@/hooks/useClickOutside';
 import type { FormValues } from '@/hooks/useFormRef';
 import { useFormRef } from '@/hooks/useFormRef';
 import { isSaturday } from '@/utils/date';
@@ -63,7 +62,6 @@ const useSchedulePopover = ({
 export const SchedulePopover = (
   { setIsOpen, scheduleId, type, values, ...event }: SchedulePopoverProps,
 ) => {
-  const ref = useClickOutside<HTMLDialogElement>(() => setIsOpen(false));
   const startDate = new Date(event.startDateTime);
   const { x: sx, y: sy } = calcPositionByDate(startDate);
   const { valuesRef, handleChange } = useFormRef<PersonalEventRequest>({
@@ -77,10 +75,9 @@ export const SchedulePopover = (
     valuesRef,
   });
   return(
-    <Flex className={backgroundStyle}>
+    <>
       <dialog
         className={containerStyle}
-        ref={ref}
         style={{
           position: 'absolute',
           left: isSaturday(startDate) 
@@ -97,6 +94,7 @@ export const SchedulePopover = (
           type={type}
         />
       </dialog>
-    </Flex>
+      <Flex className={backgroundStyle} onClick={() => setIsOpen(false)} />
+    </>
   ); 
 };

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
@@ -1,3 +1,5 @@
+import { Flex } from '@/components/Flex';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import type { FormValues } from '@/hooks/useFormRef';
 import { useFormRef } from '@/hooks/useFormRef';
 import { isSaturday } from '@/utils/date';
@@ -5,7 +7,7 @@ import { calcPositionByDate } from '@/utils/date/position';
 
 import { usePersonalEventMutation, usePersonalEventUpdateMutation } from '../../api/mutations';
 import type { PersonalEventRequest, PopoverType } from '../../model';
-import { containerStyle } from './index.css';
+import { backgroundStyle, containerStyle } from './index.css';
 import { PopoverButton } from './PopoverButton';
 import { PopoverForm } from './PopoverForm';
 import { Title } from './Title';
@@ -61,6 +63,7 @@ const useSchedulePopover = ({
 export const SchedulePopover = (
   { setIsOpen, scheduleId, type, values, ...event }: SchedulePopoverProps,
 ) => {
+  const ref = useClickOutside<HTMLDialogElement>(() => setIsOpen(false));
   const startDate = new Date(event.startDateTime);
   const { x: sx, y: sy } = calcPositionByDate(startDate);
   const { valuesRef, handleChange } = useFormRef<PersonalEventRequest>({
@@ -68,31 +71,32 @@ export const SchedulePopover = (
     endDateTime: event.endDateTime,
     ...initEvent(values),
   });
-
   const { handleClickCreate, handleClickEdit, handleClickDelete } = useSchedulePopover({
     setIsOpen,
     scheduleId,
     valuesRef,
   });
-
   return(
-    <dialog
-      className={containerStyle}
-      style={{
-        position: 'absolute',
-        left: isSaturday(startDate) 
-          ? `calc((100% - 72px) / 7 * ${sx - 1})` : `calc((100% - 72px) / 7 * ${sx + 1})`,
-        top: 16 + sy,
-      }}
-    >
-      <Title type={type} />
-      <PopoverForm handleChange={handleChange} valuesRef={valuesRef} />
-      <PopoverButton
-        onClickCreate={handleClickCreate}
-        onClickDelete={handleClickDelete}
-        onClickEdit={handleClickEdit}
-        type={type}
-      />
-    </dialog>
+    <Flex className={backgroundStyle}>
+      <dialog
+        className={containerStyle}
+        ref={ref}
+        style={{
+          position: 'absolute',
+          left: isSaturday(startDate) 
+            ? `calc((100% - 72px) / 7 * ${sx - 1})` : `calc((100% - 72px) / 7 * ${sx + 1})`,
+          top: 16 + sy,
+        }}
+      >
+        <Title type={type} />
+        <PopoverForm handleChange={handleChange} valuesRef={valuesRef} />
+        <PopoverButton
+          onClickCreate={handleClickCreate}
+          onClickDelete={handleClickDelete}
+          onClickEdit={handleClickEdit}
+          type={type}
+        />
+      </dialog>
+    </Flex>
   ); 
 };

--- a/frontend/src/hooks/useCheckbox.ts
+++ b/frontend/src/hooks/useCheckbox.ts
@@ -12,15 +12,20 @@ interface CheckedStateProps {
   type: 'all' | 'single';
 }
 
+interface UseCheckboxReturn {
+  handleClickCheck: () => void;
+  checked: boolean;
+}
+
 export const useCheckbox = ({ 
   value, 
   defaultChecked, 
   isChecked, 
   onToggleCheck, 
   type, 
-}: CheckedStateProps) => {
+}: CheckedStateProps): UseCheckboxReturn => {
   const group = useContext(GroupContext);
-  const [checked, setChecked] = useState(defaultChecked || false);
+  const [checked, setChecked] = useState<boolean>(defaultChecked || false);
   
   const handleClickCheck = () => {
     if (group) {
@@ -35,8 +40,10 @@ export const useCheckbox = ({
   };
 
   const findIsChecked = () => {
-    if (type === 'all') return group?.isAllChecked;
-    if (value) return group?.checkedList.has(value);
+    if (group) {
+      if (type === 'all') return group.isAllChecked;
+      if (value) return group.checkedList.has(value);
+    }
     if (isChecked) return isChecked;
     return checked;
   };

--- a/frontend/src/hooks/useFormRef.ts
+++ b/frontend/src/hooks/useFormRef.ts
@@ -1,20 +1,20 @@
-import type { ChangeEvent } from 'react';
 import { useRef } from 'react';
 
 // Form의 value로는 다양한 값이 올 수 있습니다.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FormValues<T> = { [K in keyof T]: any };
+export type ChangeEvent<T> = { name: keyof T; value: string | boolean };
 
 export interface FormRef<T> {
   valuesRef: { current: FormValues<T> };
-  handleChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  handleChange: ({ name, value }: ChangeEvent<T>) => void;
 }
 
 export const useFormRef = <T>(initialValues: FormValues<T>): FormRef<T> => {
   const valuesRef = useRef<FormValues<T>>({ ...initialValues });
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    valuesRef.current[e.target.name as keyof T] = e.target.value;
+  const handleChange = ({ name, value }: ChangeEvent<T>) => {
+    valuesRef.current[name] = value;
   };
 
   return { valuesRef, handleChange };

--- a/frontend/src/hooks/useSelectTime.ts
+++ b/frontend/src/hooks/useSelectTime.ts
@@ -31,18 +31,18 @@ const resetDoneTime = () => ({
   endTime: null,
 });
 
-const calcDoneTimeRange = (selectedTime: TimeRange, date?: Date) => {
+const calcDoneTimeRange = (selectedTime: TimeRange) => {
   const OFFSET = 15 * 60 * 1000;
-  if (!selectedTime.startTime && date) {
+  if (selectedTime.startTime && !selectedTime.endTime) {
     return {
-      startTime: date,
-      endTime: new Date(date.getTime() + OFFSET),
+      startTime: selectedTime.startTime,
+      endTime: new Date(selectedTime.startTime.getTime() + OFFSET),
     };
   }
   const { startDate, endDate } = sortDate(selectedTime.startTime, selectedTime.endTime);
   return {
-    startTime: date || startDate,
-    endTime: date || endDate,
+    startTime: startDate,
+    endTime: endDate,
   };
 };
 
@@ -61,7 +61,7 @@ const selectReducer = (state: State, action: Action) => {
       };
 
     case 'SELECT_END': {
-      const doneTime = calcDoneTimeRange(state.selectedTime, action.date);
+      const doneTime = calcDoneTimeRange(state.selectedTime);
       if (typeof action.callback === 'function') action.callback(doneTime);
       return {
         selectedTime: resetSelectedTime(),
@@ -90,7 +90,6 @@ export interface TimeInfo {
   handleMouseDown: (date: Date) => void;
   handleMouseEnter: (date: Date) => void;
   handleMouseUp: (callback?: Callback) => void;
-  handleClick: (date: Date) => void;
   reset: () => void;
 }
 
@@ -109,7 +108,6 @@ export const useSelectTime = (): TimeInfo => {
     handleMouseDown: (date: Date) => dispatch({ type: 'SELECT_START', date }),
     handleMouseEnter: (date: Date) => dispatch({ type: 'SELECT_PROGRESS', date }),
     handleMouseUp: (callback) => dispatch({ type: 'SELECT_END', callback }),
-    handleClick: (date: Date) => dispatch({ type: 'SELECT_END', date }),
     reset: () => dispatch({ type: 'SELECT_CANCEL' }),
   };
 };

--- a/frontend/src/routes/oauth.redirect/index.tsx
+++ b/frontend/src/routes/oauth.redirect/index.tsx
@@ -5,16 +5,16 @@ import { useJWTMutation } from '@/features/login/api/mutations';
 import { getLastRoutePath } from '@/utils/route';
 
 const Redirect = () => {
-  const { loginMutate, isPending } = useJWTMutation();
+  const { loginMutate } = useJWTMutation();
   const lastPath = getLastRoutePath();
   const params: { code: string } = useSearch({ from: '/oauth/redirect/' });
   const { code } = params;
 
   useEffect(() => {
-    if (code && !isPending) {
+    if (code) {
       loginMutate({ code, lastPath });
     }
-  }, [code, loginMutate, isPending, lastPath]);
+  }, [code, loginMutate, lastPath]);
 
   return null;
 };

--- a/frontend/src/utils/fetch/index.ts
+++ b/frontend/src/utils/fetch/index.ts
@@ -54,8 +54,12 @@ export const executeFetch = async (
       throw new Error(`HTTP Error: ${response.status}`);
     }
 
+    const text = await response.clone().text();
+    if (!text) return response;
+
     const data = await response.json();
     return data;
+
   } catch (error) {
     throw new Error(`Network Error : ${error}`);
   }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- close #122 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 개인 일정 수정, 삭제
- 팝오버 스크롤 막기, 외부 클릭 시 선택 해제, 위치 변경

https://github.com/user-attachments/assets/717fe1a3-b06a-45e0-9279-c389f3ef2461

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 기능 동작 위주로 봐주시면 좋을 것 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced interactive calendar cards with a refreshed design and a scheduling popover that simplifies event editing and management.
  - Enabled streamlined creation, updating, and deletion of personal events for an enhanced calendar experience.

- **UX Enhancements**
  - Improved visual feedback and overall interaction across calendar elements.
  - Refined checkbox and form behaviors for smoother scheduling.
  - Enhanced login flow and data fetching reliability for stable performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->