### PR TITLE
[BE-Feat] 논의 참여시 이미 참여자일 경우 400 리턴

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -279,4 +279,12 @@ public class DiscussionParticipantService {
                 userService.getCurrentUser().getId())
             .orElseThrow(() -> new ApiException(ErrorCode.NOT_ALLOWED_USER));
     }
+
+    @Transactional(readOnly = true)
+    public void checkAlreadyParticipated(Long discussionId, Long userId) {
+        discussionParticipantRepository.findOffsetByDiscussionIdAndUserId(discussionId, userId)
+            .ifPresent(offset -> {
+                throw new ApiException(ErrorCode.ALREADY_PARTICIPATED);
+            });
+    }
 }

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -299,7 +299,9 @@ public class DiscussionService {
 
         User currentUser = userService.getCurrentUser();
 
-        if (hasDiscussionPassword(discussionId) && !checkPassword(discussion, request.password())) {
+        discussionParticipantService.checkAlreadyParticipated(discussionId, currentUser.getId());
+
+        if (discussion.getPassword() != null && !checkPassword(discussion, request.password())) {
             int failedCount = passwordCountService.increaseCount(currentUser.getId(), discussionId);
             return new JoinDiscussionResponse(false, failedCount);
         }
@@ -340,13 +342,5 @@ public class DiscussionService {
         }
 
         return passwordEncoder.matches(discussion.getId(), password, discussion.getPassword());
-    }
-
-    @Transactional(readOnly = true)
-    protected boolean hasDiscussionPassword(Long discussionId) {
-        Discussion discussion = discussionRepository.findById(discussionId)
-            .orElseThrow(() -> new ApiException(ErrorCode.DISCUSSION_NOT_FOUND));
-
-        return discussion.getPassword() != null;
     }
 }

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     INVALID_DISCUSSION_PARTICIPANT(HttpStatus.BAD_REQUEST, "DP003", "Invalid Discussion participant"),
     DISCUSSION_HOST_NOT_FOUND(HttpStatus.NOT_FOUND, "DP004", "Discussion host not found"),
     NOT_ALLOWED_USER(HttpStatus.FORBIDDEN, "DP005", "Not allowed user"),
+    ALREADY_PARTICIPATED(HttpStatus.BAD_REQUEST, "DP006", "Already participated"),
 
     //Calendar
     CALENDAR_UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "CA001", "Unauthorized"),

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -659,6 +659,7 @@ public class DiscussionServiceTest {
         discussion.setPassword("encodedPassword123");
 
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
+        when(userService.getCurrentUser()).thenReturn(new User());
 
         // When & Then
         assertThatThrownBy(() -> discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(null)))


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #215 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
논의 참여 시 이미 참여하고 있는지 검증하는 코드를 추가했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a safeguard to prevent joining a discussion more than once, providing clear feedback if a duplicate participation is attempted.
- **Refactor**
  - Simplified the discussion joining process by streamlining password validation procedures.
- **Tests**
  - Enhanced test coverage to ensure consistent behavior, especially when password information is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->