### PR TITLE
[BE-Feat] 개인 일정을 구글 캘린더에 반영하는 기능 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/auth/AuthService.java
+++ b/backend/src/main/java/endolphin/backend/domain/auth/AuthService.java
@@ -43,8 +43,6 @@ public class AuthService {
         validateUserInfo(userInfo);
         User user = userService.upsertUser(userInfo, tokenResponse);
 
-//        googleCalendarService.upsertGoogleCalendar(user);
-
         String accessToken = jwtProvider.createToken(user.getId(), user.getEmail());
         LocalDateTime expiredAt = LocalDateTime.now().plus(expired, ChronoUnit.MILLIS);
 

--- a/backend/src/main/java/endolphin/backend/domain/auth/AuthService.java
+++ b/backend/src/main/java/endolphin/backend/domain/auth/AuthService.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final GoogleOAuthService googleOAuthService;
-    private final GoogleCalendarService googleCalendarService;
     private final UserService userService;
     private final JwtProvider jwtProvider;
 
@@ -44,7 +43,7 @@ public class AuthService {
         validateUserInfo(userInfo);
         User user = userService.upsertUser(userInfo, tokenResponse);
 
-        googleCalendarService.upsertGoogleCalendar(user);
+//        googleCalendarService.upsertGoogleCalendar(user);
 
         String accessToken = jwtProvider.createToken(user.getId(), user.getEmail());
         LocalDateTime expiredAt = LocalDateTime.now().plus(expired, ChronoUnit.MILLIS);

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventController.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventController.java
@@ -113,8 +113,9 @@ public class PersonalEventController {
     })
     @DeleteMapping("/{personalEventId}")
     public ResponseEntity<Void> deletePersonalEvent(
-        @PathVariable("personalEventId") Long personalEventId) {
-        personalEventService.deletePersonalEvent(personalEventId);
+        @PathVariable("personalEventId") Long personalEventId,
+        @RequestParam("syncWithGoogleCalendar") Boolean syncWithGoogleCalendar) {
+        personalEventService.deletePersonalEvent(personalEventId, syncWithGoogleCalendar);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -14,9 +14,9 @@ import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.dto.ListResponse;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
-import endolphin.backend.global.google.GoogleCalendarService;
 import endolphin.backend.global.google.dto.GoogleEvent;
 import endolphin.backend.global.google.enums.GoogleEventStatus;
+import endolphin.backend.domain.personal_event.event.InsertPersonalEvent;
 import endolphin.backend.global.util.Validator;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,7 +41,7 @@ public class PersonalEventService {
     private final UserService userService;
     private final PersonalEventPreprocessor personalEventPreprocessor;
     private final DiscussionParticipantService discussionParticipantService;
-    private final GoogleCalendarService googleCalendarService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public ListResponse<PersonalEventResponse> listPersonalEvents(LocalDate startDate,
@@ -80,6 +81,8 @@ public class PersonalEventService {
         //TODO syncWithGoogleCalendar == true 일 때 구글 캘린더에도 업데이트
 
         googleCalendarService.insertPersonalEventToGoogleCalendar(personalEvent);
+//        googleCalendarService.insertPersonalEventToGoogleCalendar(personalEvent);
+        eventPublisher.publishEvent(new InsertPersonalEvent(List.of(result)));
         // TODO: 비트맵 반영
         return PersonalEventResponse.fromEntity(result);
     }
@@ -105,6 +108,8 @@ public class PersonalEventService {
         googleCalendarService.insertPersonalEvents(events);
 
         //TODO 구글캘린더에 반영
+//        googleCalendarService.insertPersonalEvents(events);
+        eventPublisher.publishEvent(new InsertPersonalEvent(events));
     }
 
     public PersonalEventResponse updateWithRequest(PersonalEventRequest request,

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -19,17 +19,18 @@ import endolphin.backend.global.error.exception.ErrorCode;
 import endolphin.backend.global.google.dto.GoogleEvent;
 import endolphin.backend.global.google.enums.GoogleEventStatus;
 import endolphin.backend.domain.personal_event.event.InsertPersonalEvent;
+import endolphin.backend.global.util.IdGenerator;
 import endolphin.backend.global.util.Validator;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.binary.Base32;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -74,7 +75,7 @@ public class PersonalEventService {
             .build();
 
         if (request.syncWithGoogleCalendar()) {
-            personalEvent.setGoogleEventId(createGoogleEventId(user.getId()));
+            personalEvent.setGoogleEventId(IdGenerator.generateId(user.getId()));
             personalEvent.setCalendarId(PRIMARY);
             eventPublisher.publishEvent(new InsertPersonalEvent(List.of(personalEvent)));
         }
@@ -96,7 +97,7 @@ public class PersonalEventService {
         SharedEventDto sharedEvent) {
         List<PersonalEvent> events = participants.stream()
             .map(participant -> {
-                String googleEventId = createGoogleEventId(participant.getId());
+                String googleEventId = IdGenerator.generateId(participant.getId());
                 return PersonalEvent.builder()
                     .title(discussion.getTitle())
                     .startTime(sharedEvent.startDateTime())
@@ -280,13 +281,5 @@ public class PersonalEventService {
         result.sort(
             Comparator.comparing(UserInfoWithPersonalEvents::requirementOfAdjustment).reversed());
         return result;
-    }
-
-    private String createGoogleEventId(Long id) {
-        final String PREFIX = "endolphin";
-        return String.format("%s%d%s",
-            PREFIX, id,
-            Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes())
-                .toLowerCase());
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -71,15 +71,15 @@ public class PersonalEventService {
             .isAdjustable(request.isAdjustable())
             .user(user)
             .build();
-
+        
         PersonalEvent result = personalEventRepository.save(personalEvent);
-
+        
         if (request.syncWithGoogleCalendar()) {
             personalEvent.setGoogleEventId(IdGenerator.generateId(user.getId()));
             personalEvent.setCalendarId(PRIMARY);
             eventPublisher.publishEvent(new InsertPersonalEvent(List.of(personalEvent)));
         }
-        
+
         List<Discussion> discussions = discussionParticipantService.getDiscussionsByUserId(
             user.getId());
 
@@ -129,7 +129,7 @@ public class PersonalEventService {
 
         if (request.syncWithGoogleCalendar()) {
             if (result.getGoogleEventId() == null) {
-                eventPublisher.publishEvent(new InsertPersonalEvent(List.of(result)));
+                eventPublisher.publishEvent(new InsertPersonalEvent(List.of(personalEvent)));
             } else {
                 eventPublisher.publishEvent(new UpdatePersonalEvent(result));
             }
@@ -145,6 +145,10 @@ public class PersonalEventService {
         PersonalEvent oldEvent = personalEvent.copy();
 
         personalEvent.update(request);
+
+        if (request.syncWithGoogleCalendar()) {
+            personalEvent.update(IdGenerator.generateId(user.getId()), PRIMARY);
+        }
 
         if (isChanged(personalEvent, request)) {
             discussions.forEach(discussion -> {

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 
 
@@ -40,9 +41,11 @@ public class PersonalEvent extends BaseTimeEntity {
     @Column(name = "is_adjustable")
     private Boolean isAdjustable;
 
+    @Setter
     @Column(name = "calendar_id")
     private String calendarId;
 
+    @Setter
     @Column(name = "google_event_id")
     private String googleEventId;
 

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/entity/PersonalEvent.java
@@ -69,10 +69,9 @@ public class PersonalEvent extends BaseTimeEntity {
         this.isAdjustable = personalEventRequest.isAdjustable();
     }
 
-    public void update(LocalDateTime startDateTime, LocalDateTime endDateTime, String title) {
-        this.startTime = startDateTime;
-        this.endTime = endDateTime;
-        this.title = title;
+    public void update(String googleEventId, String calendarId) {
+        this.googleEventId = googleEventId;
+        this.calendarId = calendarId;
     }
 
     public PersonalEvent copy() {

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/event/DeletePersonalEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/event/DeletePersonalEvent.java
@@ -1,0 +1,9 @@
+package endolphin.backend.domain.personal_event.event;
+
+import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+
+public record DeletePersonalEvent(
+    PersonalEvent personalEvent
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/event/InsertPersonalEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/event/InsertPersonalEvent.java
@@ -1,0 +1,10 @@
+package endolphin.backend.domain.personal_event.event;
+
+import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+import java.util.List;
+
+public record InsertPersonalEvent(
+    List<PersonalEvent> personalEventList
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/event/UpdatePersonalEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/event/UpdatePersonalEvent.java
@@ -1,0 +1,9 @@
+package endolphin.backend.domain.personal_event.event;
+
+import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+
+public record UpdatePersonalEvent(
+    PersonalEvent personalEvent
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/event/handler/PersonalEventHandler.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/event/handler/PersonalEventHandler.java
@@ -1,0 +1,24 @@
+package endolphin.backend.domain.personal_event.event.handler;
+
+import endolphin.backend.domain.personal_event.PersonalEventService;
+import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.google.dto.GoogleEvent;
+import endolphin.backend.global.google.event.GoogleEventChanged;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PersonalEventHandler {
+    private final PersonalEventService personalEventService;
+
+    @EventListener(classes = {GoogleEventChanged.class})
+    public void sync(GoogleEventChanged event) {
+        List<GoogleEvent> events = event.events();
+        User user = event.user();
+        String googleCalendarId = event.googleCalendarId();
+        personalEventService.syncWithGoogleEvents(events, user, googleCalendarId);
+    }
+}

--- a/backend/src/main/java/endolphin/backend/domain/user/UserService.java
+++ b/backend/src/main/java/endolphin/backend/domain/user/UserService.java
@@ -1,6 +1,7 @@
 package endolphin.backend.domain.user;
 
 import endolphin.backend.domain.user.dto.UserIdNameDto;
+import endolphin.backend.domain.user.event.LoginEvent;
 import endolphin.backend.global.google.dto.GoogleUserInfo;
 import endolphin.backend.global.google.dto.GoogleTokens;
 import endolphin.backend.domain.user.entity.User;
@@ -11,6 +12,7 @@ import endolphin.backend.global.security.UserInfo;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class UserService {
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public User getCurrentUser() {
@@ -55,7 +58,8 @@ public class UserService {
             });
         user.setAccessToken(tokenResponse.accessToken());
         user.setRefreshToken(tokenResponse.refreshToken());
-        userRepository.save(user);
+        user = userRepository.save(user);
+        eventPublisher.publishEvent(new LoginEvent(user));
         return user;
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/user/event/LoginEvent.java
+++ b/backend/src/main/java/endolphin/backend/domain/user/event/LoginEvent.java
@@ -1,0 +1,9 @@
+package endolphin.backend.domain.user.event;
+
+import endolphin.backend.domain.user.entity.User;
+
+public record LoginEvent(
+    User user
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/global/config/GoogleCalendarUrl.java
+++ b/backend/src/main/java/endolphin/backend/global/config/GoogleCalendarUrl.java
@@ -9,7 +9,8 @@ public record GoogleCalendarUrl(
     String unsubscribeUrl,
     String webhookUrl,
     String primaryCalendarUrl,
-    String eventsUrl
+    String eventsUrl,
+    String updateUrl
 ) {
 
 }

--- a/backend/src/main/java/endolphin/backend/global/google/dto/GoogleEventDateTime.java
+++ b/backend/src/main/java/endolphin/backend/global/google/dto/GoogleEventDateTime.java
@@ -1,0 +1,16 @@
+package endolphin.backend.global.google.dto;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public record GoogleEventDateTime(
+    String dateTime,
+    String timeZone
+) {
+    private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+    public static GoogleEventDateTime fromLocalDateTime(LocalDateTime dateTime) {
+
+        return new GoogleEventDateTime(dateTime.atOffset(ZoneOffset.ofHours(9)).format(DATE_TIME_FORMATTER), "Asia/Seoul");
+    }
+}

--- a/backend/src/main/java/endolphin/backend/global/google/dto/GoogleEventDateTime.java
+++ b/backend/src/main/java/endolphin/backend/global/google/dto/GoogleEventDateTime.java
@@ -1,6 +1,7 @@
 package endolphin.backend.global.google.dto;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
@@ -9,8 +10,11 @@ public record GoogleEventDateTime(
     String timeZone
 ) {
     private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+    private final static ZoneId DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul");
+
     public static GoogleEventDateTime fromLocalDateTime(LocalDateTime dateTime) {
 
-        return new GoogleEventDateTime(dateTime.atOffset(ZoneOffset.ofHours(9)).format(DATE_TIME_FORMATTER), "Asia/Seoul");
+        return new GoogleEventDateTime(dateTime.atOffset(ZoneOffset.ofHours(9))
+            .format(DATE_TIME_FORMATTER), DEFAULT_ZONE_ID.getId());
     }
 }

--- a/backend/src/main/java/endolphin/backend/global/google/dto/GoogleEventRequest.java
+++ b/backend/src/main/java/endolphin/backend/global/google/dto/GoogleEventRequest.java
@@ -1,0 +1,18 @@
+package endolphin.backend.global.google.dto;
+
+import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+
+public record GoogleEventRequest(
+    GoogleEventDateTime start,
+    GoogleEventDateTime end,
+    String summary,
+    String id
+) {
+
+    public static GoogleEventRequest of(PersonalEvent personalEvent, String id) {
+        GoogleEventDateTime start = GoogleEventDateTime.fromLocalDateTime(personalEvent.getStartTime());
+        GoogleEventDateTime end = GoogleEventDateTime.fromLocalDateTime(personalEvent.getEndTime());
+        return new GoogleEventRequest(start, end, personalEvent.getTitle(), id);
+    }
+
+}

--- a/backend/src/main/java/endolphin/backend/global/google/event/GoogleEventChanged.java
+++ b/backend/src/main/java/endolphin/backend/global/google/event/GoogleEventChanged.java
@@ -1,0 +1,13 @@
+package endolphin.backend.global.google.event;
+
+import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.global.google.dto.GoogleEvent;
+import java.util.List;
+
+public record GoogleEventChanged(
+    List<GoogleEvent> events,
+    User user,
+    String googleCalendarId
+) {
+
+}

--- a/backend/src/main/java/endolphin/backend/global/google/event/handler/GoogleEventHandler.java
+++ b/backend/src/main/java/endolphin/backend/global/google/event/handler/GoogleEventHandler.java
@@ -1,6 +1,8 @@
 package endolphin.backend.global.google.event.handler;
 
 import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+import endolphin.backend.domain.personal_event.event.DeletePersonalEvent;
+import endolphin.backend.domain.personal_event.event.UpdatePersonalEvent;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.domain.user.event.LoginEvent;
 import endolphin.backend.global.google.GoogleCalendarService;
@@ -29,5 +31,17 @@ public class GoogleEventHandler {
     public void login(LoginEvent event) {
         User user = event.user();
         googleCalendarService.upsertGoogleCalendar(user);
+    }
+
+    @Async
+    @TransactionalEventListener(classes = {UpdatePersonalEvent.class})
+    public void update(UpdatePersonalEvent event) {
+        googleCalendarService.updatePersonalEventToGoogleCalendar(event.personalEvent());
+    }
+
+    @Async
+    @TransactionalEventListener(classes = {DeletePersonalEvent.class})
+    public void delete(DeletePersonalEvent event) {
+        googleCalendarService.deletePersonalEventFromGoogleCalender(event.personalEvent());
     }
 }

--- a/backend/src/main/java/endolphin/backend/global/google/event/handler/GoogleEventHandler.java
+++ b/backend/src/main/java/endolphin/backend/global/google/event/handler/GoogleEventHandler.java
@@ -1,0 +1,33 @@
+package endolphin.backend.global.google.event.handler;
+
+import endolphin.backend.domain.personal_event.entity.PersonalEvent;
+import endolphin.backend.domain.user.entity.User;
+import endolphin.backend.domain.user.event.LoginEvent;
+import endolphin.backend.global.google.GoogleCalendarService;
+import endolphin.backend.domain.personal_event.event.InsertPersonalEvent;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleEventHandler {
+    private final GoogleCalendarService googleCalendarService;
+
+    @Async
+    @TransactionalEventListener(classes = {InsertPersonalEvent.class})
+    public void insert(InsertPersonalEvent event) {
+        List<PersonalEvent> personalEventList =
+            event.personalEventList();
+        googleCalendarService.insertPersonalEvents(personalEventList);
+    }
+
+    @Async
+    @TransactionalEventListener(classes = {LoginEvent.class})
+    public void login(LoginEvent event) {
+        User user = event.user();
+        googleCalendarService.upsertGoogleCalendar(user);
+    }
+}

--- a/backend/src/main/java/endolphin/backend/global/util/IdGenerator.java
+++ b/backend/src/main/java/endolphin/backend/global/util/IdGenerator.java
@@ -1,0 +1,15 @@
+package endolphin.backend.global.util;
+
+import java.util.UUID;
+import org.apache.commons.codec.binary.Base32;
+
+public class IdGenerator {
+    private static final String PREFIX = "endolphin";
+    private static final Base32 base = new Base32(true);
+    public static String generateId(Long id) {
+        return String.format("%s%d%s",
+            PREFIX, id,
+            base.encodeToString(UUID.randomUUID().toString().getBytes())
+                .replace("=","").toLowerCase());
+    }
+}

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -12,9 +12,11 @@ import endolphin.backend.global.dto.ListResponse;
 import java.time.LocalDate;
 import endolphin.backend.global.google.dto.GoogleEvent;
 import endolphin.backend.global.google.enums.GoogleEventStatus;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -447,5 +449,10 @@ class PersonalEventServiceTest {
         assertThat(user2Info.selected()).isFalse();
         assertThat(user2Info.requirementOfAdjustment()).isFalse();
         assertThat(user2Info.events()).isEmpty();
+    }
+
+    @Test
+    public void test() {
+        System.out.println(Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes()).toLowerCase());
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import org.springframework.context.ApplicationEventPublisher;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -40,6 +41,9 @@ class PersonalEventServiceTest {
 
     @Mock
     private DiscussionParticipantService discussionParticipantService;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @Mock
     private UserService userService;

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -186,7 +186,7 @@ class PersonalEventServiceTest {
         given(personalEventRepository.findById(anyLong())).willReturn(Optional.of(existingEvent));
         given(userService.getCurrentUser()).willReturn(testUser);
 
-        assertThatThrownBy(() -> personalEventService.deletePersonalEvent(anyLong()))
+        assertThatThrownBy(() -> personalEventService.deletePersonalEvent(anyLong(), false))
             .isInstanceOf(RuntimeException.class);
 
         then(personalEventRepository).should(times(1)).findById(anyLong());
@@ -204,7 +204,7 @@ class PersonalEventServiceTest {
         given(userService.getCurrentUser()).willReturn(testUser);
 
         // when
-        personalEventService.deletePersonalEvent(anyLong());
+        personalEventService.deletePersonalEvent(anyLong(), false);
 
         // then
         then(personalEventRepository).should(times(1)).delete(any(PersonalEvent.class));

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -454,9 +454,4 @@ class PersonalEventServiceTest {
         assertThat(user2Info.requirementOfAdjustment()).isFalse();
         assertThat(user2Info.events()).isEmpty();
     }
-
-    @Test
-    public void test() {
-        System.out.println(Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes()).toLowerCase());
-    }
 }

--- a/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/google/GoogleCalendarServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class GoogleCalendarServiceTest {
@@ -37,6 +38,9 @@ class GoogleCalendarServiceTest {
 
     @Mock
     private GoogleCalendarUrl googleCalendarUrl;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @Mock
     private PersonalEventService personalEventService;
@@ -108,7 +112,6 @@ class GoogleCalendarServiceTest {
         then(googleCalendarService).should().getPrimaryCalendar(user);
         then(calendarService).should().createCalendar(googleCalendarDto, user);
         then(googleCalendarService).should().getCalendarEvents(googleCalendarDto.id(), user);
-        then(personalEventService).should().syncWithGoogleEvents(events, user, googleCalendarDto.id());
     }
 
     @Test


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #220
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
구글 캘린더에 개인 일정 변경을 반영하는 기능 구현했습니다. 
순환 참조가 생겨서 spring event를 사용해서 해결했습니다. 
- 구글 캘린더에 추가
- 구글 캘린더에 업데이트
- 구글 캘린더에서 삭제
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to control Google Calendar synchronization when deleting personal events.
  - Enabled real-time updates between personal events and Google Calendar for creation, update, and deletion operations.
  - Introduced new event handling for Google Calendar changes, enhancing synchronization capabilities.
  - Added new records for managing events related to personal event insertion, updates, and deletions.
  - Added a new class for handling Google event changes.

- **Improvements**
  - Enhanced error recovery for calendar operations with automatic token refresh.
  - Streamlined user login processing with improved event-driven handling, leading to a smoother overall experience.
  - Added unique identifier generation for events to ensure consistency.
  - Updated the configuration to include a new update URL for Google Calendar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->