### PR TITLE
[BE-Feat] 공유 일정 조회 api 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionController.java
@@ -68,6 +68,8 @@ public class DiscussionController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "인증 실패",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "허락되지 않은 유저",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "해당 논의 없음",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", description = "서버 오류",
@@ -108,6 +110,8 @@ public class DiscussionController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "인증 실패",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "허락되지 않은 유저",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", description = "서버 오류",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
@@ -129,6 +133,8 @@ public class DiscussionController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "인증 실패",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "허락되지 않은 유저",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", description = "서버 오류",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
@@ -149,6 +155,8 @@ public class DiscussionController {
         @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "허락되지 않은 유저",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", description = "서버 오류",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
@@ -207,6 +215,8 @@ public class DiscussionController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "인증 실패",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "허락되지 않은 유저",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "논의 참여자 없음",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", description = "서버 오류",
@@ -236,5 +246,26 @@ public class DiscussionController {
     public ResponseEntity<Boolean> amIHost(
         @PathVariable("discussionId") @Min(1) Long discussionId) {
         return ResponseEntity.ok(discussionParticipantService.amIHost(discussionId));
+    }
+
+    @Operation(summary = "공유 일정 조회", description = "해당 논의의 공유 일정 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "공유 일정 조회 성공",
+            content = @Content(schema = @Schema(implementation = SharedEventWithDiscussionInfoResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "허락되지 않은 유저",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "해당 논의 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{discussionId}/shared-event")
+    public ResponseEntity<SharedEventWithDiscussionInfoResponse> getSharedEvent(
+        @PathVariable("discussionId") @Min(1) Long discussionId) {
+        return ResponseEntity.ok(discussionService.getSharedEventInfo(discussionId));
     }
 }

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // Common
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "Internal Server Error"),
-    INVALID_DATE_TIME_RANGE(HttpStatus.BAD_REQUEST, "C002", "End Time must be after Start Time"),
+    INVALID_DATE_TIME_REQUEST(HttpStatus.BAD_REQUEST, "C002", "Invalid Date Time Request"),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "C003", "Invalid Input"),
 
     // User

--- a/backend/src/main/java/endolphin/backend/global/util/Validator.java
+++ b/backend/src/main/java/endolphin/backend/global/util/Validator.java
@@ -1,5 +1,6 @@
 package endolphin.backend.global.util;
 
+import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
 import java.time.LocalDate;
@@ -10,19 +11,37 @@ public class Validator {
 
     public static void validateDateTimeRange(LocalDateTime start, LocalDateTime end) {
         if (end.isBefore(start)) {
-            throw new ApiException(ErrorCode.INVALID_DATE_TIME_RANGE);
+            throw new ApiException(ErrorCode.INVALID_DATE_TIME_REQUEST);
         }
     }
 
     public static void validateDateTimeRange(LocalDate start, LocalDate end) {
         if (end.isBefore(start)) {
-            throw new ApiException(ErrorCode.INVALID_DATE_TIME_RANGE);
+            throw new ApiException(ErrorCode.INVALID_DATE_TIME_REQUEST);
         }
     }
 
     public static void validateDateTimeRange(LocalTime start, LocalTime end) {
         if (end.isBefore(start)) {
-            throw new ApiException(ErrorCode.INVALID_DATE_TIME_RANGE);
+            throw new ApiException(ErrorCode.INVALID_DATE_TIME_REQUEST);
+        }
+    }
+
+    public static void validateInRange(Discussion discussion, LocalDateTime eventStart, LocalDateTime eventEnd) {
+        LocalDate startDate = discussion.getDateRangeStart();
+        LocalDate endDate = discussion.getDateRangeEnd();
+        LocalTime startTime = discussion.getTimeRangeStart();
+        LocalTime endTime = discussion.getTimeRangeEnd();
+
+        if (eventStart.toLocalDate().isBefore(startDate) || eventEnd.toLocalDate().isAfter(endDate)
+            || eventStart.toLocalTime().isBefore(startTime) || eventEnd.toLocalTime().isAfter(endTime)) {
+            throw new ApiException(ErrorCode.INVALID_DATE_TIME_REQUEST);
+        }
+    }
+
+    public static void validateDuration(LocalDateTime start, LocalDateTime end, int duration) {
+        if (!start.plusMinutes(duration).equals(end)) {
+            throw new ApiException(ErrorCode.INVALID_DATE_TIME_REQUEST);
         }
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -135,6 +135,11 @@ public class DiscussionServiceTest {
         Discussion discussion = Discussion.builder()
             .title("Project Sync")
             .meetingMethod(MeetingMethod.ONLINE)
+            .dateStart(LocalDate.of(2025, 3, 1))
+            .dateEnd(LocalDate.of(2025, 3, 1))
+            .timeStart(LocalTime.of(10, 0))
+            .timeEnd(LocalTime.of(12, 0))
+            .duration(120)
             .build();
 
         discussion.setDiscussionStatus(DiscussionStatus.ONGOING);
@@ -195,6 +200,11 @@ public class DiscussionServiceTest {
         Discussion discussion = Discussion.builder()
             .title("Project Sync")
             .meetingMethod(MeetingMethod.ONLINE)
+            .dateStart(LocalDate.of(2025, 3, 1))
+            .dateEnd(LocalDate.of(2025, 3, 1))
+            .timeStart(LocalTime.of(10, 0))
+            .timeEnd(LocalTime.of(12, 0))
+            .duration(120)
             .build();
 
         discussion.setDiscussionStatus(DiscussionStatus.ONGOING);
@@ -253,6 +263,11 @@ public class DiscussionServiceTest {
         Discussion discussion = Discussion.builder()
             .title("Test Discussion")
             .meetingMethod(MeetingMethod.ONLINE)
+            .dateStart(LocalDate.of(2025, 3, 1))
+            .dateEnd(LocalDate.of(2025, 3, 1))
+            .timeStart(LocalTime.of(10, 0))
+            .timeEnd(LocalTime.of(12, 0))
+            .duration(120)
             .build();
 
         discussion.setDiscussionStatus(DiscussionStatus.FINISHED);

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -526,7 +525,7 @@ public class DiscussionServiceTest {
         assertThatThrownBy(
             () -> discussionService.retrieveCandidateEventDetails(discussionId, request))
             .isInstanceOf(ApiException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_DATE_TIME_RANGE);
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_DATE_TIME_REQUEST);
 
         // 날짜 범위 검증 단계에서 예외가 발생하므로 다른 서비스들은 호출되지 않아야 함
         then(userService).shouldHaveNoInteractions();

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -10,6 +10,10 @@ spring:
     hibernate:
       ddl-auto: create
 
+  sql:
+    init:
+      mode: never
+
   data:
     redis:
       port: 6379


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #108 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 후보 일정 확정하는 api 구현했습니다.
- Validator에 메서드 추가했습니다.
- confirm schedule에 validation 추가했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new endpoint for retrieving shared event details associated with discussions.
  - Enhanced API responses to return clear unauthorized access errors.

- **Bug Fixes/Improvements**
  - Refined error messaging for invalid date/time inputs, providing clearer user feedback.

- **Chores**
  - Updated configuration to disable automatic SQL initialization at startup for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->