### PR TITLE
[BE-Feat] 지난 일정 조회 api 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -18,13 +18,6 @@ import org.springframework.stereotype.Repository;
 public interface DiscussionParticipantRepository extends
     JpaRepository<DiscussionParticipant, Long> {
 
-    @Query("SELECT u.picture " +
-        "FROM DiscussionParticipant dp " +
-        "JOIN dp.user u " +
-        "WHERE dp.discussion.id = :discussionId " +
-        "ORDER BY dp.userOffset ASC")
-    List<String> findUserPicturesByDiscussionId(@Param("discussionId") Long discussionId);
-
     @Query("SELECT dp.user " +
         "FROM DiscussionParticipant dp " +
         "WHERE dp.discussion.id = :discussionId " +
@@ -96,4 +89,12 @@ public interface DiscussionParticipantRepository extends
     Page<Discussion> findOngoingDiscussions(@Param("userId") Long userId,
         @Param("isHost") Boolean isHost,
         Pageable pageable);
+
+    @Query("SELECT dp.discussion.id, u.picture " +
+        "FROM DiscussionParticipant dp " +
+        "JOIN dp.user u " +
+        "WHERE dp.discussion.id IN :discussionIds " +
+        "ORDER BY dp.userOffset ASC")
+    List<Object[]> findUserPicturesByDiscussionIds(
+        @Param("discussionIds") List<Long> discussionIds);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -97,4 +97,15 @@ public interface DiscussionParticipantRepository extends
         "ORDER BY dp.userOffset ASC")
     List<Object[]> findUserPicturesByDiscussionIds(
         @Param("discussionIds") List<Long> discussionIds);
+
+    @Query("SELECT d " +
+        "FROM DiscussionParticipant dp " +
+        "JOIN dp.discussion d " +
+        "WHERE dp.user.id = :userId " +
+        "AND d.discussionStatus = 'FINISHED' " +
+        "AND FUNCTION('YEAR', d.fixedDate) = :year " +
+        "ORDER BY d.fixedDate ASC")
+    Page<Discussion> findFinishedDiscussions(@Param("userId") Long userId,
+        Pageable pageable,
+        @Param("year") int year);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -145,14 +145,7 @@ public class DiscussionParticipantService {
             .map(Discussion::getId)
             .collect(Collectors.toList());
 
-        List<Object[]> pictureResults = discussionParticipantRepository.findUserPicturesByDiscussionIds(
-            discussionIds);
-
-        Map<Long, List<String>> discussionPicturesMap = pictureResults.stream()
-            .collect(Collectors.groupingBy(
-                result -> (Long) result[0],
-                Collectors.mapping(result -> (String) result[1], Collectors.toList())
-            ));
+        Map<Long, List<String>> discussionPicturesMap = getDiscussionPicturesMap(discussionIds);
 
         List<OngoingDiscussion> ongoingDiscussions = discussions.stream()
             .map(discussion -> new OngoingDiscussion(
@@ -186,14 +179,7 @@ public class DiscussionParticipantService {
             .map(Discussion::getId)
             .collect(Collectors.toList());
 
-        List<Object[]> pictureResults = discussionParticipantRepository.findUserPicturesByDiscussionIds(
-            discussionIds);
-
-        Map<Long, List<String>> discussionPicturesMap = pictureResults.stream()
-            .collect(Collectors.groupingBy(
-                result -> (Long) result[0],
-                Collectors.mapping(result -> (String) result[1], Collectors.toList())
-            ));
+        Map<Long, List<String>> discussionPicturesMap = getDiscussionPicturesMap(discussionIds);
 
         Map<Long, SharedEventDto> sharedEventMap = sharedEventService.getSharedEventMap(
             discussionIds);
@@ -215,6 +201,18 @@ public class DiscussionParticipantService {
             discussionPage.hasNext(),
             discussionPage.hasPrevious(),
             finishedDiscussions);
+    }
+
+    @Transactional(readOnly = true)
+    protected Map<Long, List<String>> getDiscussionPicturesMap(List<Long> discussionIds) {
+        List<Object[]> pictureResults = discussionParticipantRepository.findUserPicturesByDiscussionIds(
+            discussionIds);
+
+        return pictureResults.stream()
+            .collect(Collectors.groupingBy(
+                result -> (Long) result[0],
+                Collectors.mapping(result -> (String) result[1], Collectors.toList())
+            ));
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -1,7 +1,7 @@
 package endolphin.backend.domain.discussion;
 
 import endolphin.backend.domain.discussion.dto.DiscussionParticipantsResponse;
-import endolphin.backend.domain.discussion.dto.FinishedDiscussionResponse;
+import endolphin.backend.domain.discussion.dto.FinishedDiscussionsResponse;
 import endolphin.backend.domain.discussion.dto.OngoingDiscussion;
 import endolphin.backend.domain.discussion.dto.OngoingDiscussionsResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
@@ -167,7 +167,7 @@ public class DiscussionParticipantService {
     }
 
     @Transactional(readOnly = true)
-    public FinishedDiscussionResponse getFinishedDiscussions(Long userId, int page, int size,
+    public FinishedDiscussionsResponse getFinishedDiscussions(Long userId, int page, int size,
         int year) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Discussion> discussionPage = discussionParticipantRepository.findFinishedDiscussions(
@@ -194,7 +194,7 @@ public class DiscussionParticipantService {
             ))
             .collect(Collectors.toList());
 
-        return new FinishedDiscussionResponse(
+        return new FinishedDiscussionsResponse(
             year,
             page + 1,
             discussionPage.getTotalPages(),

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -5,6 +5,7 @@ import endolphin.backend.domain.discussion.dto.CandidateEventDetailsResponse;
 import endolphin.backend.domain.discussion.dto.CreateDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.DiscussionInfo;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
+import endolphin.backend.domain.discussion.dto.FinishedDiscussionsResponse;
 import endolphin.backend.domain.discussion.dto.JoinDiscussionRequest;
 import endolphin.backend.domain.discussion.dto.InvitationInfo;
 import endolphin.backend.domain.discussion.dto.JoinDiscussionResponse;
@@ -224,6 +225,15 @@ public class DiscussionService {
         };
         return discussionParticipantService
             .getOngoingDiscussions(currentUser.getId(), page - 1, size, isHost);
+    }
+
+    @Transactional(readOnly = true)
+    public FinishedDiscussionsResponse getFinishedDiscussions(int page, int size,
+        int year) {
+        User currentUser = userService.getCurrentUser();
+
+        return discussionParticipantService
+            .getFinishedDiscussions(currentUser.getId(), page - 1, size, year);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -113,6 +113,8 @@ public class DiscussionService {
 
         discussion.setDiscussionStatus(DiscussionStatus.UPCOMING);
 
+        discussion.setFixedDate(sharedEventDto.startDateTime().toLocalDate());
+
         discussionRepository.save(discussion);
 
         discussionBitmapService.deleteDiscussionBitmapsUsingScan(discussionId)

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/FinishedDiscussionResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/FinishedDiscussionResponse.java
@@ -1,0 +1,15 @@
+package endolphin.backend.domain.discussion.dto;
+
+import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
+import java.util.List;
+
+public record FinishedDiscussionResponse(
+    int currentYear,
+    int currentPage,
+    int totalPages,
+    Boolean hasNext,
+    Boolean hasPrevious,
+    List<SharedEventWithDiscussionInfoResponse> finishedDiscussions
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/FinishedDiscussionsResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/FinishedDiscussionsResponse.java
@@ -3,7 +3,7 @@ package endolphin.backend.domain.discussion.dto;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import java.util.List;
 
-public record FinishedDiscussionResponse(
+public record FinishedDiscussionsResponse(
     int currentYear,
     int currentPage,
     int totalPages,

--- a/backend/src/main/java/endolphin/backend/domain/discussion/entity/Discussion.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/entity/Discussion.java
@@ -64,6 +64,10 @@ public class Discussion extends BaseTimeEntity {
     @Size(min = 4, max = 100)
     private String password;
 
+    @Setter
+    @Column(name = "fixed_date")
+    private LocalDate fixedDate;
+
     @Builder
     public Discussion(String title, LocalDate dateStart, LocalDate dateEnd,
         LocalTime timeStart, LocalTime timeEnd,

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
@@ -1,6 +1,7 @@
 package endolphin.backend.domain.shared_event;
 
 import endolphin.backend.domain.discussion.DiscussionService;
+import endolphin.backend.domain.discussion.dto.FinishedDiscussionsResponse;
 import endolphin.backend.domain.discussion.dto.OngoingDiscussion;
 import endolphin.backend.domain.discussion.dto.OngoingDiscussionsResponse;
 import endolphin.backend.domain.discussion.enums.AttendType;
@@ -49,4 +50,23 @@ public class SharedEventController {
         return ResponseEntity.ok(discussionService.getOngoingDiscussions(page, size, attendType));
     }
 
+    @Operation(summary = "지나간 논의 조회", description = "지난 논의를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "논의 조회 성공",
+            content = @Content(schema = @Schema(implementation = FinishedDiscussionsResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/finished")
+    public ResponseEntity<FinishedDiscussionsResponse> getFinishedDiscussion(
+        @Min(1) @RequestParam int page,
+        @Min(1) @RequestParam int size,
+        @RequestParam int year
+    ) {
+        return ResponseEntity.ok(discussionService.getFinishedDiscussions(page, size, year));
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventRepository.java
@@ -1,10 +1,13 @@
 package endolphin.backend.domain.shared_event;
 
 import endolphin.backend.domain.shared_event.entity.SharedEvent;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SharedEventRepository extends JpaRepository<SharedEvent, Long> {
+
+    public List<SharedEvent> findByDiscussionIdIn(List<Long> discussionIds);
 
 }

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
@@ -7,6 +7,9 @@ import endolphin.backend.domain.shared_event.entity.SharedEvent;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
 import endolphin.backend.global.util.Validator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,11 +42,21 @@ public class SharedEventService {
         return SharedEventDto.of(sharedEvent);
     }
 
+    @Transactional(readOnly = true)
+    public Map<Long, SharedEventDto> getSharedEventMap(List<Long> discussionIds) {
+        List<SharedEvent> events = sharedEventRepository.findByDiscussionIdIn(discussionIds);
+
+        return events.stream()
+            .collect(Collectors.toMap(
+                event -> event.getDiscussion().getId(),
+                SharedEventDto::of
+            ));
+    }
+
     public void deleteSharedEvent(Long sharedEventId) {
         if (!sharedEventRepository.existsById(sharedEventId)) {
             throw new ApiException(ErrorCode.SHARED_EVENT_NOT_FOUND);
         }
         sharedEventRepository.deleteById(sharedEventId);
     }
-
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantRepositoryTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantRepositoryTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
@@ -324,5 +325,121 @@ public class DiscussionParticipantRepositoryTest {
 
         assertThat((Long) row3[0]).isEqualTo(discussionId);
         assertThat((String) row3[1]).isEqualTo("pic1.jpg");
+    }
+
+    @DisplayName("findFinishedDiscussions: userId, year 필터 및 fixedDate 정렬 검증")
+    @Test
+    public void testFindFinishedDiscussions() {
+        // 사용자 생성
+        User user = User.builder()
+            .name("Test User")
+            .email("test@example.com")
+            .picture("userpic.jpg")
+            .build();
+        entityManager.persist(user);
+
+        // Discussion 1: FINISHED, dateRangeEnd 연도 2025, fixedDate = 2025-01-01
+        Discussion discussion1 = Discussion.builder()
+            .title("Discussion 1")
+            .dateStart(LocalDate.of(2025, 1, 10))
+            .dateEnd(LocalDate.of(2025, 1, 15))
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(17, 0))
+            .duration(60)
+            .deadline(LocalDate.of(2025, 1, 20))
+            .location("Room 1")
+            .build();
+        ReflectionTestUtils.setField(discussion1, "discussionStatus", DiscussionStatus.FINISHED);
+        ReflectionTestUtils.setField(discussion1, "fixedDate", LocalDate.of(2025, 1, 1));
+        entityManager.persist(discussion1);
+
+        // Discussion 2: FINISHED, dateRangeEnd 연도 2025, fixedDate = 2025-02-01
+        Discussion discussion2 = Discussion.builder()
+            .title("Discussion 2")
+            .dateStart(LocalDate.of(2025, 2, 5))
+            .dateEnd(LocalDate.of(2025, 2, 10))
+            .timeStart(LocalTime.of(10, 0))
+            .timeEnd(LocalTime.of(18, 0))
+            .duration(60)
+            .deadline(LocalDate.of(2025, 2, 15))
+            .location("Room 2")
+            .build();
+        ReflectionTestUtils.setField(discussion2, "discussionStatus", DiscussionStatus.FINISHED);
+        ReflectionTestUtils.setField(discussion2, "fixedDate", LocalDate.of(2025, 2, 1));
+        entityManager.persist(discussion2);
+
+        // Discussion 3: FINISHED, 하지만 dateRangeEnd 연도가 2024 -> 필터링되어야 함
+        Discussion discussion3 = Discussion.builder()
+            .title("Discussion 3")
+            .dateStart(LocalDate.of(2024, 12, 1))
+            .dateEnd(LocalDate.of(2024, 12, 5))
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(17, 0))
+            .duration(60)
+            .deadline(LocalDate.of(2024, 12, 10))
+            .location("Room 3")
+            .build();
+        ReflectionTestUtils.setField(discussion3, "discussionStatus", DiscussionStatus.FINISHED);
+        ReflectionTestUtils.setField(discussion3, "fixedDate", LocalDate.of(2024, 12, 1));
+        entityManager.persist(discussion3);
+
+        // Discussion 4: ONGOING 상태 -> 필터링되어야 함
+        Discussion discussion4 = Discussion.builder()
+            .title("Discussion 4")
+            .dateStart(LocalDate.of(2025, 3, 1))
+            .dateEnd(LocalDate.of(2025, 3, 5))
+            .timeStart(LocalTime.of(10, 0))
+            .timeEnd(LocalTime.of(18, 0))
+            .duration(60)
+            .deadline(LocalDate.of(2025, 3, 10))
+            .location("Room 4")
+            .build();
+        ReflectionTestUtils.setField(discussion4, "discussionStatus", DiscussionStatus.ONGOING);
+        ReflectionTestUtils.setField(discussion4, "fixedDate", LocalDate.of(2025, 3, 1));
+        entityManager.persist(discussion4);
+
+        // DiscussionParticipant 생성: user가 모든 Discussion에 참여하도록 생성
+        DiscussionParticipant dp1 = DiscussionParticipant.builder()
+            .discussion(discussion1)
+            .user(user)
+            .userOffset(0L)
+            .build();
+        entityManager.persist(dp1);
+
+        DiscussionParticipant dp2 = DiscussionParticipant.builder()
+            .discussion(discussion2)
+            .user(user)
+            .userOffset(1L)
+            .build();
+        entityManager.persist(dp2);
+
+        DiscussionParticipant dp3 = DiscussionParticipant.builder()
+            .discussion(discussion3)
+            .user(user)
+            .userOffset(2L)
+            .build();
+        entityManager.persist(dp3);
+
+        DiscussionParticipant dp4 = DiscussionParticipant.builder()
+            .discussion(discussion4)
+            .user(user)
+            .userOffset(3L)
+            .build();
+        entityManager.persist(dp4);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // Pageable: 첫 페이지, size 10 (총 2건의 결과가 있어야 함: discussion1 & discussion2)
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Discussion> resultPage = discussionParticipantRepository.findFinishedDiscussions(
+            user.getId(), pageable, 2025);
+        List<Discussion> results = resultPage.getContent();
+
+        // 검증: discussion3 (2024)와 discussion4 (ONGOING)는 필터링되어야 하므로, 결과는 2건
+        assertThat(results).hasSize(2);
+        // 정렬은 fixedDate ASC 기준이므로, discussion1(fixedDate=2025-01-01)이 먼저, 그 다음 discussion2(fixedDate=2025-02-01)
+        assertThat(results.get(0).getId()).isEqualTo(discussion1.getId());
+        assertThat(results.get(1).getId()).isEqualTo(discussion2.getId());
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-import endolphin.backend.domain.discussion.dto.FinishedDiscussionResponse;
+import endolphin.backend.domain.discussion.dto.FinishedDiscussionsResponse;
 import endolphin.backend.domain.discussion.dto.OngoingDiscussion;
 import endolphin.backend.domain.discussion.dto.OngoingDiscussionsResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
@@ -444,7 +444,7 @@ class DiscussionParticipantServiceTest {
             .willReturn(sharedEventMap);
 
         // When: Service 메서드 호출
-        FinishedDiscussionResponse response = discussionParticipantService.getFinishedDiscussions(userId, page, size, year);
+        FinishedDiscussionsResponse response = discussionParticipantService.getFinishedDiscussions(userId, page, size, year);
 
         // Then: FinishedDiscussionResponse 검증
         assertThat(response.currentYear()).isEqualTo(year);


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #195 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Discussison 엔티티에 fixedDate 칼럼 추가했습니다.
   - 지난 일정 조회 시 정렬을 위해 필요한 칼럼입니다.
- Pageable과 Function 사용하여 정렬된 지난 일정 조회하는 쿼리 작성했습니다.
- 지난 일정 조회하여 반환하는 API 구현했습니다.
- 관련 테스트 코드 추가했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.