### PR TITLE
[BE-Fix] 후보 일정 상세 정보 조회 시 선택된 사용자가 없어도 되도록 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -31,6 +31,7 @@ import endolphin.backend.global.util.TimeCalculator;
 import endolphin.backend.global.util.Validator;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -179,10 +180,6 @@ public class DiscussionService {
         Long discussionId, CandidateEventDetailsRequest request) {
         final int TIME_OFFSET = 4;
 
-        if (request.selectedUserIdList().isEmpty()) {
-            throw new ApiException(ErrorCode.EMPTY_SELECTED_USER_IDS);
-        }
-
         LocalDateTime startTime = request.startDateTime();
         LocalDateTime endTime = request.endDateTime();
 
@@ -201,8 +198,11 @@ public class DiscussionService {
             throw new ApiException(ErrorCode.NOT_ALLOWED_USER);
         }
 
+        List<Long> selectedIds = request.selectedUserIdList() != null ?
+            request.selectedUserIdList() : List.of();
+
         Map<Long, Integer> selectedUserIdMap = new HashMap<>();
-        for (int i = 0; i < request.selectedUserIdList().size(); i++) {
+        for (int i = 0; i < selectedIds.size(); i++) {
             selectedUserIdMap.put(request.selectedUserIdList().get(i), i);
         }
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/CandidateEventDetailsRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/CandidateEventDetailsRequest.java
@@ -7,7 +7,7 @@ import java.util.List;
 public record CandidateEventDetailsRequest(
     @NotNull LocalDateTime startDateTime,
     @NotNull LocalDateTime endDateTime,
-    @NotNull List<Long> selectedUserIdList
+    List<Long> selectedUserIdList
 ) {
 
 }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #157 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
후보 일정 상세 정보 조회 시에 선택된 사용자 리스트에 null이나 빈 배열이 들어와도 정상 작동하도록 수정하였습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
