### PR TITLE
[FE-Feat] 호스트 여부 체크, 일정 확정하기 버튼, 일정 확정 후 라우팅 및 조회 구현

### DIFF
--- a/frontend/src/features/discussion/api/index.ts
+++ b/frontend/src/features/discussion/api/index.ts
@@ -54,4 +54,9 @@ export const candidateApi = {
     const response = await request.post(`/api/v1/discussion/${id}/confirm`, { body });
     return response;
   },
+
+  getDiscussionConfirm: async (id: string): Promise<DiscussionConfirmResponse> => {
+    const response = await request.get(`/api/v1/discussion/${id}/shared-event`);
+    return response;
+  },
 };

--- a/frontend/src/features/discussion/api/index.ts
+++ b/frontend/src/features/discussion/api/index.ts
@@ -3,6 +3,8 @@ import { request } from '@/utils/fetch';
 import type { 
   DiscussionCalendarRequest,
   DiscussionCalendarResponse, 
+  DiscussionConfirmRequest,
+  DiscussionConfirmResponse, 
   DiscussionParticipantResponse, 
   DiscussionRankRequest, 
   DiscussionRankResponse, 
@@ -44,5 +46,12 @@ export const candidateApi = {
     const response 
       = await request.get(`/api/v1/discussion/${discussionId}/participants`);
     return response.participants;
+  },
+  
+  postDiscussionConfirm: async (
+    { id, body }: { id: string; body: DiscussionConfirmRequest },
+  ): Promise<DiscussionConfirmResponse> => {
+    const response = await request.post(`/api/v1/discussion/${id}/confirm`, { body });
+    return response;
   },
 };

--- a/frontend/src/features/discussion/api/index.ts
+++ b/frontend/src/features/discussion/api/index.ts
@@ -17,8 +17,14 @@ export const discussionApi = {
     const response = await request.post('/api/v1/discussion', { body });
     return response;
   },
+
   getDiscussion: async (id: string): Promise<DiscussionResponse> => {
     const response = await request.get(`/api/v1/discussion/${id}`);
+    return response;
+  },
+
+  getIsHost: async (id: string): Promise<boolean> => {
+    const response = await request.get(`/api/v1/discussion/${id}/role`);
     return response;
   },
 };

--- a/frontend/src/features/discussion/api/keys.ts
+++ b/frontend/src/features/discussion/api/keys.ts
@@ -21,3 +21,8 @@ export const participantKeys = {
   all: ['participants'],
   detail: (id: string) => [...participantKeys.all, id],
 };
+
+export const sharedEventKeys = {
+  all: ['sharedEvents'],
+  detail: (id: string) => [...sharedEventKeys.all, id],
+};

--- a/frontend/src/features/discussion/api/keys.ts
+++ b/frontend/src/features/discussion/api/keys.ts
@@ -26,3 +26,8 @@ export const sharedEventKeys = {
   all: ['sharedEvents'],
   detail: (id: string) => [...sharedEventKeys.all, id],
 };
+
+export const hostKeys = {
+  all: ['hosts'],
+  detail: (id: string) => [...hostKeys.all, id],
+};

--- a/frontend/src/features/discussion/api/mutations.ts
+++ b/frontend/src/features/discussion/api/mutations.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import type { DiscussionRequest } from '../model';
+import { personalEventKeys } from '@/features/my-calendar/api/keys';
+
+import type { DiscussionConfirmRequest, DiscussionRequest } from '../model';
 import { discussionApi } from '.';
 import { discussionKeys } from './keys';
 
@@ -16,6 +18,24 @@ export const useDiscussionMutation = () => {
       callback?.(id.toString());
       queryClient.invalidateQueries({
         queryKey: discussionKeys.all,
+      });
+    },
+  });
+  
+  return { mutate };
+};
+
+export const useDiscussionConfirmMutation = () => {
+  const queryClient = useQueryClient();
+  
+  const { mutate } = useMutation({
+    mutationFn: ({ id, body }: { 
+      id: string;
+      body: DiscussionConfirmRequest;
+    }) => discussionApi.postDiscussionConfirm({ id, body }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: personalEventKeys.all,
       });
     },
   });

--- a/frontend/src/features/discussion/api/mutations.ts
+++ b/frontend/src/features/discussion/api/mutations.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 
 import { personalEventKeys } from '@/features/my-calendar/api/keys';
 
@@ -27,15 +28,20 @@ export const useDiscussionMutation = () => {
 
 export const useDiscussionConfirmMutation = () => {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   
   const { mutate } = useMutation({
     mutationFn: ({ id, body }: { 
       id: string;
       body: DiscussionConfirmRequest;
     }) => discussionApi.postDiscussionConfirm({ id, body }),
-    onSuccess: () => {
+    onSuccess: ({ discussionId }) => {
       queryClient.invalidateQueries({
         queryKey: personalEventKeys.all,
+      });
+      navigate({
+        to: '/discussion/confirm/$id',
+        params: { id: String(discussionId) },
       });
     },
   });

--- a/frontend/src/features/discussion/api/mutations.ts
+++ b/frontend/src/features/discussion/api/mutations.ts
@@ -4,7 +4,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { personalEventKeys } from '@/features/my-calendar/api/keys';
 
 import type { DiscussionConfirmRequest, DiscussionRequest } from '../model';
-import { discussionApi } from '.';
+import { candidateApi, discussionApi } from '.';
 import { discussionKeys } from './keys';
 
 export const useDiscussionMutation = () => {
@@ -34,7 +34,7 @@ export const useDiscussionConfirmMutation = () => {
     mutationFn: ({ id, body }: { 
       id: string;
       body: DiscussionConfirmRequest;
-    }) => discussionApi.postDiscussionConfirm({ id, body }),
+    }) => candidateApi.postDiscussionConfirm({ id, body }),
     onSuccess: ({ discussionId }) => {
       queryClient.invalidateQueries({
         queryKey: personalEventKeys.all,

--- a/frontend/src/features/discussion/api/queries.ts
+++ b/frontend/src/features/discussion/api/queries.ts
@@ -10,7 +10,14 @@ import type {
   DiscussionResponse, 
 } from '../model';
 import { candidateApi, discussionApi } from '.';
-import { calendarKeys, discussionKeys, participantKeys, rankKeys, sharedEventKeys } from './keys';
+import { 
+  calendarKeys, 
+  discussionKeys,
+  hostKeys, 
+  participantKeys, 
+  rankKeys, 
+  sharedEventKeys, 
+} from './keys';
 
 export const discussionQuery = (discussionId: string) => ({
   queryKey: discussionKeys.detail(discussionId), 
@@ -41,6 +48,11 @@ export const discussionParticipantQuery = (discussionId: string) => ({
 export const discussionConfirmQuery = (discussionId: string) => ({
   queryKey: sharedEventKeys.detail(discussionId),
   queryFn: () => candidateApi.getDiscussionConfirm(discussionId),
+});
+
+export const discussionHostQuery = (discussionId: string) => ({
+  queryKey: hostKeys.detail(discussionId),
+  queryFn: () => discussionApi.getIsHost(discussionId),
 });
 
 export const useDiscussionQuery = (discussionId: string) => {
@@ -85,4 +97,11 @@ export const useDiscussionConfirmQuery = (discussionId: string) => {
     = useQuery<DiscussionConfirmResponse>(discussionConfirmQuery(discussionId));
 
   return { sharedEvent, isPending };
+};
+
+export const useDiscussionHostQuery = (discussionId: string) => {
+  const { data: isHost, isPending }
+    = useQuery<boolean>(discussionHostQuery(discussionId));
+
+  return { isHost, isPending };
 };

--- a/frontend/src/features/discussion/api/queries.ts
+++ b/frontend/src/features/discussion/api/queries.ts
@@ -3,13 +3,14 @@ import { useQuery } from '@tanstack/react-query';
 import type { 
   DiscussionCalendarRequest, 
   DiscussionCalendarResponse,
+  DiscussionConfirmResponse,
   DiscussionParticipantResponse,
   DiscussionRankRequest,
   DiscussionRankResponse,
   DiscussionResponse, 
 } from '../model';
 import { candidateApi, discussionApi } from '.';
-import { calendarKeys, discussionKeys, participantKeys, rankKeys } from './keys';
+import { calendarKeys, discussionKeys, participantKeys, rankKeys, sharedEventKeys } from './keys';
 
 export const discussionQuery = (discussionId: string) => ({
   queryKey: discussionKeys.detail(discussionId), 
@@ -35,6 +36,11 @@ export const discussionRankQuery = (
 export const discussionParticipantQuery = (discussionId: string) => ({
   queryKey: participantKeys.detail(discussionId),
   queryFn: () => candidateApi.getCandidateParticipants(discussionId),
+});
+
+export const discussionConfirmQuery = (discussionId: string) => ({
+  queryKey: sharedEventKeys.detail(discussionId),
+  queryFn: () => candidateApi.getDiscussionConfirm(discussionId),
 });
 
 export const useDiscussionQuery = (discussionId: string) => {
@@ -72,4 +78,11 @@ export const useDiscussionParticipantsQuery = (discussionId: string) => {
         );
     
   return { participants, isLoading };
+};
+
+export const useDiscussionConfirmQuery = (discussionId: string) => {
+  const { data: sharedEvent, isPending } 
+    = useQuery<DiscussionConfirmResponse>(discussionConfirmQuery(discussionId));
+
+  return { sharedEvent, isPending };
 };

--- a/frontend/src/features/discussion/model/index.ts
+++ b/frontend/src/features/discussion/model/index.ts
@@ -11,6 +11,12 @@ const DiscussionDTO = z.object({
   usersForAdjust: z.array(UserDTO.pick({ id: true, name: true })),
 });
 
+const SharedEventDTO = z.object({
+  id: z.number(),
+  startDateTime: z.string().datetime(),
+  endDateTime: z.string().datetime(),
+});
+
 const DiscussionRequest = z.object({
   title: z.string().min(1, '제목은 필수입니다')
     .max(15, '제목은 15자 이하로 입력해주세요'),
@@ -26,6 +32,8 @@ const DiscussionRequest = z.object({
   password: z.string().regex(PASSWORD)
     .optional(),
 });
+
+const DiscussionConfirmRequest = SharedEventDTO.omit({ id: true });
 
 const DiscussionResponse = z.object({
   id: z.number(),
@@ -66,9 +74,19 @@ const DiscussionRankResponse = z.object({
   eventsRankedOfTime: z.array(DiscussionDTO),
 });
 
+const DiscussionConfirmResponse = z.object({
+  discussionId: z.number(),
+  title: z.string(),
+  meetingMethodOrLocation: z.string(),
+  sharedEventDto: SharedEventDTO,
+  participantPictureUrls: z.array(z.string()),
+});
+
 export type DiscussionRequest = z.infer<typeof DiscussionRequest>;
+export type DiscussionConfirmRequest = z.infer<typeof DiscussionConfirmRequest>;
 export type DiscussionResponse = z.infer<typeof DiscussionResponse>;
 export type DiscussionParticipantResponse = z.infer<typeof DiscussionParticipantResponse>;
+export type DiscussionConfirmResponse = z.infer<typeof DiscussionConfirmResponse>;
 
 export type DiscussionCalendarRequest = z.infer<typeof DiscussionCalendarRequest>;
 export type DiscussionCalendarResponse = z.infer<typeof DiscussionCalendarResponse>;

--- a/frontend/src/features/discussion/ui/DiscussionCard/DiscussionLarge.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCard/DiscussionLarge.tsx
@@ -51,7 +51,7 @@ const DiscussionContents = (
 );
 
 export const DiscussionLarge = (
-  { discussion, rank }: { discussion: DiscussionDTO; rank: number },
+  { discussion, rank, onClick }: { discussion: DiscussionDTO; rank: number; onClick: () => void },
 ) => {
   const ADJUSTMENT_LENGTH = discussion.usersForAdjust.length;
   const isRecommend = ADJUSTMENT_LENGTH === 0;
@@ -60,6 +60,7 @@ export const DiscussionLarge = (
       className={largeContainerStyle}
       direction='column'
       gap={800}
+      onClick={onClick}
       width='100%'
     >
       <Flex direction='column' gap={300}>

--- a/frontend/src/features/discussion/ui/DiscussionCard/DiscussionLarge.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCard/DiscussionLarge.tsx
@@ -51,7 +51,7 @@ const DiscussionContents = (
 );
 
 export const DiscussionLarge = (
-  { discussion, rank, onClick }: { discussion: DiscussionDTO; rank: number; onClick: () => void },
+  { discussion, rank }: { discussion: DiscussionDTO; rank: number },
 ) => {
   const ADJUSTMENT_LENGTH = discussion.usersForAdjust.length;
   const isRecommend = ADJUSTMENT_LENGTH === 0;
@@ -60,7 +60,6 @@ export const DiscussionLarge = (
       className={largeContainerStyle}
       direction='column'
       gap={800}
-      onClick={onClick}
       width='100%'
     >
       <Flex direction='column' gap={300}>

--- a/frontend/src/features/discussion/ui/DiscussionCard/DiscussionSmall.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCard/DiscussionSmall.tsx
@@ -7,7 +7,9 @@ import { formatDateToTimeString } from '@/utils/date/format';
 import type { DiscussionDTO } from '../../model';
 import { containerStyle } from './card.css';
 
-export const DiscussionSmall = ({ discussion }: { discussion: DiscussionDTO }) => {
+export const DiscussionSmall = (
+  { discussion, onClick }: { discussion: DiscussionDTO; onClick: () => void },
+) => {
   const ADJUSTMENT_LENGTH = discussion.usersForAdjust.length;
   const isRecommend = ADJUSTMENT_LENGTH === 0;
   return (
@@ -15,6 +17,7 @@ export const DiscussionSmall = ({ discussion }: { discussion: DiscussionDTO }) =
       className={containerStyle({ isRecommend })}
       direction='column'
       gap={300}
+      onClick={onClick}
       width='100%'
     >
       {isRecommend && <Chip color='blue' size='lg'>추천</Chip>}

--- a/frontend/src/features/discussion/ui/DiscussionCard/DiscussionSmall.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCard/DiscussionSmall.tsx
@@ -5,10 +5,14 @@ import { vars } from '@/theme/index.css';
 import { formatDateToTimeString } from '@/utils/date/format';
 
 import type { DiscussionDTO } from '../../model';
+import DiscussionConfirmButton from '../DiscussionConfirmButton';
 import { containerStyle } from './card.css';
 
+// 추후 삭제할 코드가 포함되어 있습니다.
+// TODO: 일정 확정 버튼 디테일 페이지로 이동
+// eslint-disable-next-line
 export const DiscussionSmall = (
-  { discussion, onClick }: { discussion: DiscussionDTO; onClick: () => void },
+  { discussion }: { discussion: DiscussionDTO },
 ) => {
   const ADJUSTMENT_LENGTH = discussion.usersForAdjust.length;
   const isRecommend = ADJUSTMENT_LENGTH === 0;
@@ -17,9 +21,12 @@ export const DiscussionSmall = (
       className={containerStyle({ isRecommend })}
       direction='column'
       gap={300}
-      onClick={onClick}
       width='100%'
     >
+      <DiscussionConfirmButton 
+        endDateTime={discussion.endDateTime}
+        startDateTime={discussion.startDateTime}
+      />
       {isRecommend && <Chip color='blue' size='lg'>추천</Chip>}
       <Flex direction='column' gap={50}>
         <Text color={vars.color.Ref.Netural[600]} typo='b3R'>

--- a/frontend/src/features/discussion/ui/DiscussionCard/card.css.ts
+++ b/frontend/src/features/discussion/ui/DiscussionCard/card.css.ts
@@ -12,6 +12,8 @@ export const containerStyle = recipe({
     borderLeft: '3px solid transparent',
 
     backgroundColor: vars.color.Ref.Netural.White,
+
+    cursor: 'pointer',
   },
   variants: {
     isRecommend: {
@@ -34,6 +36,8 @@ export const largeContainerStyle = style({
   borderRadius: vars.radius[500],
 
   backgroundColor: vars.color.Ref.Netural.White,
+
+  cursor: 'pointer',
 });
 
 export const rankContainerStyle = recipe({

--- a/frontend/src/features/discussion/ui/DiscussionCard/card.css.ts
+++ b/frontend/src/features/discussion/ui/DiscussionCard/card.css.ts
@@ -12,8 +12,6 @@ export const containerStyle = recipe({
     borderLeft: '3px solid transparent',
 
     backgroundColor: vars.color.Ref.Netural.White,
-
-    cursor: 'pointer',
   },
   variants: {
     isRecommend: {
@@ -36,8 +34,6 @@ export const largeContainerStyle = style({
   borderRadius: vars.radius[500],
 
   backgroundColor: vars.color.Ref.Netural.White,
-
-  cursor: 'pointer',
 });
 
 export const rankContainerStyle = recipe({

--- a/frontend/src/features/discussion/ui/DiscussionCard/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCard/index.tsx
@@ -1,6 +1,3 @@
-import { useParams } from '@tanstack/react-router';
-
-import { useDiscussionConfirmMutation } from '../../api/mutations';
 import type { DiscussionDTO } from '../../model';
 import { DiscussionLarge } from './DiscussionLarge';
 import { DiscussionSmall } from './DiscussionSmall';
@@ -11,33 +8,15 @@ interface DiscussionCardProps {
   rank?: number;
 }
 
-const DiscussionCard = ({ size, discussion, rank }: DiscussionCardProps) => {
-  const param: { id: string } = useParams({ from: '/_main/discussion/$id' });
-  const { mutate } = useDiscussionConfirmMutation();
-
-  const handleClickConfirm = () => {
-    if (!param.id) return;
-    mutate({
-      id: param.id, 
-      body: {
-        startDateTime: discussion.startDateTime,
-        endDateTime: discussion.endDateTime,
-      }, 
-    });
-  };
-
-  return (
-    size === 'lg' ? 
-      <DiscussionLarge
-        discussion={discussion}
-        onClick={handleClickConfirm}
-        rank={rank as number}
-      /> : 
-      <DiscussionSmall 
-        discussion={discussion}
-        onClick={handleClickConfirm}
-      />
-  );
-};
+const DiscussionCard = ({ size, discussion, rank }: DiscussionCardProps) => (
+  size === 'lg' ? 
+    <DiscussionLarge
+      discussion={discussion}
+      rank={rank as number}
+    /> : 
+    <DiscussionSmall 
+      discussion={discussion}
+    />
+);
 
 export default DiscussionCard;

--- a/frontend/src/features/discussion/ui/DiscussionCard/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCard/index.tsx
@@ -1,3 +1,6 @@
+import { useSearch } from '@tanstack/react-router';
+
+import { useDiscussionConfirmMutation } from '../../api/mutations';
 import type { DiscussionDTO } from '../../model';
 import { DiscussionLarge } from './DiscussionLarge';
 import { DiscussionSmall } from './DiscussionSmall';
@@ -8,9 +11,33 @@ interface DiscussionCardProps {
   rank?: number;
 }
 
-const DiscussionCard = ({ size, discussion, rank }: DiscussionCardProps) => (
-  size === 'lg' ? <DiscussionLarge discussion={discussion} rank={rank as number} /> 
-    : <DiscussionSmall discussion={discussion} />
-);
+const DiscussionCard = ({ size, discussion, rank }: DiscussionCardProps) => {
+  const param: { id: string } = useSearch({ from: '/_main/discussion/$id' });
+  const { mutate } = useDiscussionConfirmMutation();
+
+  const handleClickConfirm = () => {
+    if (!param.id) return;
+    mutate({
+      id: param.id, 
+      body: {
+        startDateTime: discussion.startDateTime,
+        endDateTime: discussion.endDateTime,
+      }, 
+    });
+  };
+
+  return (
+    size === 'lg' ? 
+      <DiscussionLarge
+        discussion={discussion}
+        onClick={handleClickConfirm}
+        rank={rank as number}
+      /> : 
+      <DiscussionSmall 
+        discussion={discussion}
+        onClick={handleClickConfirm}
+      />
+  );
+};
 
 export default DiscussionCard;

--- a/frontend/src/features/discussion/ui/DiscussionCard/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCard/index.tsx
@@ -1,4 +1,4 @@
-import { useSearch } from '@tanstack/react-router';
+import { useParams } from '@tanstack/react-router';
 
 import { useDiscussionConfirmMutation } from '../../api/mutations';
 import type { DiscussionDTO } from '../../model';
@@ -12,7 +12,7 @@ interface DiscussionCardProps {
 }
 
 const DiscussionCard = ({ size, discussion, rank }: DiscussionCardProps) => {
-  const param: { id: string } = useSearch({ from: '/_main/discussion/$id' });
+  const param: { id: string } = useParams({ from: '/_main/discussion/$id' });
   const { mutate } = useDiscussionConfirmMutation();
 
   const handleClickConfirm = () => {

--- a/frontend/src/features/discussion/ui/DiscussionConfirmButton/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionConfirmButton/index.tsx
@@ -1,0 +1,27 @@
+import { useParams } from '@tanstack/react-router';
+
+import Button from '@/components/Button';
+
+import { useDiscussionConfirmMutation } from '../../api/mutations';
+import type { DiscussionDTO } from '../../model';
+
+const DiscussionConfirmButton = (
+  { startDateTime, endDateTime }: Omit<DiscussionDTO, 'usersForAdjust'>,
+) => {
+  const param: { id: string } = useParams({ from: '/_main/discussion/$id' });
+  const { mutate } = useDiscussionConfirmMutation();
+  
+  const handleClickConfirm = () => {
+    if (!param.id) return;
+    mutate({
+      id: param.id, 
+      body: { startDateTime, endDateTime }, 
+    });
+  };
+
+  return (
+    <Button onClick={handleClickConfirm}>일정 확정하기</Button>
+  );
+};
+
+export default DiscussionConfirmButton;

--- a/frontend/src/features/discussion/ui/DiscussionConfirmButton/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionConfirmButton/index.tsx
@@ -3,13 +3,17 @@ import { useParams } from '@tanstack/react-router';
 import Button from '@/components/Button';
 
 import { useDiscussionConfirmMutation } from '../../api/mutations';
+import { useDiscussionHostQuery } from '../../api/queries';
 import type { DiscussionDTO } from '../../model';
 
 const DiscussionConfirmButton = (
   { startDateTime, endDateTime }: Omit<DiscussionDTO, 'usersForAdjust'>,
 ) => {
   const param: { id: string } = useParams({ from: '/_main/discussion/$id' });
+  const { isHost, isPending } = useDiscussionHostQuery(param.id);
   const { mutate } = useDiscussionConfirmMutation();
+
+  if (isPending || !isHost) return null;
   
   const handleClickConfirm = () => {
     if (!param.id) return;

--- a/frontend/src/features/discussion/ui/DiscussionConfirmCard/BadgeContainer.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionConfirmCard/BadgeContainer.tsx
@@ -1,32 +1,36 @@
 import { Badge } from '@/components/Badge';
 import { Flex } from '@/components/Flex';
-import { getHourDiff, getTimeRangeString } from '@/utils/date';
+import { getDateRangeString, getHourDiff, getMinuteDiff, getTimeRangeString } from '@/utils/date';
+import { formatDateToString } from '@/utils/date/format';
 
-import type { DiscussionConfirmCardProps } from '.';
 import { badgeContainerStyle } from './index.css';
 
-interface BadgeContainerProps {
-  meetingDateTimeRange: DiscussionConfirmCardProps['meetingDateTimeRange'];
-  location?: DiscussionConfirmCardProps['location'];
-}
-
-const BadgeContainer = ({ 
-  meetingDateTimeRange, 
-  location,
-}: BadgeContainerProps) => {
-  const [timeStart, timeEnd] = [meetingDateTimeRange.start, meetingDateTimeRange.end];
-  const timeRangeString = getTimeRangeString(timeStart, timeEnd);
-  return (
+const BadgeContainer = (
+  { startDateTime, endDateTime, location }: 
+  {
+    startDateTime: Date; 
+    endDateTime: Date; 
+    location: string;
+  }) => 
+  (
     <Flex
       align='center'
       className={badgeContainerStyle}
       gap={250}
       justify='flex-start'
     >
-      <Badge iconType='date'>{`${timeRangeString} (${getHourDiff(timeStart, timeEnd)}시간)`}</Badge>
+      <Badge iconType='date'>
+        {formatDateToString(startDateTime)}
+      </Badge>
+      <Badge iconType='date'>
+        {getTimeRangeString(startDateTime, endDateTime)}
+      </Badge>
+      <Badge iconType='time'>
+        {getMinuteDiff(startDateTime, endDateTime)}
+        분
+      </Badge>
       {location && <Badge iconType='location'>{location}</Badge>}
     </Flex>
   );
-};
 
 export default BadgeContainer;

--- a/frontend/src/features/discussion/ui/DiscussionConfirmCard/BadgeContainer.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionConfirmCard/BadgeContainer.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@/components/Badge';
 import { Flex } from '@/components/Flex';
-import { getDateRangeString, getHourDiff, getMinuteDiff, getTimeRangeString } from '@/utils/date';
+import { getMinuteDiff, getTimeRangeString } from '@/utils/date';
 import { formatDateToString } from '@/utils/date/format';
 
 import { badgeContainerStyle } from './index.css';

--- a/frontend/src/features/discussion/ui/DiscussionConfirmCard/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionConfirmCard/index.tsx
@@ -1,9 +1,12 @@
 
+import { Link } from '@tanstack/react-router';
+
 import Avatar from '@/components/Avatar';
 import Button from '@/components/Button';
 import { Flex } from '@/components/Flex';
 import { Modal } from '@/components/Modal';
 
+import type { DiscussionConfirmResponse } from '../../model';
 import BadgeContainer from './BadgeContainer';
 import {
   avatarWrapperStyle,
@@ -12,33 +15,28 @@ import {
   modalFooterStyle,
 } from './index.css';
 
-export interface DiscussionConfirmCardProps {
-  participantImageUrls: string[];
-  // Badge props
-  meetingDateTimeRange: { start: Date; end: Date };
-  meetingDuration: number;
-  location?: string;
-}
-
-const DiscussionConfirmCard = ({
-  participantImageUrls,
-  ...badgeProps
-}: DiscussionConfirmCardProps) => (
+const DiscussionConfirmCard = (
+  { title, participantPictureUrls, ...badgeProps }: DiscussionConfirmResponse,
+) => (
   <>
     <Modal
       className={modalContainerStyle}
       isOpen
       subTitle={'확정된 일정'}
-      title='기업디(3) 첫 팀플'
+      title={title}
     >
       <Modal.Contents className={modalContentsStyle}>
-        <BadgeContainer {...badgeProps} />
+        <BadgeContainer
+          endDateTime={new Date(badgeProps.sharedEventDto.endDateTime)}
+          location={badgeProps.meetingMethodOrLocation}
+          startDateTime={new Date(badgeProps.sharedEventDto.startDateTime)}
+        />
         <Flex
           align='center'
           className={avatarWrapperStyle}
           justify='flex-start'
         >
-          <Avatar imageUrls={participantImageUrls} size='lg' />
+          <Avatar imageUrls={participantPictureUrls} size='lg' />
         </Flex>
       </Modal.Contents>
       <Modal.Footer className={modalFooterStyle}>
@@ -50,15 +48,16 @@ const DiscussionConfirmCard = ({
 
 const Buttons = () => (
   <>
-    <Button
+    {/* <Button
       size='xl'
       style='borderless'
     >
       다시 일정 조율하기
-    </Button>
+    </Button> */}
     <Button
-      onClick={() => alert('navigate to my calendar')}
+      as={Link}
       size='xl'
+      to='/my-calendar'
     >
       내 캘린더 확인하기
     </Button>

--- a/frontend/src/pages/DiscussionPage/DiscussionConfirmPage/index.tsx
+++ b/frontend/src/pages/DiscussionPage/DiscussionConfirmPage/index.tsx
@@ -1,24 +1,13 @@
 
 import { Flex } from '@/components/Flex';
 import { Text } from '@/components/Text';
+import type { DiscussionConfirmResponse } from '@/features/discussion/model';
 import DiscussionConfirmCard from '@/features/discussion/ui/DiscussionConfirmCard';
 import { vars } from '@/theme/index.css';
 
 import { backdropStyle, containerStyle, subtitleStyle, titleStyle } from './index.css';
 
-const mockData = {
-  participantImageUrls: [
-    'https://via.placeholder.com/150',
-    'https://via.placeholder.com/150',
-  ],
-  dateTimeRange: {
-    start: new Date('2023-10-20T10:00:00'),
-    end: new Date('2023-10-20T11:00:00'),
-  },
-  meetingDuration: 60,
-};
-
-const DiscussionConfirmPage = () => (
+const DiscussionConfirmPage = ({ confirm }: { confirm: DiscussionConfirmResponse }) => (
   <>
     <div className={backdropStyle} />
     <Flex
@@ -38,11 +27,7 @@ const DiscussionConfirmPage = () => (
       >
         참여한 모든 인원의 개인 캘린더에 확정된 일정이 추가되었어요.
       </Text>
-      <DiscussionConfirmCard
-        meetingDateTimeRange={mockData.dateTimeRange}
-        meetingDuration={mockData.meetingDuration}
-        participantImageUrls={mockData.participantImageUrls}
-      />
+      <DiscussionConfirmCard {...confirm} />
     </Flex>
   </>
 );

--- a/frontend/src/routes/_main/discussion/confirm/$id.tsx
+++ b/frontend/src/routes/_main/discussion/confirm/$id.tsx
@@ -1,17 +1,25 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+import { discussionConfirmQuery } from '@/features/discussion/api/queries';
 import GlobalNavBar from '@/layout/GlobalNavBar';
 import DiscussionConfirmPage from '@/pages/DiscussionPage/DiscussionConfirmPage';
 
-const DiscussionConfirm = () => (
-  <>
-    <GlobalNavBar>
-      <GlobalNavBar.MyCalendarLink />
-    </GlobalNavBar>
-    <DiscussionConfirmPage />
-  </>
-);
+const DiscussionConfirm = () => {
+  const { confirm } = Route.useLoaderData();
+  return (
+    <>
+      <GlobalNavBar>
+        <GlobalNavBar.MyCalendarLink />
+      </GlobalNavBar>
+      <DiscussionConfirmPage confirm={confirm} />
+    </>
+  );
+};
 
 export const Route = createFileRoute('/_main/discussion/confirm/$id')({
+  loader: async ({ params: { id }, context }) => {
+    const confirm = await context.queryClient.fetchQuery(discussionConfirmQuery(id));
+    return { confirm };
+  },
   component: DiscussionConfirm,
 });

--- a/frontend/src/routes/_main/discussion/confirm/$id.tsx
+++ b/frontend/src/routes/_main/discussion/confirm/$id.tsx
@@ -3,14 +3,15 @@ import { createFileRoute } from '@tanstack/react-router';
 import GlobalNavBar from '@/layout/GlobalNavBar';
 import DiscussionConfirmPage from '@/pages/DiscussionPage/DiscussionConfirmPage';
 
-const DiscussionConfirm = () => 
+const DiscussionConfirm = () => (
   <>
     <GlobalNavBar>
       <GlobalNavBar.MyCalendarLink />
     </GlobalNavBar>
     <DiscussionConfirmPage />
-  </>;
+  </>
+);
 
-export const Route = createFileRoute('/discussion/confirm/')({
+export const Route = createFileRoute('/_main/discussion/confirm/$id')({
   component: DiscussionConfirm,
 });


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- close #127

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
총 세가지 API를 연결했습니다.
- 호스트 여부를 체크하여 호스트일때만 일정 확정하기 버튼이 렌더링됩니다. (내가 호스트인가요? API)
- 일정 확정하기 버튼을 클릭하면 일정이 확정되고, 확정 페이지로 네비게이션됩니다. (논의 확정 API)
- 네비게이션 시 일정에 대한 정보를 조회하여 보여줍니다. (공유 일정 조회 API)
<img width="1450" alt="image" src="https://github.com/user-attachments/assets/d1c721d4-abeb-482b-80fb-b5d43ccbdd36" />
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/9226193e-354c-48f6-872b-a9a23efff99f" />



## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
임시로 버튼을 카드에 붙여두었습니다. 추후에 디테일 페이지에 붙일 때는 라우팅 수정해주셔야 합니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced new methods for retrieving discussion details and host status.
  - Added functionality for confirming discussions with a dedicated button and confirmation page.
  - Implemented new hooks for managing discussion confirmation and host queries.

- **Refactor**
  - Enhanced the structure of components for better readability and maintainability.
  - Updated data handling in the confirmation page to utilize dynamic data instead of mock data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->