### PR TITLE
[BE-Fix] 구글 캘린더 이벤트 받아올 때 타임존 고정

### DIFF
--- a/backend/src/main/java/endolphin/backend/global/config/GoogleCalendarProperties.java
+++ b/backend/src/main/java/endolphin/backend/global/config/GoogleCalendarProperties.java
@@ -4,7 +4,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "google.calendar.api")
 public record GoogleCalendarProperties(
-    int subscribeDuration
+    int subscribeDuration,
+    String timeZone
 ) {
 
 }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 구글 캘린더 api를 사용할 때 timeZone을 Asia/seoul로 지정했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced calendar functionality with added time zone support, ensuring event times align more accurately with user settings.
  - Improved synchronization processes for calendar events, providing more consistent updates during calendar refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->