### PR TITLE
[BE-Feat] 다가오는 일정 조회 기능 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantRepository.java
@@ -108,4 +108,11 @@ public interface DiscussionParticipantRepository extends
     Page<Discussion> findFinishedDiscussions(@Param("userId") Long userId,
         Pageable pageable,
         @Param("year") int year);
+
+    @Query("SELECT d "
+        + "FROM DiscussionParticipant dp "
+        + "JOIN dp.discussion d "
+        + "WHERE dp.user.id = :userId "
+        + "AND d.discussionStatus = 'UPCOMING' ")
+    List<Discussion> findUpcomingDiscussionsByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -209,7 +209,12 @@ public class DiscussionParticipantService {
     }
 
     @Transactional(readOnly = true)
-    protected Map<Long, List<String>> getDiscussionPicturesMap(List<Long> discussionIds) {
+    public List<Discussion> getUpcomingDiscussionsByUserId(Long userId) {
+        return discussionParticipantRepository.findUpcomingDiscussionsByUserId(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, List<String>> getDiscussionPicturesMap(List<Long> discussionIds) {
         List<Object[]> pictureResults = discussionParticipantRepository.findUserPicturesByDiscussionIds(
             discussionIds);
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -235,8 +235,7 @@ public class DiscussionParticipantService {
         return new ListResponse<>(upcomingDiscussions);
     }
 
-    @Transactional(readOnly = true)
-    public List<Discussion> getUpcomingDiscussionsByUserId(Long userId) {
+    private List<Discussion> getUpcomingDiscussionsByUserId(Long userId) {
         return discussionParticipantRepository.findUpcomingDiscussionsByUserId(userId);
     }
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -18,6 +18,7 @@ import endolphin.backend.global.error.exception.ErrorCode;
 import endolphin.backend.global.util.TimeCalculator;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -230,7 +231,8 @@ public class DiscussionParticipantService {
                 sharedEventMap.getOrDefault(discussion.getId(), null),
                 discussionPicturesMap.getOrDefault(discussion.getId(), Collections.emptyList())
             ))
-            .toList();
+            .sorted(Comparator.comparing(key ->
+                key.sharedEventDto().startDateTime())).toList();
 
         return new ListResponse<>(upcomingDiscussions);
     }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -22,6 +22,7 @@ import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.dto.UserInfoWithPersonalEvents;
 import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.dto.ListResponse;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
 import endolphin.backend.global.redis.DiscussionBitmapService;
@@ -239,6 +240,13 @@ public class DiscussionService {
 
         return discussionParticipantService
             .getFinishedDiscussions(currentUser.getId(), page - 1, size, year);
+    }
+
+    @Transactional(readOnly = true)
+    public ListResponse<SharedEventWithDiscussionInfoResponse> getUpcomingDiscussions() {
+        User currentUser = userService.getCurrentUser();
+
+        return discussionParticipantService.getUpcomingDiscussions(currentUser);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
@@ -2,12 +2,12 @@ package endolphin.backend.domain.shared_event;
 
 import endolphin.backend.domain.discussion.DiscussionService;
 import endolphin.backend.domain.discussion.dto.FinishedDiscussionsResponse;
-import endolphin.backend.domain.discussion.dto.OngoingDiscussion;
 import endolphin.backend.domain.discussion.dto.OngoingDiscussionsResponse;
 import endolphin.backend.domain.discussion.enums.AttendType;
+import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
+import endolphin.backend.global.dto.ListResponse;
 import endolphin.backend.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SharedEventController {
 
     private final DiscussionService discussionService;
+    private final SharedEventService sharedEventService;
 
     @Operation(summary = "진행 중인 논의 조회", description = "진행 중인 논의를 조회합니다.")
     @ApiResponses(value = {
@@ -68,5 +69,23 @@ public class SharedEventController {
         @RequestParam int year
     ) {
         return ResponseEntity.ok(discussionService.getFinishedDiscussions(page, size, year));
+    }
+
+    @Operation(summary = "다가오는 일정 조회", description = "다가오는 일정을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "일정 조회 성공",
+            content = @Content(schema = @Schema(implementation = SharedEventWithDiscussionInfoResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/upcoming")
+    public ResponseEntity<ListResponse<SharedEventWithDiscussionInfoResponse>> getUpcomingDiscussions() {
+        List<SharedEventWithDiscussionInfoResponse> responses =
+            sharedEventService.getUpcomingSharedEvents();
+        return ResponseEntity.ok(new ListResponse<>(responses));
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
@@ -85,7 +85,7 @@ public class SharedEventController {
     @GetMapping("/upcoming")
     public ResponseEntity<ListResponse<SharedEventWithDiscussionInfoResponse>> getUpcomingDiscussions() {
         ListResponse<SharedEventWithDiscussionInfoResponse> responses =
-            sharedEventService.getUpcomingSharedEvents();
+            discussionService.getUpcomingDiscussions();
         return ResponseEntity.ok(responses);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventController.java
@@ -84,8 +84,8 @@ public class SharedEventController {
     })
     @GetMapping("/upcoming")
     public ResponseEntity<ListResponse<SharedEventWithDiscussionInfoResponse>> getUpcomingDiscussions() {
-        List<SharedEventWithDiscussionInfoResponse> responses =
+        ListResponse<SharedEventWithDiscussionInfoResponse> responses =
             sharedEventService.getUpcomingSharedEvents();
-        return ResponseEntity.ok(new ListResponse<>(responses));
+        return ResponseEntity.ok(responses);
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventRepository.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SharedEventRepository extends JpaRepository<SharedEvent, Long> {
 
-    public List<SharedEvent> findByDiscussionIdIn(List<Long> discussionIds);
-
     Optional<SharedEvent> findByDiscussionId(Long discussionId);
 
+
+    List<SharedEvent> findByDiscussionIdIn(List<Long> discussionIds);
 }

--- a/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/shared_event/SharedEventService.java
@@ -8,6 +8,7 @@ import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoRe
 import endolphin.backend.domain.shared_event.entity.SharedEvent;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.dto.ListResponse;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
 import endolphin.backend.global.util.Validator;
@@ -67,7 +68,7 @@ public class SharedEventService {
     }
 
     @Transactional(readOnly = true)
-    public List<SharedEventWithDiscussionInfoResponse> getUpcomingSharedEvents() {
+    public ListResponse<SharedEventWithDiscussionInfoResponse> getUpcomingSharedEvents() {
         User currentUser = userService.getCurrentUser();
         List<Discussion> discussions = discussionParticipantService.getUpcomingDiscussionsByUserId(
             currentUser.getId());
@@ -80,7 +81,7 @@ public class SharedEventService {
         Map<Long, List<String>> discussionParticipantsPicturesMap =
             discussionParticipantService.getDiscussionPicturesMap(discussionIds);
 
-        return sharedEvents.stream().map(se -> {
+        return new ListResponse<>(sharedEvents.stream().map(se -> {
             Discussion d = se.getDiscussion();
 
             List<String> pictures = discussionParticipantsPicturesMap.getOrDefault(d.getId(),
@@ -90,6 +91,6 @@ public class SharedEventService {
                 d.getId(), d.getTitle(), d.getMeetingMethodOrLocation(), SharedEventDto.of(se),
                 pictures
             );
-        }).toList();
+        }).toList());
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantRepositoryTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantRepositoryTest.java
@@ -546,7 +546,7 @@ public class DiscussionParticipantRepositoryTest {
 
         // when
 
-        List<Discussion> result = discussionParticipantRepository.findUpcomingDiscussions(
+        List<Discussion> result = discussionParticipantRepository.findUpcomingDiscussionsByUserId(
             user.getId());
 
         assertThat(result).isNotNull();

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
@@ -563,8 +563,8 @@ class DiscussionParticipantServiceTest {
             LocalDateTime.of(2025, 1, 10, 9, 0),
             LocalDateTime.of(2025, 1, 15, 17, 0));
         SharedEventDto sharedEvent2 = new SharedEventDto(101L,
-            LocalDateTime.of(2025, 2, 5, 10, 0),
-            LocalDateTime.of(2025, 2, 10, 18, 0));
+            LocalDateTime.of(2025, 1, 5, 10, 0),
+            LocalDateTime.of(2025, 1, 10, 18, 0));
         Map<Long, SharedEventDto> sharedEventMap = Map.of(
             100L, sharedEvent1,
             101L, sharedEvent2
@@ -581,20 +581,20 @@ class DiscussionParticipantServiceTest {
         List<SharedEventWithDiscussionInfoResponse> upcomingDiscussions = response.data();
         assertThat(upcomingDiscussions).hasSize(2);
 
-        // 정렬: fixedDate ASC 기준 -> discussion1 (fixedDate=2025-01-01) 먼저, discussion2 (fixedDate=2025-02-01) 이후
+        // 정렬: sharedEvent startTime ASC 기준 -> discussion2 (fixedDate=2025-01-05) 먼저, discussion1 (fixedDate=2025-1-5) 이후
         SharedEventWithDiscussionInfoResponse ded1 = upcomingDiscussions.get(0);
         SharedEventWithDiscussionInfoResponse ded2 = upcomingDiscussions.get(1);
 
-        assertThat(ded1.discussionId()).isEqualTo(100L);
-        assertThat(ded1.title()).isEqualTo("Discussion 1");
-        assertThat(ded1.meetingMethodOrLocation()).isEqualTo("Room 1");
-        assertThat(ded1.sharedEventDto()).isEqualTo(sharedEvent1);
-        assertThat(ded1.participantPictureUrls()).containsExactly("pic1.jpg", "pic2.jpg");
+        assertThat(ded1.discussionId()).isEqualTo(101L);
+        assertThat(ded1.title()).isEqualTo("Discussion 2");
+        assertThat(ded1.meetingMethodOrLocation()).isEqualTo("Room 2");
+        assertThat(ded1.sharedEventDto()).isEqualTo(sharedEvent2);
+        assertThat(ded1.participantPictureUrls()).containsExactly("pic3.jpg");
 
-        assertThat(ded2.discussionId()).isEqualTo(101L);
-        assertThat(ded2.title()).isEqualTo("Discussion 2");
-        assertThat(ded2.meetingMethodOrLocation()).isEqualTo("Room 2");
-        assertThat(ded2.sharedEventDto()).isEqualTo(sharedEvent2);
-        assertThat(ded2.participantPictureUrls()).containsExactly("pic3.jpg");
+        assertThat(ded2.discussionId()).isEqualTo(100L);
+        assertThat(ded2.title()).isEqualTo("Discussion 1");
+        assertThat(ded2.meetingMethodOrLocation()).isEqualTo("Room 1");
+        assertThat(ded2.sharedEventDto()).isEqualTo(sharedEvent1);
+        assertThat(ded2.participantPictureUrls()).containsExactly("pic1.jpg", "pic2.jpg");
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionParticipantServiceTest.java
@@ -14,9 +14,11 @@ import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.shared_event.SharedEventService;
 import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
+import endolphin.backend.domain.shared_event.entity.SharedEvent;
 import endolphin.backend.domain.user.UserService;
 import endolphin.backend.domain.user.dto.UserIdNameDto;
 import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.dto.ListResponse;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
 
@@ -24,6 +26,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -475,4 +479,122 @@ class DiscussionParticipantServiceTest {
         assertThat(ded2.participantPictureUrls()).containsExactly("pic3.jpg");
     }
 
+    @Test
+    @DisplayName("다가오는 일정 조회 테스트")
+    public void getUpcomingSharedEvents_ShouldReturnSharedEventsWithDiscussionInfo() {
+        User user = Mockito.mock(User.class);
+        given(user.getId()).willReturn(1L);
+
+
+        // --- 준비: 4개의 Discussion 생성 ---
+        // Discussion 1: UPCOMING, year=2025, fixedDate = 2025-01-01, id=100L
+        Discussion discussion1 = Discussion.builder()
+            .title("Discussion 1")
+            .dateStart(LocalDate.of(2025, 1, 10))
+            .dateEnd(LocalDate.of(2025, 1, 15))
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(17, 0))
+            .duration(60)
+            .deadline(LocalDate.of(2025, 1, 20))
+            .location("Room 1")
+            .build();
+        ReflectionTestUtils.setField(discussion1, "discussionStatus", DiscussionStatus.UPCOMING);
+        ReflectionTestUtils.setField(discussion1, "fixedDate", LocalDate.of(2025, 1, 1));
+        ReflectionTestUtils.setField(discussion1, "id", 100L);
+
+        // Discussion 2: UPCOMING, year=2025, fixedDate = 2025-02-01, id=101L
+        Discussion discussion2 = Discussion.builder()
+            .title("Discussion 2")
+            .dateStart(LocalDate.of(2025, 2, 5))
+            .dateEnd(LocalDate.of(2025, 2, 10))
+            .timeStart(LocalTime.of(10, 0))
+            .timeEnd(LocalTime.of(18, 0))
+            .duration(60)
+            .deadline(LocalDate.of(2025, 2, 15))
+            .location("Room 2")
+            .build();
+        ReflectionTestUtils.setField(discussion2, "discussionStatus", DiscussionStatus.UPCOMING);
+        ReflectionTestUtils.setField(discussion2, "fixedDate", LocalDate.of(2025, 2, 1));
+        ReflectionTestUtils.setField(discussion2, "id", 101L);
+
+        // Discussion 3: FINISHED, but year=2024 -> 필터링되어야 함, id=102L
+        Discussion discussion3 = Discussion.builder()
+            .title("Discussion 3")
+            .dateStart(LocalDate.of(2024, 12, 1))
+            .dateEnd(LocalDate.of(2024, 12, 5))
+            .timeStart(LocalTime.of(9, 0))
+            .timeEnd(LocalTime.of(17, 0))
+            .duration(60)
+            .deadline(LocalDate.of(2024, 12, 10))
+            .location("Room 3")
+            .build();
+        ReflectionTestUtils.setField(discussion3, "discussionStatus", DiscussionStatus.FINISHED);
+        ReflectionTestUtils.setField(discussion3, "fixedDate", LocalDate.of(2024, 12, 1));
+        ReflectionTestUtils.setField(discussion3, "id", 102L);
+
+        // Discussion 4: ONGOING 상태 -> 필터링되어야 함, id=103L
+        Discussion discussion4 = Discussion.builder()
+            .title("Discussion 4")
+            .dateStart(LocalDate.of(2025, 3, 1))
+            .dateEnd(LocalDate.of(2025, 3, 5))
+            .timeStart(LocalTime.of(10, 0))
+            .timeEnd(LocalTime.of(18, 0))
+            .duration(60)
+            .deadline(LocalDate.of(2025, 3, 10))
+            .location("Room 4")
+            .build();
+        ReflectionTestUtils.setField(discussion4, "discussionStatus", DiscussionStatus.ONGOING);
+        ReflectionTestUtils.setField(discussion4, "fixedDate", LocalDate.of(2025, 3, 1));
+        ReflectionTestUtils.setField(discussion4, "id", 103L);
+
+        given(discussionParticipantRepository.findUpcomingDiscussionsByUserId(user.getId()))
+            .willReturn(Arrays.asList(discussion1, discussion2));
+
+        List<Object[]> pictureResults = Arrays.asList(
+            new Object[]{100L, "pic1.jpg"},
+            new Object[]{100L, "pic2.jpg"},
+            new Object[]{101L, "pic3.jpg"}
+        );
+        given(discussionParticipantRepository.findUserPicturesByDiscussionIds(Arrays.asList(100L, 101L)))
+            .willReturn(pictureResults);
+
+        // --- 목업: sharedEventService.getSharedEventMap ---
+        SharedEventDto sharedEvent1 = new SharedEventDto(100L,
+            LocalDateTime.of(2025, 1, 10, 9, 0),
+            LocalDateTime.of(2025, 1, 15, 17, 0));
+        SharedEventDto sharedEvent2 = new SharedEventDto(101L,
+            LocalDateTime.of(2025, 2, 5, 10, 0),
+            LocalDateTime.of(2025, 2, 10, 18, 0));
+        Map<Long, SharedEventDto> sharedEventMap = Map.of(
+            100L, sharedEvent1,
+            101L, sharedEvent2
+        );
+        given(sharedEventService.getSharedEventMap(Arrays.asList(100L, 101L)))
+            .willReturn(sharedEventMap);
+
+        // when
+        ListResponse<SharedEventWithDiscussionInfoResponse> response =
+            discussionParticipantService.getUpcomingDiscussions(user);
+
+        // then
+
+        List<SharedEventWithDiscussionInfoResponse> upcomingDiscussions = response.data();
+        assertThat(upcomingDiscussions).hasSize(2);
+
+        // 정렬: fixedDate ASC 기준 -> discussion1 (fixedDate=2025-01-01) 먼저, discussion2 (fixedDate=2025-02-01) 이후
+        SharedEventWithDiscussionInfoResponse ded1 = upcomingDiscussions.get(0);
+        SharedEventWithDiscussionInfoResponse ded2 = upcomingDiscussions.get(1);
+
+        assertThat(ded1.discussionId()).isEqualTo(100L);
+        assertThat(ded1.title()).isEqualTo("Discussion 1");
+        assertThat(ded1.meetingMethodOrLocation()).isEqualTo("Room 1");
+        assertThat(ded1.sharedEventDto()).isEqualTo(sharedEvent1);
+        assertThat(ded1.participantPictureUrls()).containsExactly("pic1.jpg", "pic2.jpg");
+
+        assertThat(ded2.discussionId()).isEqualTo(101L);
+        assertThat(ded2.title()).isEqualTo("Discussion 2");
+        assertThat(ded2.meetingMethodOrLocation()).isEqualTo("Room 2");
+        assertThat(ded2.sharedEventDto()).isEqualTo(sharedEvent2);
+        assertThat(ded2.participantPictureUrls()).containsExactly("pic3.jpg");
+    }
 }

--- a/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
@@ -1,20 +1,13 @@
 package endolphin.backend.domain.shared_event;
 
-import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventDto;
-import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.domain.shared_event.entity.SharedEvent;
-import endolphin.backend.domain.user.UserRepository;
-import endolphin.backend.domain.user.UserService;
-import endolphin.backend.domain.user.entity.User;
-import endolphin.backend.global.dto.ListResponse;
 import endolphin.backend.global.error.ErrorResponse;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.time.LocalDateTime;
@@ -30,7 +22,6 @@ import java.util.Optional;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -40,12 +31,6 @@ class SharedEventServiceTest {
 
     @Mock
     private SharedEventRepository sharedEventRepository;
-
-    @Mock
-    private UserService userService;
-
-    @Mock
-    private DiscussionParticipantService discussionParticipantService;
 
     @InjectMocks
     private SharedEventService sharedEventService;
@@ -199,63 +184,5 @@ class SharedEventServiceTest {
         SharedEventDto expectedDto2 = SharedEventDto.of(event2);
         assertThat(result.get(100L)).isEqualTo(expectedDto1);
         assertThat(result.get(101L)).isEqualTo(expectedDto2);
-    }
-
-    @Test
-    public void getUpcomingSharedEvents_ShouldReturnSharedEventsWithDiscussionInfo() {
-        // given
-        User currentUser = Mockito.mock(User.class);
-        given(currentUser.getId()).willReturn(1L);
-
-        Discussion discussion1 = Mockito.mock(Discussion.class);
-        given(discussion1.getId()).willReturn(1L);
-        given(discussion1.getTitle()).willReturn("Discussion 1");
-        given(discussion1.getMeetingMethodOrLocation()).willReturn("Meeting 1");
-
-        Discussion discussion2 = Mockito.mock(Discussion.class);
-        given(discussion2.getId()).willReturn(2L);
-        given(discussion2.getTitle()).willReturn("Discussion 2");
-        given(discussion2.getMeetingMethodOrLocation()).willReturn("Google Meet");
-
-        List<Discussion> discussions = List.of(discussion1, discussion2);
-
-        SharedEvent sharedEvent1 = Mockito.mock(SharedEvent.class);
-        given(sharedEvent1.getDiscussion()).willReturn(discussion1);
-
-        SharedEvent sharedEvent2 = Mockito.mock(SharedEvent.class);
-        given(sharedEvent2.getDiscussion()).willReturn(discussion2);
-
-        List<SharedEvent> sharedEvents = List.of(sharedEvent1, sharedEvent2);
-
-        Map<Long, List<String>> discussionPicturesMap = new HashMap<>();
-        discussionPicturesMap.put(1L, List.of("pic1.png", "pic2.png"));
-        discussionPicturesMap.put(2L, List.of("pic3.png"));
-
-        given(userService.getCurrentUser()).willReturn(currentUser);
-        given(discussionParticipantService.getUpcomingDiscussionsByUserId(1L))
-            .willReturn(discussions);
-        given(sharedEventRepository.findByDiscussionIdIn(List.of(1L, 2L)))
-            .willReturn(sharedEvents);
-        given(discussionParticipantService.getDiscussionPicturesMap(List.of(1L, 2L)))
-            .willReturn(discussionPicturesMap);
-
-        // when
-        ListResponse<SharedEventWithDiscussionInfoResponse> result = sharedEventService.getUpcomingSharedEvents();
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.data()).hasSize(2);
-
-        SharedEventWithDiscussionInfoResponse response1 = result.data().get(0);
-        assertThat(response1.discussionId()).isEqualTo(1L);
-        assertThat(response1.title()).isEqualTo("Discussion 1");
-        assertThat(response1.meetingMethodOrLocation()).isEqualTo("Meeting 1");
-        assertThat(response1.participantPictureUrls()).containsExactly("pic1.png", "pic2.png");
-
-        SharedEventWithDiscussionInfoResponse response2 = result.data().get(1);
-        assertThat(response2.discussionId()).isEqualTo(2L);
-        assertThat(response2.title()).isEqualTo("Discussion 2");
-        assertThat(response2.meetingMethodOrLocation()).isEqualTo("Google Meet");
-        assertThat(response2.participantPictureUrls()).containsExactly("pic3.png");
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/shared_event/SharedEventServiceTest.java
@@ -1,13 +1,20 @@
 package endolphin.backend.domain.shared_event;
 
+import endolphin.backend.domain.discussion.DiscussionParticipantService;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.shared_event.dto.SharedEventRequest;
 import endolphin.backend.domain.shared_event.dto.SharedEventDto;
+import endolphin.backend.domain.shared_event.dto.SharedEventWithDiscussionInfoResponse;
 import endolphin.backend.domain.shared_event.entity.SharedEvent;
+import endolphin.backend.domain.user.UserRepository;
+import endolphin.backend.domain.user.UserService;
+import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.dto.ListResponse;
 import endolphin.backend.global.error.ErrorResponse;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.time.LocalDateTime;
@@ -32,6 +40,12 @@ class SharedEventServiceTest {
 
     @Mock
     private SharedEventRepository sharedEventRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private DiscussionParticipantService discussionParticipantService;
 
     @InjectMocks
     private SharedEventService sharedEventService;
@@ -185,5 +199,63 @@ class SharedEventServiceTest {
         SharedEventDto expectedDto2 = SharedEventDto.of(event2);
         assertThat(result.get(100L)).isEqualTo(expectedDto1);
         assertThat(result.get(101L)).isEqualTo(expectedDto2);
+    }
+
+    @Test
+    public void getUpcomingSharedEvents_ShouldReturnSharedEventsWithDiscussionInfo() {
+        // given
+        User currentUser = Mockito.mock(User.class);
+        given(currentUser.getId()).willReturn(1L);
+
+        Discussion discussion1 = Mockito.mock(Discussion.class);
+        given(discussion1.getId()).willReturn(1L);
+        given(discussion1.getTitle()).willReturn("Discussion 1");
+        given(discussion1.getMeetingMethodOrLocation()).willReturn("Meeting 1");
+
+        Discussion discussion2 = Mockito.mock(Discussion.class);
+        given(discussion2.getId()).willReturn(2L);
+        given(discussion2.getTitle()).willReturn("Discussion 2");
+        given(discussion2.getMeetingMethodOrLocation()).willReturn("Google Meet");
+
+        List<Discussion> discussions = List.of(discussion1, discussion2);
+
+        SharedEvent sharedEvent1 = Mockito.mock(SharedEvent.class);
+        given(sharedEvent1.getDiscussion()).willReturn(discussion1);
+
+        SharedEvent sharedEvent2 = Mockito.mock(SharedEvent.class);
+        given(sharedEvent2.getDiscussion()).willReturn(discussion2);
+
+        List<SharedEvent> sharedEvents = List.of(sharedEvent1, sharedEvent2);
+
+        Map<Long, List<String>> discussionPicturesMap = new HashMap<>();
+        discussionPicturesMap.put(1L, List.of("pic1.png", "pic2.png"));
+        discussionPicturesMap.put(2L, List.of("pic3.png"));
+
+        given(userService.getCurrentUser()).willReturn(currentUser);
+        given(discussionParticipantService.getUpcomingDiscussionsByUserId(1L))
+            .willReturn(discussions);
+        given(sharedEventRepository.findByDiscussionIdIn(List.of(1L, 2L)))
+            .willReturn(sharedEvents);
+        given(discussionParticipantService.getDiscussionPicturesMap(List.of(1L, 2L)))
+            .willReturn(discussionPicturesMap);
+
+        // when
+        ListResponse<SharedEventWithDiscussionInfoResponse> result = sharedEventService.getUpcomingSharedEvents();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.data()).hasSize(2);
+
+        SharedEventWithDiscussionInfoResponse response1 = result.data().get(0);
+        assertThat(response1.discussionId()).isEqualTo(1L);
+        assertThat(response1.title()).isEqualTo("Discussion 1");
+        assertThat(response1.meetingMethodOrLocation()).isEqualTo("Meeting 1");
+        assertThat(response1.participantPictureUrls()).containsExactly("pic1.png", "pic2.png");
+
+        SharedEventWithDiscussionInfoResponse response2 = result.data().get(1);
+        assertThat(response2.discussionId()).isEqualTo(2L);
+        assertThat(response2.title()).isEqualTo("Discussion 2");
+        assertThat(response2.meetingMethodOrLocation()).isEqualTo("Google Meet");
+        assertThat(response2.participantPictureUrls()).containsExactly("pic3.png");
     }
 }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #198 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
다가오는 일정들을 조회하는 기능을 구현했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality for users to view their upcoming discussions along with associated event details, enhancing the user experience by filtering out ongoing or finished discussions.

- **Tests**
  - Enhanced test coverage to ensure upcoming discussions are accurately retrieved and displayed, validating the expected outcomes for a reliable user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->