### PR TITLE
[BE-Feat] 토큰 발급 시 만료기한 추가 응답

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/auth/AuthService.java
+++ b/backend/src/main/java/endolphin/backend/domain/auth/AuthService.java
@@ -10,7 +10,10 @@ import endolphin.backend.domain.auth.dto.OAuthResponse;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.google.GoogleOAuthService;
 import endolphin.backend.global.security.JwtProvider;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +26,9 @@ public class AuthService {
     private final GoogleCalendarService googleCalendarService;
     private final UserService userService;
     private final JwtProvider jwtProvider;
+
+    @Value("${jwt.expired}")
+    private long expired;
 
     @Transactional(readOnly = true)
     public String oauth2Callback(String code) {
@@ -41,7 +47,9 @@ public class AuthService {
         googleCalendarService.upsertGoogleCalendar(user);
 
         String accessToken = jwtProvider.createToken(user.getId(), user.getEmail());
-        return new OAuthResponse(accessToken);
+        LocalDateTime expiredAt = LocalDateTime.now().plus(expired, ChronoUnit.MILLIS);
+
+        return new OAuthResponse(accessToken, expiredAt);
     }
 
 

--- a/backend/src/main/java/endolphin/backend/domain/auth/dto/OAuthResponse.java
+++ b/backend/src/main/java/endolphin/backend/domain/auth/dto/OAuthResponse.java
@@ -1,5 +1,10 @@
 package endolphin.backend.domain.auth.dto;
 
-public record OAuthResponse(String accessToken) {
+import java.time.LocalDateTime;
+
+public record OAuthResponse(
+    String accessToken,
+    LocalDateTime expiredAt
+) {
 
 }

--- a/backend/src/main/java/endolphin/backend/global/security/JwtProvider.java
+++ b/backend/src/main/java/endolphin/backend/global/security/JwtProvider.java
@@ -11,7 +11,8 @@ import java.util.Date;
 @Component
 public class JwtProvider {
 
-    private final long validityInMs = 60 * 60 * 1000L; // 1시간
+    @Value("${jwt.expired}")
+    private long validityInMs;
     private final SecretKey key;
 
     public JwtProvider(@Value("${jwt.secret}") String secretKey) {

--- a/backend/src/test/java/endolphin/backend/domain/auth/AuthServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/auth/AuthServiceTest.java
@@ -6,8 +6,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 import endolphin.backend.domain.auth.dto.OAuthResponse;
-import endolphin.backend.domain.calendar.entity.Calendar;
-import endolphin.backend.domain.personal_event.PersonalEventService;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.google.GoogleCalendarService;
@@ -16,12 +14,15 @@ import endolphin.backend.global.google.dto.GoogleTokens;
 import endolphin.backend.global.google.dto.GoogleUserInfo;
 import endolphin.backend.global.security.JwtProvider;
 
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -30,16 +31,21 @@ class AuthServiceTest {
     private UserService userService;
 
     @Mock
-    private GoogleOAuthService googleOAuthService;
+    private GoogleCalendarService googleCalendarService;
 
     @Mock
-    private GoogleCalendarService googleCalendarService;
+    private GoogleOAuthService googleOAuthService;
 
     @Mock
     private JwtProvider jwtProvider;
 
     @InjectMocks
     private AuthService authService;
+
+    @BeforeEach
+    public void setUp() {
+        ReflectionTestUtils.setField(authService, "expired", 10000);
+    }
 
     @Test
     @DisplayName("로그인 테스트 - 캘린더 연동 포함")
@@ -74,5 +80,7 @@ class AuthServiceTest {
 
         // Then
         assertThat(response.accessToken()).isEqualTo("test-jwt-token");
+        assertThat(response.expiredAt()).isNotNull();
+        assertThat(response.expiredAt()).isAfter(LocalDateTime.now());
     }
 }

--- a/backend/src/test/java/endolphin/backend/global/security/JwtProviderTest.java
+++ b/backend/src/test/java/endolphin/backend/global/security/JwtProviderTest.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -16,6 +17,7 @@ public class JwtProviderTest {
     void setUp() {
         String secretKey = "my-very-long-and-secure-secret-key-which-is-at-least-32-chars";
         jwtProvider = new JwtProvider(secretKey);
+        ReflectionTestUtils.setField(jwtProvider, "validityInMs", 10000);
     }
 
     @DisplayName("토큰 생성 및 검증 테스트")

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -46,6 +46,7 @@ google:
 
 jwt:
   secret: "my-very-long-and-secure-secret-key-which-is-at-least-32-chars-test"
+  expired: 1000
 
 springdoc:
   packages-to-scan: endolphin.backend


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #32 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
access token 발급 시에 만료기한도 함께 응답하도록 수정
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Authentication responses now include a clear token expiration timestamp.
	- Token expiration durations are now configurable, offering improved flexibility in session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->