### PR TITLE
[FE-Feat] 일정이 다음날로 넘어가는 경우 & 하루 종일인 경우 대응, 현재 시간에 맞춰서 스크롤

### DIFF
--- a/frontend/src/features/my-calendar/api/queries.ts
+++ b/frontend/src/features/my-calendar/api/queries.ts
@@ -5,10 +5,10 @@ import { personalEventApi } from '.';
 import { personalEventKeys } from './keys';
 
 export const usePersonalEventsQuery = (params: DateRangeParams) => {
-  const { data: personalEvents, isLoading } = useQuery<PersonalEventResponse[]>({
+  const { data: personalEvents, isPending } = useQuery<PersonalEventResponse[]>({
     queryKey: personalEventKeys.detail(params), 
     queryFn: () => personalEventApi.getPersonalEvent(params),
   });
 
-  return { personalEvents, isLoading };
+  return { personalEvents, isPending };
 };

--- a/frontend/src/features/my-calendar/ui/CalendarCard/index.css.ts
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/index.css.ts
@@ -50,7 +50,7 @@ export const cardBackgroundStyle = recipe({
 export const cardContentStyle = recipe({
   base: {
     width: '100%',
-    maxWidth: '100%',
+    maxWidth: 'calc(100% - 50px)',
     maxHeight: '100%',
     padding: `${vars.spacing[200]} ${vars.spacing[400]} ${vars.spacing[100]}`,
     borderLeft: '3px solid transparent',

--- a/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
@@ -1,5 +1,5 @@
 import { TIME_HEIGHT } from '@/constants/date';
-import { isAllday } from '@/utils/date';
+import { getDateParts, isAllday } from '@/utils/date';
 import { calcPositionByDate } from '@/utils/date/position';
 
 import type { PersonalEventResponse } from '../../model';
@@ -43,13 +43,15 @@ export const CalendarCardList = ({ cards }: { cards: PersonalEventResponse[] }) 
       .map((card) => {
         const start = new Date(card.startDateTime);
         const end = new Date(card.endDateTime);
+        const { year: sy, month: sm, day: sd } = getDateParts(start);
+        const { year: ey, month: em, day: ed } = getDateParts(end);
 
-        if (start.getDate() !== end.getDate()) {
+        if (sd !== ed) {
           return (
             <>
               <DefaultCard
                 card={card}
-                end={new Date(start.getFullYear(), start.getMonth(), start.getDate(), 23, 59)}
+                end={new Date(sy, sm, sd, 23, 59)}
                 key={`${card.id}-start`}
                 start={start}
               />
@@ -57,7 +59,7 @@ export const CalendarCardList = ({ cards }: { cards: PersonalEventResponse[] }) 
                 card={card}
                 end={end}
                 key={`${card.id}-end`}
-                start={new Date(end.getFullYear(), end.getMonth(), end.getDate(), 0, 0)}
+                start={new Date(ey, em, ed, 0, 0)}
               />
             </>
           );

--- a/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
@@ -22,7 +22,6 @@ const DefaultCard = (
       calendarId={card.calendarId}
       endTime={new Date(card.endDateTime)}
       id={card.id}
-      key={card.id}
       size={calcSize(height)}
       startTime={new Date(card.startDateTime)}
       status={card.isAdjustable ? 'adjustable' : 'fixed'}
@@ -51,11 +50,13 @@ export const CalendarCardList = ({ cards }: { cards: PersonalEventResponse[] }) 
               <DefaultCard
                 card={card}
                 end={new Date(start.getFullYear(), start.getMonth(), start.getDate(), 23, 59)}
+                key={`${card.id}-start`}
                 start={start}
               />
               <DefaultCard
                 card={card}
                 end={end}
+                key={`${card.id}-end`}
                 start={new Date(end.getFullYear(), end.getMonth(), end.getDate(), 0, 0)}
               />
             </>
@@ -66,6 +67,7 @@ export const CalendarCardList = ({ cards }: { cards: PersonalEventResponse[] }) 
           <DefaultCard
             card={card}
             end={end}
+            key={card.id}
             start={start}
           />
         );

--- a/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
@@ -11,33 +11,62 @@ const calcSize = (height: number) => {
   return 'lg';
 };
 
+const DefaultCard = (
+  { card, start, end }: { card: PersonalEventResponse; start: Date; end: Date },
+) => {
+  const { x: sx, y: sy } = calcPositionByDate(start);
+  const { y: ey } = calcPositionByDate(end);
+  const height = ey - sy;
+  return (
+    <CalendarCard
+      calendarId={card.calendarId}
+      endTime={new Date(card.endDateTime)}
+      id={card.id}
+      key={card.id}
+      size={calcSize(height)}
+      startTime={new Date(card.startDateTime)}
+      status={card.isAdjustable ? 'adjustable' : 'fixed'}
+      style={{
+        width: 'calc((100% - 72px) / 7)',
+        height,
+        position: 'absolute',
+        left: `calc(((100% - 72px) / 7 * ${sx}) + 72px)`,
+        top: 16 + sy,
+      }}
+      title={card.title}
+    />
+  );
+};
+
 export const CalendarCardList = ({ cards }: { cards: PersonalEventResponse[] }) => (
   <>
     {cards.filter((card) => !isAllday(card.startDateTime, card.endDateTime))
       .map((card) => {
         const start = new Date(card.startDateTime);
         const end = new Date(card.endDateTime);
-        const { x: sx, y: sy } = calcPositionByDate(start);
-        const { y: ey } = calcPositionByDate(end);
-        const height = ey - sy;
+
+        if (start.getDate() !== end.getDate()) {
+          return (
+            <>
+              <DefaultCard
+                card={card}
+                end={new Date(start.getFullYear(), start.getMonth(), start.getDate(), 23, 59)}
+                start={start}
+              />
+              <DefaultCard
+                card={card}
+                end={end}
+                start={new Date(end.getFullYear(), end.getMonth(), end.getDate(), 0, 0)}
+              />
+            </>
+          );
+        }
 
         return (
-          <CalendarCard
-            calendarId={card.calendarId}
-            endTime={end}
-            id={card.id}
-            key={card.id}
-            size={calcSize(height)}
-            startTime={start}
-            status={card.isAdjustable ? 'adjustable' : 'fixed'}
-            style={{
-              width: 'calc((100% - 72px) / 7)',
-              height,
-              position: 'absolute',
-              left: `calc(((100% - 72px) / 7 * ${sx}) + 72px)`,
-              top: 16 + sy,
-            }}
-            title={card.title}
+          <DefaultCard
+            card={card}
+            end={end}
+            start={start}
           />
         );
       })}

--- a/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
@@ -1,4 +1,5 @@
 import { TIME_HEIGHT } from '@/constants/date';
+import { isAllday } from '@/utils/date';
 import { calcPositionByDate } from '@/utils/date/position';
 
 import type { PersonalEventResponse } from '../../model';
@@ -12,32 +13,33 @@ const calcSize = (height: number) => {
 
 export const CalendarCardList = ({ cards }: { cards: PersonalEventResponse[] }) => (
   <>
-    {cards.map((card) => {
-      const start = new Date(card.startDateTime);
-      const end = new Date(card.endDateTime);
-      const { x: sx, y: sy } = calcPositionByDate(start);
-      const { y: ey } = calcPositionByDate(end);
-      const height = ey - sy;
+    {cards.filter((card) => !isAllday(card.startDateTime, card.endDateTime))
+      .map((card) => {
+        const start = new Date(card.startDateTime);
+        const end = new Date(card.endDateTime);
+        const { x: sx, y: sy } = calcPositionByDate(start);
+        const { y: ey } = calcPositionByDate(end);
+        const height = ey - sy;
 
-      return (
-        <CalendarCard
-          calendarId={card.calendarId}
-          endTime={end}
-          id={card.id}
-          key={card.id}
-          size={calcSize(height)}
-          startTime={start}
-          status={card.isAdjustable ? 'adjustable' : 'fixed'}
-          style={{
-            width: 'calc((100% - 72px) / 7)',
-            height,
-            position: 'absolute',
-            left: `calc(((100% - 72px) / 7 * ${sx}) + 72px)`,
-            top: 16 + sy,
-          }}
-          title={card.title}
-        />
-      );
-    })}
+        return (
+          <CalendarCard
+            calendarId={card.calendarId}
+            endTime={end}
+            id={card.id}
+            key={card.id}
+            size={calcSize(height)}
+            startTime={start}
+            status={card.isAdjustable ? 'adjustable' : 'fixed'}
+            style={{
+              width: 'calc((100% - 72px) / 7)',
+              height,
+              position: 'absolute',
+              left: `calc(((100% - 72px) / 7 * ${sx}) + 72px)`,
+              top: 16 + sy,
+            }}
+            title={card.title}
+          />
+        );
+      })}
   </>
 );

--- a/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTable.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTable.tsx
@@ -7,20 +7,23 @@ import { formatDateToDateTimeString } from '@/utils/date/format';
 import type { PersonalEventResponse } from '../../model';
 import { CalendarCardList } from '../CalendarCardList';
 import { SchedulePopover } from '../SchedulePopover';
+import { CalendarTimeBar } from './CalendarTimeBar';
 import { containerStyle } from './index.css';
+import { useScrollToCurrentTime } from './useScrollToCurrentTime';
 
 const CalendarTable = (
   { personalEvents = [] }: { personalEvents?: PersonalEventResponse[] },
 ) => {
   const { handleMouseUp, reset, ...time } = useSelectTime();
   const [open, setOpen] = useState(false);
+  const { tableRef, height } = useScrollToCurrentTime();
   
   const handleMouseUpAddSchedule = () => {
     setOpen(true);
   };
   
   return (
-    <div className={containerStyle({ open })}>
+    <div className={containerStyle({ open })} ref={tableRef}>
       {open && 
         <SchedulePopover
           endDateTime={formatDateToDateTimeString(time.doneEndTime)}
@@ -30,6 +33,7 @@ const CalendarTable = (
           type='add'
         />}
       <CalendarCardList cards={personalEvents} />
+      <CalendarTimeBar height={height} />
       <Calendar.Table 
         context={{
           handleMouseUp: () => handleMouseUp(handleMouseUpAddSchedule),

--- a/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTable.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTable.tsx
@@ -7,6 +7,7 @@ import { formatDateToDateTimeString } from '@/utils/date/format';
 import type { PersonalEventResponse } from '../../model';
 import { CalendarCardList } from '../CalendarCardList';
 import { SchedulePopover } from '../SchedulePopover';
+import { CalendarTimeBar } from './CalendarTimeBar';
 import { containerStyle } from './index.css';
 import { useScrollToCurrentTime } from './useScrollToCurrentTime';
 
@@ -15,7 +16,7 @@ const CalendarTable = (
 ) => {
   const { handleMouseUp, reset, ...time } = useSelectTime();
   const [open, setOpen] = useState(false);
-  const { tableRef } = useScrollToCurrentTime();
+  const { tableRef, height } = useScrollToCurrentTime();
   
   const handleMouseUpAddSchedule = () => {
     setOpen(true);
@@ -32,6 +33,7 @@ const CalendarTable = (
           type='add'
         />}
       <CalendarCardList cards={personalEvents} />
+      <CalendarTimeBar height={height} />
       <Calendar.Table 
         context={{
           handleMouseUp: () => handleMouseUp(handleMouseUpAddSchedule),

--- a/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTable.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTable.tsx
@@ -7,7 +7,6 @@ import { formatDateToDateTimeString } from '@/utils/date/format';
 import type { PersonalEventResponse } from '../../model';
 import { CalendarCardList } from '../CalendarCardList';
 import { SchedulePopover } from '../SchedulePopover';
-import { CalendarTimeBar } from './CalendarTimeBar';
 import { containerStyle } from './index.css';
 import { useScrollToCurrentTime } from './useScrollToCurrentTime';
 
@@ -16,7 +15,7 @@ const CalendarTable = (
 ) => {
   const { handleMouseUp, reset, ...time } = useSelectTime();
   const [open, setOpen] = useState(false);
-  const { tableRef, height } = useScrollToCurrentTime();
+  const { tableRef } = useScrollToCurrentTime();
   
   const handleMouseUpAddSchedule = () => {
     setOpen(true);
@@ -33,7 +32,6 @@ const CalendarTable = (
           type='add'
         />}
       <CalendarCardList cards={personalEvents} />
-      <CalendarTimeBar height={height} />
       <Calendar.Table 
         context={{
           handleMouseUp: () => handleMouseUp(handleMouseUpAddSchedule),

--- a/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTable.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTable.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+import { Calendar } from '@/components/Calendar';
+import { useSelectTime } from '@/hooks/useSelectTime';
+import { formatDateToDateTimeString } from '@/utils/date/format';
+
+import type { PersonalEventResponse } from '../../model';
+import { CalendarCardList } from '../CalendarCardList';
+import { SchedulePopover } from '../SchedulePopover';
+import { containerStyle } from './index.css';
+
+const CalendarTable = (
+  { personalEvents = [] }: { personalEvents?: PersonalEventResponse[] },
+) => {
+  const { handleMouseUp, reset, ...time } = useSelectTime();
+  const [open, setOpen] = useState(false);
+  
+  const handleMouseUpAddSchedule = () => {
+    setOpen(true);
+  };
+  
+  return (
+    <div className={containerStyle({ open })}>
+      {open && 
+        <SchedulePopover
+          endDateTime={formatDateToDateTimeString(time.doneEndTime)}
+          reset={reset}
+          setIsOpen={setOpen}
+          startDateTime={formatDateToDateTimeString(time.doneStartTime)}
+          type='add'
+        />}
+      <CalendarCardList cards={personalEvents} />
+      <Calendar.Table 
+        context={{
+          handleMouseUp: () => handleMouseUp(handleMouseUpAddSchedule),
+          reset: () => {
+            setOpen(false);
+            reset();
+          },
+          ...time,
+        }}
+      />
+    </div>
+  );
+};
+
+export default CalendarTable;
+  

--- a/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTimeBar.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTimeBar.tsx
@@ -11,7 +11,8 @@ export const CalendarTimeBar = ({ height }: { height: number }) => (
     style={{ top: height }}
     width='100%'
   >
-    <Text color={vars.color.Ref.Primary[500]} typo='caption'>
+    <div className={timeBarStyle} />
+    <Text color={vars.color.Ref.Primary[500]} typo='t3'>
       {formatDateToTimeString(new Date())}
     </Text>
     <div className={timeBarStyle} />

--- a/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTimeBar.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTimeBar.tsx
@@ -1,0 +1,19 @@
+import { Flex } from '@/components/Flex';
+import { Text } from '@/components/Text';
+import { vars } from '@/theme/index.css';
+import { formatDateToTimeString } from '@/utils/date';
+
+import { timeBarStyle, timeBarWrapperStyle } from './index.css';
+
+export const CalendarTimeBar = ({ height }: { height: number }) => (
+  <Flex
+    className={timeBarWrapperStyle}
+    style={{ top: height }}
+    width='100%'
+  >
+    <Text color={vars.color.Ref.Primary[500]} typo='caption'>
+      {formatDateToTimeString(new Date())}
+    </Text>
+    <div className={timeBarStyle} />
+  </Flex>
+);

--- a/frontend/src/features/my-calendar/ui/MyCalendar/index.css.ts
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/index.css.ts
@@ -1,6 +1,7 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
+import { fadeTimeBarProps } from '@/theme/animation.css';
 import { vars } from '@/theme/index.css';
 
 export const containerStyle = recipe({
@@ -29,6 +30,8 @@ export const timeBarWrapperStyle = style({
   position: 'absolute',
   alignItems: 'center',
   gap: vars.spacing[100],
+
+  ...fadeTimeBarProps,
 });
 
 export const timeBarStyle = style({

--- a/frontend/src/features/my-calendar/ui/MyCalendar/index.css.ts
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/index.css.ts
@@ -23,3 +23,16 @@ export const calendarStyle = style({
   height: 'calc(100vh - 150px)',
   paddingRight: vars.spacing[500],
 });
+
+export const timeBarWrapperStyle = style({
+  paddingLeft: vars.spacing[500],
+  position: 'absolute',
+  alignItems: 'center',
+  gap: vars.spacing[100],
+});
+
+export const timeBarStyle = style({
+  width: '100%',
+  height: 1,
+  backgroundColor: vars.color.Ref.Primary[500],
+});

--- a/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
@@ -1,50 +1,41 @@
-import { useState } from 'react';
-
 import { Calendar } from '@/components/Calendar';
 import { useSharedCalendarContext } from '@/components/Calendar/context/SharedCalendarContext';
-import { useSelectTime } from '@/hooks/useSelectTime';
-import { formatDateToWeekRange } from '@/utils/date';
-import { formatDateToBarString, formatDateToDateTimeString } from '@/utils/date/format';
+import { formatDateToWeekRange, isAllday } from '@/utils/date';
+import { formatDateToBarString } from '@/utils/date/format';
+import { calcPositionByDate } from '@/utils/date/position';
 
 import { usePersonalEventsQuery } from '../../api/queries';
 import type { PersonalEventResponse } from '../../model';
-import { CalendarCardList } from '../CalendarCardList';
-import { SchedulePopover } from '../SchedulePopover';
-import { calendarStyle, containerStyle } from './index.css';
+import { CalendarCard } from '../CalendarCard';
+import CalendarTable from './CalendarTable';
+import { calendarStyle } from './index.css';
 
-const CalendarTable = (
-  { personalEvents = [] }: { personalEvents?: PersonalEventResponse[] },
-) => {
-  const { handleMouseUp, reset, ...time } = useSelectTime();
-  const [open, setOpen] = useState(false);
-
-  const handleMouseUpAddSchedule = () => {
-    setOpen(true);
-  };
+const AlldayCard = (card: PersonalEventResponse) => {
+  const start = new Date(card.startDateTime);
+  const end = new Date(card.endDateTime);
+  const dayDiff = end.getDate() - start.getDate() + 1;
+  const { x: sx } = calcPositionByDate(start);
 
   return (
-    <div className={containerStyle({ open })}>
-      {open && 
-      <SchedulePopover
-        endDateTime={formatDateToDateTimeString(time.doneEndTime)}
-        reset={reset}
-        setIsOpen={setOpen}
-        startDateTime={formatDateToDateTimeString(time.doneStartTime)}
-        type='add'
-      />}
-      <CalendarCardList cards={personalEvents} />
-      <Calendar.Table 
-        context={{
-          handleMouseUp: () => handleMouseUp(handleMouseUpAddSchedule),
-          reset: () => {
-            setOpen(false);
-            reset();
-          },
-          ...time,
-        }}
-      />
-    </div>
-  );
+    <CalendarCard
+      calendarId={card.calendarId}
+      endTime={end}
+      id={card.id}
+      key={card.id}
+      size='md'
+      startTime={start}
+      status={card.isAdjustable ? 'adjustable' : 'fixed'}
+      style={{
+        width: `calc((100% - 72px - 1.25rem) / 7 * ${dayDiff})`,
+        height: 57,
+        position: 'absolute',
+        left: `calc(((100% - 72px - 1.25rem) / 7 * ${sx}) + 72px)`,
+        top: 136,
+        zIndex: 2,
+      }}
+      title={card.title}
+    />
+  ); 
 };
 
 export const MyCalendar = () => {
@@ -59,6 +50,11 @@ export const MyCalendar = () => {
   return (
     <Calendar {...calendar} className={calendarStyle}>
       <Calendar.Core />
+      {
+        !isLoading && 
+        personalEvents?.filter((event) => isAllday(event.startDateTime, event.endDateTime))
+          .map((event) => <AlldayCard key={event.id} {...event} />)
+      }
       <Calendar.Header />
       {<CalendarTable personalEvents={isLoading ? [] : personalEvents} />}
     </Calendar>

--- a/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/index.tsx
@@ -42,7 +42,7 @@ export const MyCalendar = () => {
   const calendar = useSharedCalendarContext();
   const { startDate, endDate } = formatDateToWeekRange(calendar.selectedDate);
 
-  const { personalEvents, isLoading } = usePersonalEventsQuery({ 
+  const { personalEvents, isPending } = usePersonalEventsQuery({ 
     startDate: formatDateToBarString(startDate), 
     endDate: formatDateToBarString(endDate),
   });
@@ -51,12 +51,12 @@ export const MyCalendar = () => {
     <Calendar {...calendar} className={calendarStyle}>
       <Calendar.Core />
       {
-        !isLoading && 
+        !isPending && 
         personalEvents?.filter((event) => isAllday(event.startDateTime, event.endDateTime))
           .map((event) => <AlldayCard key={event.id} {...event} />)
       }
       <Calendar.Header />
-      {<CalendarTable personalEvents={isLoading ? [] : personalEvents} />}
+      {<CalendarTable personalEvents={isPending ? [] : personalEvents} />}
     </Calendar>
   );
 };

--- a/frontend/src/features/my-calendar/ui/MyCalendar/useScrollToCurrentTime.ts
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/useScrollToCurrentTime.ts
@@ -10,10 +10,10 @@ export const useScrollToCurrentTime = () => {
   useEffect(() => {
     if (tableRef.current) {
       const { hour, minute } = getTimeParts(new Date());
-      const offset = (hour + minute / 60) * TIME_HEIGHT + 8;
+      const offset = (hour + minute / 60) * TIME_HEIGHT + 16;
       heightRef.current = offset;
       tableRef.current.scrollTo({
-        top: heightRef.current / 2,
+        top: heightRef.current - 5 * TIME_HEIGHT,
         behavior: 'smooth',
       });
     }

--- a/frontend/src/features/my-calendar/ui/MyCalendar/useScrollToCurrentTime.ts
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/useScrollToCurrentTime.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react';
+
+import { TIME_HEIGHT } from '@/constants/date';
+import { getTimeParts } from '@/utils/date';
+
+export const useScrollToCurrentTime = () => {
+  const tableRef = useRef<HTMLDivElement | null>(null);
+  const heightRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (tableRef.current) {
+      const { hour, minute } = getTimeParts(new Date());
+      const offset = (hour + minute / 60) * TIME_HEIGHT + 8;
+      heightRef.current = offset;
+      tableRef.current.scrollTo({
+        top: heightRef.current / 2,
+        behavior: 'smooth',
+      });
+    }
+  }, []);
+
+  return { tableRef, height: heightRef.current };
+};

--- a/frontend/src/features/my-calendar/ui/MyCalendar/useScrollToCurrentTime.ts
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/useScrollToCurrentTime.ts
@@ -5,19 +5,17 @@ import { getTimeParts } from '@/utils/date';
 
 export const useScrollToCurrentTime = () => {
   const tableRef = useRef<HTMLDivElement | null>(null);
-  const heightRef = useRef<number>(0);
+  const { hour, minute } = getTimeParts(new Date());
+  const offset = 6.5 + (hour + minute / 60) * TIME_HEIGHT;
 
   useEffect(() => {
     if (tableRef.current) {
-      const { hour, minute } = getTimeParts(new Date());
-      const offset = (hour + minute / 60) * TIME_HEIGHT + 16;
-      heightRef.current = offset;
       tableRef.current.scrollTo({
-        top: heightRef.current - 5 * TIME_HEIGHT,
+        top: offset - 5 * TIME_HEIGHT,
         behavior: 'smooth',
       });
     }
-  }, []);
+  }, [offset]);
 
-  return { tableRef, height: heightRef.current };
+  return { tableRef, height: offset };
 };

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.css.ts
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.css.ts
@@ -65,6 +65,6 @@ export const backgroundStyle = style({
   right: 0,
   bottom: 0,
 
-  zIndex: 2,
+  zIndex: 3,
   backgroundColor: 'rgba(0, 0, 0, 0.2)',
 });

--- a/frontend/src/theme/animation.css.ts
+++ b/frontend/src/theme/animation.css.ts
@@ -46,8 +46,24 @@ export const fadeHighlight = keyframes({
   },
 });
 
+export const fadeTimeBar = keyframes({
+  '0%': { opacity: 0 },
+  '5%': { opacity: 1 },
+  '50%': { opacity: 1 },
+  '100%': {
+    opacity: 0,
+    display: 'none',
+  },
+});
+
 export const fadeHighlightProps: CSSProperties = {
   animationName: fadeHighlight,
+  animationDuration: '2s',
+  animationFillMode: 'forwards',
+};
+
+export const fadeTimeBarProps: CSSProperties = {
+  animationName: fadeTimeBar,
   animationDuration: '2s',
   animationFillMode: 'forwards',
 };

--- a/frontend/src/utils/date/date.ts
+++ b/frontend/src/utils/date/date.ts
@@ -203,11 +203,11 @@ export const getYearMonthDay = (date: Date) => {
   return { year, month, day };
 };
 
-export const isAllday = (startDate: Date | null, endDate: Date | null): boolean => {
+export const isAllday = (startDate: string, endDate: string): boolean => {
   const ALL_DAY = 24 * 60 * 60 * 1000;
 
   if (!startDate || !endDate) return false;
-  return endDate.getTime() - startDate.getTime() >= ALL_DAY;
+  return new Date(endDate).getTime() - new Date(startDate).getTime() >= ALL_DAY;
 };
 
 export const getDateRangeString = (startDate: Date, endDate: Date): string => {


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #123 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 일정이 다음날로 넘어가는 경우, 카드를 잘라서 두 개 렌더링
- 일정 기간이 24시간 이상인 경우, 최상단 '하루 종일' 필드에 렌더링
- 해당 페이지 진입 시 현재 시간으로 스크롤 및 하이라이팅

https://github.com/user-attachments/assets/c0ca1e2e-86cf-40c9-8867-00f8bc2d1580

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Launched an enhanced calendar view with new components for managing multi-day and all-day events.
  - Introduced an interactive calendar table and a dedicated time bar that auto-scrolls to the current time and displays real-time updates.

- **Style**
  - Refined card layouts with adjusted spacing for a more balanced interface.
  - Added a subtle fade animation and improved layering for smoother visual transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->