### PR TITLE
[BE-Fix] 논의 참여자가 아닐 시 에러 반환

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/candidate_event/CandidateEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/candidate_event/CandidateEventService.java
@@ -30,9 +30,11 @@ public class CandidateEventService {
     private final DiscussionBitmapService discussionBitmapService;
     private final DiscussionService discussionService;
     private final DiscussionParticipantService discussionParticipantService;
+    private final static long MINUTE_PER_DAY = 1440;
 
     public CalendarViewResponse getEventsOnCalendarView(Long discussionId,
         CalendarViewRequest request) {
+        discussionParticipantService.validateDiscussionParticipant(discussionId);
 
         Discussion discussion = discussionService.getDiscussionById(discussionId);
 
@@ -62,6 +64,7 @@ public class CandidateEventService {
     }
 
     public RankViewResponse getEventsOnRankView(Long discussionId, RankViewRequest request) {
+        discussionParticipantService.validateDiscussionParticipant(discussionId);
         Discussion discussion = discussionService.getDiscussionById(discussionId);
 
         int filter = discussionParticipantService.getFilter(discussionId,
@@ -106,7 +109,7 @@ public class CandidateEventService {
             minuteKey = convertToMinute(LocalDate.now().atTime(discussion.getTimeRangeStart()));
         }
 
-        long maxTime = endDateTime % 1440 - duration;
+        long maxTime = endDateTime % MINUTE_PER_DAY - duration;
 
         Map<Long, byte[]> dataBlocks = discussionBitmapService.getDataOfDiscussionId(
             discussion.getId(), minuteKey, endDateTime);
@@ -115,8 +118,8 @@ public class CandidateEventService {
         List<CandidateEvent> events = new ArrayList<>();
 
         while (minuteKey < endDateTime) {
-            if (minuteKey % 1440 > maxTime) {
-                minuteKey = ++day * 1440 + startDateTime;
+            if (minuteKey % MINUTE_PER_DAY > maxTime) {
+                minuteKey = ++day * MINUTE_PER_DAY + startDateTime;
                 continue;
             }
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -81,7 +81,11 @@ public class DiscussionParticipantService {
     @Transactional(readOnly = true)
     public int getFilter(Long discussionId, List<Long> userIds) {
 
-        if (userIds == null || userIds.isEmpty()) {
+        if (userIds == null) {
+            return 0XFFFF;
+        }
+
+        if (userIds.isEmpty()) {
             return 0;
         }
 
@@ -233,5 +237,11 @@ public class DiscussionParticipantService {
     public Boolean isFull(Long discussionId) {
         Long offset = discussionParticipantRepository.findMaxOffsetByDiscussionId(discussionId);
         return offset >= MAX_PARTICIPANT - 1;
+    }
+
+    @Transactional(readOnly = true)
+    public void validateDiscussionParticipant(Long discussionId) {
+        discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userService.getCurrentUser().getId())
+            .orElseThrow(() -> new ApiException(ErrorCode.NOT_ALLOWED_USER));
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -128,6 +128,7 @@ public class DiscussionParticipantService {
 
     @Transactional(readOnly = true)
     public DiscussionParticipantsResponse getDiscussionParticipants(Long discussionId) {
+        validateDiscussionParticipant(discussionId);
         List<UserIdNameDto> participants = discussionParticipantRepository.findUserIdNameDtosByDiscussionId(
             discussionId);
 
@@ -241,7 +242,8 @@ public class DiscussionParticipantService {
 
     @Transactional(readOnly = true)
     public void validateDiscussionParticipant(Long discussionId) {
-        discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userService.getCurrentUser().getId())
+        discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId,
+                userService.getCurrentUser().getId())
             .orElseThrow(() -> new ApiException(ErrorCode.NOT_ALLOWED_USER));
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -101,6 +101,10 @@ public class DiscussionService {
             throw new ApiException(ErrorCode.DISCUSSION_NOT_ONGOING);
         }
 
+        if (!discussionParticipantService.amIHost(discussionId)) {
+            throw new ApiException(ErrorCode.NOT_ALLOWED_USER);
+        }
+
         SharedEventDto sharedEventDto = sharedEventService.createSharedEvent(discussion,
             request);
 
@@ -137,6 +141,7 @@ public class DiscussionService {
 
     public DiscussionInfo getDiscussionInfo(Long discussionId) {
         Discussion discussion = getDiscussionById(discussionId);
+        discussionParticipantService.validateDiscussionParticipant(discussionId);
 
         return new DiscussionInfo(
             discussionId,
@@ -193,7 +198,7 @@ public class DiscussionService {
             discussionId);
 
         if (!participants.contains(currentUser)) {
-            throw new ApiException(ErrorCode.INVALID_DISCUSSION_PARTICIPANT);
+            throw new ApiException(ErrorCode.NOT_ALLOWED_USER);
         }
 
         Map<Long, Integer> selectedUserIdMap = new HashMap<>();

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/CreateDiscussionRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/CreateDiscussionRequest.java
@@ -17,7 +17,7 @@ public record CreateDiscussionRequest(
     @NotNull LocalDate dateRangeEnd,
     @NotNull LocalTime timeRangeStart,
     @NotNull LocalTime timeRangeEnd,
-    @NotNull @Min(30) @Max(180) Integer duration,
+    @NotNull @Min(30) @Max(360) Integer duration,
     MeetingMethod meetingMethod,
     String location,
     @NotNull @Future LocalDate deadline,

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     DISCUSSION_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "DP002", "Discussion participant not found"),
     INVALID_DISCUSSION_PARTICIPANT(HttpStatus.BAD_REQUEST, "DP003", "Invalid Discussion participant"),
     DISCUSSION_HOST_NOT_FOUND(HttpStatus.NOT_FOUND, "DP004", "Discussion host not found"),
+    NOT_ALLOWED_USER(HttpStatus.FORBIDDEN, "DP005", "Not allowed user"),
 
     //Calendar
     CALENDAR_UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "CA001", "Unauthorized"),

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -164,6 +164,7 @@ public class DiscussionServiceTest {
             sharedEventDto);
         when(discussionParticipantService.getUsersByDiscussionId(discussionId))
             .thenReturn(dummyParticipants);
+        when(discussionParticipantService.amIHost(discussionId)).thenReturn(true);
 
         when(discussionBitmapService.deleteDiscussionBitmapsUsingScan(
             any(Long.class)
@@ -220,6 +221,7 @@ public class DiscussionServiceTest {
         when(sharedEventService.createSharedEvent(discussion, request)).thenReturn(sharedEventDto);
         when(discussionParticipantService.getUsersByDiscussionId(discussionId))
             .thenReturn(dummyParticipants);
+        when(discussionParticipantService.amIHost(discussionId)).thenReturn(true);
 
         when(discussionBitmapService.deleteDiscussionBitmapsUsingScan(any()))
             .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Redis Error")));
@@ -409,7 +411,7 @@ public class DiscussionServiceTest {
         assertThat(invitationInfo.requirePassword()).isTrue();
     }
 
-
+    @DisplayName("후보 일정 가져오기 테스트")
     @Test
     void retrieveCandidateEventDetails_ValidRequest_ReturnsCorrectResponse() {
         // Given
@@ -440,23 +442,6 @@ public class DiscussionServiceTest {
         given(participant2.getName()).willReturn("Participant 2");
         given(participant2.getPicture()).willReturn("participant2.jpg");
 
-//        PersonalEvent event1 = Mockito.mock(PersonalEvent.class);
-//        PersonalEvent event2 = Mockito.mock(PersonalEvent.class);
-//
-//        // Mock Event 객체들의 동작 정의
-//        // participant1의 이벤트 (검색 범위 내)
-//        given(event1.getUser()).willReturn(participant1);
-//        given(event1.getStartTime()).willReturn(now.plusHours(2));  // 14:00
-//        given(event1.getEndTime()).willReturn(now.plusHours(3));    // 15:00
-//        given(event1.getTitle()).willReturn("Meeting 1");
-//
-//        // participant2의 이벤트 (검색 범위 밖)
-//        given(event2.getUser()).willReturn(participant2);
-//        given(event2.getStartTime()).willReturn(now.plusHours(4));  // 16:00
-//        given(event2.getEndTime()).willReturn(now.plusHours(5));    // 17:00
-//        given(event2.getTitle()).willReturn("Meeting 2");
-
-        // selectedUserIds 초기화 (participant1, participant2 선택)
         List<Long> selectedUserIds = Arrays.asList(2L);
 
         CandidateEventDetailsRequest request = new CandidateEventDetailsRequest(
@@ -572,7 +557,7 @@ public class DiscussionServiceTest {
         assertThatThrownBy(
             () -> discussionService.retrieveCandidateEventDetails(discussionId, request))
             .isInstanceOf(ApiException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_DISCUSSION_PARTICIPANT);
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_ALLOWED_USER);
 
         // 날짜 범위 검증 단계에서 예외가 발생하므로 다른 서비스들은 호출되지 않아야 함
         then(personalEventService).shouldHaveNoInteractions();


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 논의 관련 페이지에서 로그인한 유저가 논의 참여자가 아닐시 403 반환합니다.
- 후보 일정 조회 시 유저 리스트를 주지 않으면 전체 참여자를 대상으로 반환합니다

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced validation to ensure only authorized participants can access discussion details and confirm schedules.
  - Increased the maximum allowable duration for discussions from 180 to 360 minutes.
  - Added a new error code for unauthorized user actions, providing clearer feedback for restricted actions.

- **Bug Fixes**
  - Replaced hardcoded scheduling values with consistent calculations to improve the reliability of event displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->