### PR TITLE
[FE-Feat] 세그먼트 컨트롤 구현 수정

### DIFF
--- a/frontend/src/components/SegmentControl/Content.tsx
+++ b/frontend/src/components/SegmentControl/Content.tsx
@@ -1,0 +1,24 @@
+import type { PropsWithChildren } from 'react';
+
+import { useSafeContext } from '@/hooks/useSafeContext';
+import clsx from '@/utils/clsx';
+
+import { contentContainerStyle } from './index.css';
+import { SegmentControlContext } from './SegmentControlContext';
+
+interface ContentProps extends PropsWithChildren {
+  value: string;
+  className?: string;
+}
+
+const Content = ({ value, className, children }: ContentProps) => {
+  const { selectedValue } = useSafeContext(SegmentControlContext);
+  if (selectedValue !== value) return null;
+  return (
+    <section className={clsx(contentContainerStyle, className)}>
+      {children}
+    </section>
+  );
+};
+
+export default Content;

--- a/frontend/src/components/SegmentControl/ControlButton.tsx
+++ b/frontend/src/components/SegmentControl/ControlButton.tsx
@@ -7,20 +7,17 @@ import { SegmentControlContext } from './SegmentControlContext';
 interface ControlButtonProps {
   value: string;
   segmentControlStyle: SegmentControlProps['style'];
-  key?: string;
 }
 
 const ControlButton = ({ 
   value, 
   segmentControlStyle,
-  key,
 }: ControlButtonProps ) => {
   const { selectedValue, handleSelect } = useSafeContext(SegmentControlContext);
   
   return (
     <Button
       as='li'
-      key={key}
       onClick={() => handleSelect(value)}
       radius='max'
       size='lg'

--- a/frontend/src/components/SegmentControl/ControlButton.tsx
+++ b/frontend/src/components/SegmentControl/ControlButton.tsx
@@ -1,0 +1,41 @@
+import { useSafeContext } from '@/hooks/useSafeContext';
+
+import Button from '../Button';
+import type { SegmentControlProps } from '.';
+import { SegmentControlContext } from './SegmentControlContext';
+
+interface ControlButtonProps {
+  value: string;
+  segmentControlStyle: SegmentControlProps['style'];
+  key?: string;
+}
+
+const ControlButton = ({ 
+  value, 
+  segmentControlStyle,
+  key,
+}: ControlButtonProps ) => {
+  const { selectedValue, handleSelect } = useSafeContext(SegmentControlContext);
+  
+  return (
+    <Button
+      as='li'
+      key={key}
+      onClick={() => handleSelect(value)}
+      radius='max'
+      size='lg'
+      style={getButtonStyle(selectedValue === value, segmentControlStyle)}
+      variant='secondary'
+    >
+      {value}
+    </Button>
+  );
+};
+
+const getButtonStyle = (isSelected: boolean, segmentControlStyle: SegmentControlProps['style']) => {
+  if (!isSelected) return 'borderless';
+  if (segmentControlStyle === 'filled') return 'filled';
+  return 'weak';
+};
+
+export default ControlButton;

--- a/frontend/src/components/SegmentControl/SegmentControl.stories.tsx
+++ b/frontend/src/components/SegmentControl/SegmentControl.stories.tsx
@@ -19,12 +19,15 @@ export default meta;
 
 export const Default: StoryObj<typeof SegmentControl> = {
   args: {
-    options: [
-      { label: '라벨1', value: 'label1' },
-      { label: '라벨2', value: 'label2' },
-      { label: '라벨3', value: 'label3' },
-    ],
-    defaultValue: 'label1',
-    onChange: () => { /* do nothing */ },
+    values: ['라벨1', '라벨2', '라벨3'],
+    defaultValue: '라벨1',
   },
 };
+
+export const WithContent = () => (
+  <SegmentControl defaultValue='라벨1' values={['라벨1', '라벨2', '라벨3']}>
+    <SegmentControl.Content value='라벨1'>컨텐츠1</SegmentControl.Content>
+    <SegmentControl.Content value='라벨2'>컨텐츠2</SegmentControl.Content>
+    <SegmentControl.Content value='라벨3'>컨텐츠3</SegmentControl.Content>
+  </SegmentControl>
+);

--- a/frontend/src/components/SegmentControl/SegmentControlContext.ts
+++ b/frontend/src/components/SegmentControl/SegmentControlContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+interface SegmentControlContextProps {
+  selectedValue: string;
+  handleSelect: (value: string) => void;
+}
+
+export const SegmentControlContext = createContext<SegmentControlContextProps | null>(null);

--- a/frontend/src/components/SegmentControl/index.css.ts
+++ b/frontend/src/components/SegmentControl/index.css.ts
@@ -1,8 +1,9 @@
+import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { vars } from '../../theme/index.css';
 
-export const segmentControlContainer = recipe({
+export const controlButtonContainerStyle = recipe({
   base: {
     display: 'inline-flex',
     borderRadius: vars.radius[600],
@@ -26,4 +27,8 @@ export const segmentControlContainer = recipe({
     style: 'filled',
     shadow: true,
   },
+});
+
+export const contentContainerStyle = style({
+  width: '100%',
 });

--- a/frontend/src/components/SegmentControl/index.tsx
+++ b/frontend/src/components/SegmentControl/index.tsx
@@ -41,7 +41,7 @@ const SegmentControl = ({
           direction='row'
         >
           {values.map((value, idx) => (
-            <ControlButton 
+            <ControlButton
               key={`${value}-${idx}`}
               segmentControlStyle={style}
               value={value}

--- a/frontend/src/components/SegmentControl/index.tsx
+++ b/frontend/src/components/SegmentControl/index.tsx
@@ -1,64 +1,59 @@
+import type { PropsWithChildren } from 'react';
 import { useState } from 'react';
 
-import type { ButtonProps } from '../Button';
-import Button from '../Button';
-import { segmentControlContainer } from './index.css';
+import { Flex } from '../Flex';
+import Content from './Content';
+import ControlButton from './ControlButton';
+import { controlButtonContainerStyle } from './index.css';
+import { SegmentControlContext } from './SegmentControlContext';
 
-export type SegmentOption = {
-  label: string;
-  value: string;
-};
-
-export interface SegmentControlProps {
-  options: SegmentOption[];
+export interface SegmentControlProps extends PropsWithChildren {
+  values: string[];
   style?: 'weak' | 'filled';
   shadow?: boolean;
   defaultValue?: string;
-  onChange: (value: string) => void;
+  onValueChange?: (value: string) => void;
 };
 
 const SegmentControl = ({
-  options,
+  values,
   style = 'filled',
   shadow = true,
-  defaultValue = options[0]?.value ?? '',
-  onChange,
+  defaultValue = values[0] ?? '',
+  onValueChange,
+  children,
 }: SegmentControlProps) => {
   const [selectedValue, setSelectedValue] = useState(defaultValue);
 
   const handleSelect = (value: string) => {
     setSelectedValue(value);
-    onChange(value);
+    onValueChange?.(value);
   };
 
   return (
-    <div className={segmentControlContainer({ style, shadow })}>
-      {options.map((option) => {
-        const isSelected = option.value === selectedValue;
-        const buttonStyles: ButtonProps = {
-          variant: 'secondary',
-          radius: 'max',
-          size: 'lg',
-          style: getButtonStyle(isSelected, style), 
-        };
-        return (
-          <Button 
-            {...buttonStyles}
-            key={option.value}
-            onClick={() => handleSelect(option.value)} 
-          >
-            {option.label}
-          </Button>
-        );
-      })}
-    </div>
+    <SegmentControlContext.Provider 
+      value={{ selectedValue, handleSelect }}
+    >
+      <Flex direction='column'>
+        <Flex
+          as='ul'
+          className={controlButtonContainerStyle({ style, shadow })}
+          direction='row'
+        >
+          {values.map((value, idx) => (
+            <ControlButton 
+              key={`${value}-${idx}`}
+              segmentControlStyle={style}
+              value={value}
+            />
+          ))}
+        </Flex>
+        {children}
+      </Flex>
+    </SegmentControlContext.Provider>
   );
 };
 
-const getButtonStyle = (isSelected: boolean, style: SegmentControlProps['style']) => {
-  if (!isSelected) return 'borderless';
-  if (style === 'filled') return 'filled';
-  return 'weak';
-};
+SegmentControl.Content = Content;
 
 export default SegmentControl;

--- a/frontend/src/features/shared-schedule/ui/UnConfirmedSchedules/index.tsx
+++ b/frontend/src/features/shared-schedule/ui/UnConfirmedSchedules/index.tsx
@@ -1,6 +1,4 @@
 
-import { useState } from 'react';
-
 import { Flex } from '@/components/Flex';
 import SegmentControl from '@/components/SegmentControl';
 import { Text } from '@/components/Text';
@@ -9,13 +7,8 @@ import { containerStyle, mainContainerStyle, titleStyle } from './index.css';
 import ScheduleContents from './ScheduleDetails';
 import UnconfirmedScheduleList from './UnconfirmedScheduleList';
 
-const segmentOptions = [
-  { label: '모든 일정', value: 'all' },
-  { label: '내가 만든 일정', value: 'mine' },
-  { label: '공유 받은 일정', value: 'shared' },
-];
+const segmentValues = ['모든 일정', '내가 만든 일정', '공유 받은 일정'];
 const UnConfirmedSchedules = () => {
-  const [_, setSelectedSegment] = useState('all');
   const schedules = [{}, {}, {}];
 
   return  (
@@ -26,7 +19,7 @@ const UnConfirmedSchedules = () => {
       width='full'
     >
       <Text className={titleStyle} typo='h2'>확정되지 않은 일정</Text>
-      <SegmentControl onChange={(value) => setSelectedSegment(value)} options={segmentOptions} />
+      <SegmentControl defaultValue='모든 일정' values={segmentValues} />
       <div className={mainContainerStyle}>
         <UnconfirmedScheduleList schedules={schedules} />
         <ScheduleContents />


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 세그먼트 컨트롤 컴포넌트의 내부에서 Content를 정의할 수 있도록 구현을 변경했습니다.
```tsx
const SegmentControlWithContent = () => (
  <SegmentControl defaultValue='라벨1' values={['라벨1', '라벨2', '라벨3']}>
    <SegmentControl.Content value='라벨1'>컨텐츠1</SegmentControl.Content>
    <SegmentControl.Content value='라벨2'>컨텐츠2</SegmentControl.Content>
    <SegmentControl.Content value='라벨3'>컨텐츠3</SegmentControl.Content>
  </SegmentControl>
);
```

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced interactive segmented control panels with conditional content display.
	- Added a new demo view showcasing segmented control behavior with contextual content.

- **Refactor**
	- Simplified segmented control setup by transitioning from detailed option objects to straightforward value arrays.
	- Streamlined schedule filtering by removing unnecessary state management.

- **Style**
	- Enhanced styling for segmented controls to improve layout and full-width content presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->