### PR TITLE
[BE-Fix] 구글 캘린더 웹훅 구독 콜백 url을 필터에서 제외

### DIFF
--- a/backend/src/main/java/endolphin/backend/global/security/JwtAuthFilter.java
+++ b/backend/src/main/java/endolphin/backend/global/security/JwtAuthFilter.java
@@ -62,6 +62,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         List<String> excludedPaths = List.of(
             "/api/v1/login",
             "/api/v1/oauth2/callback",
+            "/api/v1/google/webhook",
             "/swagger-ui", // prod profile에서는 swagger-ui 접근 불가
             "/v3/api-docs", // prod profile에서는 v3/api-docs 접근 불가
             "/h2-console", // prod profile에서는 h2-console 접근 불가


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #109 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
웹훅 콜백 url이 필터에 걸려서 구독이 되지 않고 있습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
excludedPaths를 따로 관리하는게 좋을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the handling of Google Webhook requests so that these calls bypass standard filtering, enabling a smoother integration experience without affecting other security measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->