### PR TITLE
[FE-Feat] 체크박스 [확인] 버튼 누를 때 데이터 다시 가져오기

### DIFF
--- a/frontend/src/features/discussion/api/keys.ts
+++ b/frontend/src/features/discussion/api/keys.ts
@@ -5,16 +5,17 @@ export const discussionKeys = {
   detail: (id: string) => [...discussionKeys.all, id],
 };
 
-export const calendarKeys = {
-  all: ['calendars'],
-  detail: (id: string, body: DiscussionCalendarRequest) => 
-    [...calendarKeys.all, id, JSON.stringify(body)],
-};
-
-export const rankKeys = {
-  all: ['ranks'],
-  detail: (id: string, body: DiscussionRankRequest) => 
-    [...rankKeys.all, id, JSON.stringify(body)],
+export const candidateKeys = {
+  all: ['candidates'],
+  calendar: (
+    id: string, {
+      startDate,
+      endDate,
+      selectedUserIdList,
+    }: DiscussionCalendarRequest) => 
+    [...candidateKeys.all, id, 'calendar', startDate, endDate, selectedUserIdList?.join(',')],
+  rank: (id: string, { selectedUserIdList }: DiscussionRankRequest) => 
+    [...candidateKeys.all, id, 'rank', selectedUserIdList?.join(',')],
 };
 
 export const participantKeys = {

--- a/frontend/src/features/discussion/api/queries.ts
+++ b/frontend/src/features/discussion/api/queries.ts
@@ -80,12 +80,12 @@ export const useDiscussionRankQuery = (
 };
 
 export const useDiscussionParticipantsQuery = (discussionId: string) => {
-  const { data: participants, isLoading } 
+  const { data: participants, isPending } 
         = useQuery<DiscussionParticipantResponse['participants']>(
           discussionParticipantQuery(discussionId),
         );
     
-  return { participants, isLoading };
+  return { participants, isPending };
 };
 
 export const useDiscussionConfirmQuery = (discussionId: string) => {

--- a/frontend/src/features/discussion/api/queries.ts
+++ b/frontend/src/features/discussion/api/queries.ts
@@ -28,6 +28,7 @@ export const discussionCalendarQuery = (
 ) => ({
   queryKey: candidateKeys.calendar(discussionId, body),
   queryFn: () => candidateApi.postCalendarCandidate(discussionId, body),
+  gcTime: 0,
 });
 
 export const discussionRankQuery = (
@@ -35,11 +36,13 @@ export const discussionRankQuery = (
 ) => ({
   queryKey: candidateKeys.rank(discussionId, body),
   queryFn: () => candidateApi.postRankCandidate(discussionId, body),
+  gcTime: 0,
 });
 
 export const discussionParticipantQuery = (discussionId: string) => ({
   queryKey: participantKeys.detail(discussionId),
   queryFn: () => candidateApi.getCandidateParticipants(discussionId),
+  gcTime: 0,
 });
 
 export const discussionConfirmQuery = (discussionId: string) => ({

--- a/frontend/src/features/discussion/api/queries.ts
+++ b/frontend/src/features/discussion/api/queries.ts
@@ -11,11 +11,10 @@ import type {
 } from '../model';
 import { candidateApi, discussionApi } from '.';
 import { 
-  calendarKeys, 
+  candidateKeys, 
   discussionKeys,
   hostKeys, 
-  participantKeys, 
-  rankKeys, 
+  participantKeys,
   sharedEventKeys, 
 } from './keys';
 
@@ -27,17 +26,15 @@ export const discussionQuery = (discussionId: string) => ({
 export const discussionCalendarQuery = (
   discussionId: string, body: DiscussionCalendarRequest,
 ) => ({
-  queryKey: calendarKeys.detail(discussionId, body),
+  queryKey: candidateKeys.calendar(discussionId, body),
   queryFn: () => candidateApi.postCalendarCandidate(discussionId, body),
-  cacheTime: 0,
 });
 
 export const discussionRankQuery = (
   discussionId: string, body: DiscussionRankRequest,
 ) => ({
-  queryKey: rankKeys.detail(discussionId, body),
+  queryKey: candidateKeys.rank(discussionId, body),
   queryFn: () => candidateApi.postRankCandidate(discussionId, body),
-  cacheTime: 0,
 });
 
 export const discussionParticipantQuery = (discussionId: string) => ({
@@ -65,12 +62,11 @@ export const useDiscussionQuery = (discussionId: string) => {
 export const useDiscussionCalendarQuery = (
   discussionId: string, body: DiscussionCalendarRequest,
 ) => {  
-  const { data: calendar, isLoading } = useQuery<DiscussionCalendarResponse['events']>(
+  const { data: calendar, refetch, isPending } = useQuery<DiscussionCalendarResponse['events']>(
     discussionCalendarQuery(discussionId, body),
-    
   );
 
-  return { calendar, isLoading };
+  return { calendar, isPending, refetch };
 };
 
 export const useDiscussionRankQuery = (

--- a/frontend/src/features/discussion/model/index.ts
+++ b/frontend/src/features/discussion/model/index.ts
@@ -56,13 +56,13 @@ const DiscussionParticipantResponse = z.object({
 const DiscussionCalendarRequest = z.object({
   startDate: z.string().regex(DATE_BAR),
   endDate: z.string().regex(DATE_BAR),
-  selectedUserIdList: z.array(z.number()),
+  selectedUserIdList: z.array(z.number()).nullable(),
   size: z.number().int()
     .optional(),
 });
 
 const DiscussionRankRequest = z.object({
-  selectedUserIdList: z.array(z.number()),
+  selectedUserIdList: z.array(z.number()).nullable(),
 });
 
 const DiscussionCalendarResponse = z.object({

--- a/frontend/src/features/discussion/ui/DiscussionCalendar/CalendarTable.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCalendar/CalendarTable.tsx
@@ -4,6 +4,7 @@ import { useParams } from '@tanstack/react-router';
 import { useCalendarContext } from '@/components/Calendar/context/CalendarContext';
 import { Flex } from '@/components/Flex';
 import { WEEK } from '@/constants/date';
+import { useMemberContext } from '@/pages/DiscussionPage/MemberContext';
 import { formatDateToWeekRange } from '@/utils/date';
 import { formatDateToBarString } from '@/utils/date/format';
 
@@ -24,12 +25,13 @@ const groupByDayOfWeek = (data: DiscussionDTO[]) =>
 
 export const CalendarTable = () => {
   const params: { id: string } = useParams({ from: '/_main/discussion/$id' });
+  const members = useMemberContext();
   const { dates, selected } = useCalendarContext();
   const { startDate, endDate } = formatDateToWeekRange(selected);
-  const { calendar, isLoading } = useDiscussionCalendarQuery(params.id, {
+  const { calendar, isPending } = useDiscussionCalendarQuery(params.id, {
     startDate: formatDateToBarString(startDate),
     endDate: formatDateToBarString(endDate),
-    selectedUserIdList: [1],
+    selectedUserIdList: members?.formState.checkedList || null,
   });
 
   return (
@@ -38,7 +40,7 @@ export const CalendarTable = () => {
       height='36.5rem'
       width='100%'
     >
-      {!isLoading && dates.map((date) => 
+      {!isPending && dates.map((date) => 
         <CalendarDate
           date={date}
           groupMap={groupByDayOfWeek(calendar || [])}

--- a/frontend/src/features/discussion/ui/DiscussionCalendar/CalendarTable.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCalendar/CalendarTable.tsx
@@ -28,7 +28,7 @@ export const CalendarTable = () => {
   const members = useMemberContext();
   const { dates, selected } = useCalendarContext();
   const { startDate, endDate } = formatDateToWeekRange(selected);
-  const { calendar, isPending } = useDiscussionCalendarQuery(params.id, {
+  const { calendar } = useDiscussionCalendarQuery(params.id, {
     startDate: formatDateToBarString(startDate),
     endDate: formatDateToBarString(endDate),
     selectedUserIdList: members?.formState.checkedList || null,
@@ -40,7 +40,7 @@ export const CalendarTable = () => {
       height='36.5rem'
       width='100%'
     >
-      {!isPending && dates.map((date) => 
+      {dates.map((date) => 
         <CalendarDate
           date={date}
           groupMap={groupByDayOfWeek(calendar || [])}

--- a/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { useEffect } from 'react';
 

--- a/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
@@ -1,5 +1,4 @@
 import { useParams } from '@tanstack/react-router';
-import { useEffect } from 'react';
 
 import Button from '@/components/Button';
 import { Checkbox } from '@/components/Checkbox';

--- a/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
@@ -1,4 +1,5 @@
 import { useParams } from '@tanstack/react-router';
+import { useMemo } from 'react';
 
 import Button from '@/components/Button';
 import { Checkbox } from '@/components/Checkbox';
@@ -44,9 +45,10 @@ const CheckboxContents = (
 const DiscussionMemberCheckbox = () => {
   const params: { id: string } = useParams({ from: '/_main/discussion/$id' });
   const { participants = [], isPending } = useDiscussionParticipantsQuery(params.id);
+  const participantsIds = useMemo(() => participants.map(({ id }) => id), [participants]);
   const groupInfos = useGroup({
-    defaultCheckedList: participants.map(({ id }) => id),
-    itemIds: participants.map(({ id }) => id),
+    defaultCheckedList: participantsIds,
+    itemIds: participantsIds,
   });
 
   const members = useMemberContext();

--- a/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
@@ -44,7 +44,7 @@ const CheckboxContents = (
 
 const DiscussionMemberCheckbox = () => {
   const params: { id: string } = useParams({ from: '/_main/discussion/$id' });
-  const { participants = [], isLoading } = useDiscussionParticipantsQuery(params.id);
+  const { participants = [], isPending } = useDiscussionParticipantsQuery(params.id);
   const groupInfos = useGroup({
     defaultCheckedList: participants.map(({ id }) => id),
     itemIds: participants.map(({ id }) => id),
@@ -55,15 +55,10 @@ const DiscussionMemberCheckbox = () => {
     if (!members) return;
     members.handleUpdateField('checkedList', Array.from(groupInfos.checkedList));
   };
-
-  // TODO: useEffect를 사용하지 않는 방법..
-  useEffect(() => {
-    groupInfos.init();
-  }, [participants]); 
       
   return (
     <Group groupInfos={groupInfos}>
-      {!isLoading && 
+      {!isPending && 
       <CheckboxContents 
         onClickSearch={handleClickSearch}
         participants={participants}

--- a/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { useEffect } from 'react';
 
@@ -6,6 +7,7 @@ import { Checkbox } from '@/components/Checkbox';
 import { Flex } from '@/components/Flex';
 import { Group } from '@/components/Group';
 import { useGroup } from '@/hooks/useGroup';
+import { useMemberContext } from '@/pages/DiscussionPage/MemberContext';
 
 import { useDiscussionParticipantsQuery } from '../../api/queries';
 import type { DiscussionParticipantResponse } from '../../model';
@@ -13,43 +15,47 @@ import { checkboxContainerStyle } from './index.css';
 import Title from './Title';
 
 const CheckboxContents = (
-  { participants }: { participants: DiscussionParticipantResponse['participants'] },
-) => {
-  const handleClickSearch = () => {
-    // console.log(groupInfos.checkedList);
-  };
-  return (
+  { participants, onClickSearch }: 
+  { 
+    participants: DiscussionParticipantResponse['participants'];
+    onClickSearch: () => void;
+  },
+) => (
+  <Flex
+    align='flex-end'
+    className={checkboxContainerStyle}
+    direction='column'
+    gap={400}
+    width='14.25rem'
+  >
+    <Title />
     <Flex
-      align='flex-end'
-      className={checkboxContainerStyle}
       direction='column'
       gap={400}
-      width='14.25rem'
+      width='100%'
     >
-      <Title />
-      <Flex
-        direction='column'
-        gap={400}
-        width='100%'
-      >
-        <Checkbox type='all'>전체</Checkbox>
-        {participants.map(({ id, name }) => (
-          <Checkbox key={id} value={id}>{name}</Checkbox>
-        ))}
-      </Flex>
-      <Button onClick={handleClickSearch} size='lg'>확인</Button>
+      <Checkbox type='all'>전체</Checkbox>
+      {participants.map(({ id, name }) => (
+        <Checkbox key={id} value={id}>{name}</Checkbox>
+      ))}
     </Flex>
-  );
-};
+    <Button onClick={onClickSearch} size='lg'>확인</Button>
+  </Flex>
+);
 
 const DiscussionMemberCheckbox = () => {
   const params: { id: string } = useParams({ from: '/_main/discussion/$id' });
   const { participants = [], isLoading } = useDiscussionParticipantsQuery(params.id);
-
   const groupInfos = useGroup({
     defaultCheckedList: participants.map(({ id }) => id),
     itemIds: participants.map(({ id }) => id),
   });
+
+  const members = useMemberContext();
+  const handleClickSearch = async () => {
+    if (!members) return;
+    members.handleUpdateField('checkedList', Array.from(groupInfos.checkedList));
+  };
 
   // TODO: useEffect를 사용하지 않는 방법..
   useEffect(() => {
@@ -58,7 +64,11 @@ const DiscussionMemberCheckbox = () => {
       
   return (
     <Group groupInfos={groupInfos}>
-      {!isLoading && <CheckboxContents participants={participants} />}
+      {!isLoading && 
+      <CheckboxContents 
+        onClickSearch={handleClickSearch}
+        participants={participants}
+      />}
     </Group>
   );
 };

--- a/frontend/src/features/discussion/ui/DiscussionRank/RankContents.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionRank/RankContents.tsx
@@ -23,7 +23,7 @@ export const RankContents = ({ data }: { data: DiscussionDTO[] }) => {
         {data.slice(0, TOP_CARD_NUM).map((discussion, idx) => 
           <DiscussionCard
             discussion={discussion}
-            key={discussion.endDateTime}
+            key={`${discussion.endDateTime}-${idx}`}
             rank={idx + 1}
             size='lg'
           />)}

--- a/frontend/src/features/discussion/ui/DiscussionRank/RankTable.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionRank/RankTable.tsx
@@ -31,7 +31,7 @@ export const RankTable = ({ data }: { data: DiscussionDTO[] }) => (
       {data.map((discussion, rank) => (
         <RankTableRow
           discussion={discussion}
-          key={discussion.startDateTime}
+          key={`${discussion.endDateTime}-${rank}`}
           rank={rank}
         />
       ))}

--- a/frontend/src/features/discussion/ui/DiscussionRank/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionRank/index.tsx
@@ -1,6 +1,7 @@
 import { useParams } from '@tanstack/react-router';
 
 import SegmentControl from '@/components/SegmentControl';
+import { useMemberContext } from '@/pages/DiscussionPage/MemberContext';
 
 import { useDiscussionRankQuery } from '../../api/queries';
 import { segmentControlContentsStyle, segmentControlStyle } from './index.css';
@@ -12,8 +13,11 @@ const segmentOptions = [
 ];
 const DiscussionRank = () => {
   const params: { id: string } = useParams({ from: '/_main/discussion/$id' });
+  const members = useMemberContext();
   const { rank, isLoading } 
-    = useDiscussionRankQuery(params.id, { selectedUserIdList: [1] });
+    = useDiscussionRankQuery(params.id, { 
+      selectedUserIdList: members?.formState.checkedList || null, 
+    });
 
   return (
     <SegmentControl

--- a/frontend/src/features/discussion/ui/DiscussionRank/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionRank/index.tsx
@@ -7,10 +7,6 @@ import { useDiscussionRankQuery } from '../../api/queries';
 import { segmentControlContentsStyle, segmentControlStyle } from './index.css';
 import { RankContents } from './RankContents';
 
-const segmentOptions = [
-  { label: '참가자 많은 순', value: 'participant' },
-  { label: '빠른 시간 순', value: 'time' },
-];
 const DiscussionRank = () => {
   const params: { id: string } = useParams({ from: '/_main/discussion/$id' });
   const members = useMemberContext();
@@ -19,17 +15,22 @@ const DiscussionRank = () => {
       selectedUserIdList: members?.formState.checkedList || null, 
     });
 
+  const segmentOptions = [
+    { label: '참가자 많은 순', value: 'participant' },
+    { label: '빠른 시간 순', value: 'time' },
+  ];
+
   return (
     <SegmentControl
       className={segmentControlStyle}
-      defaultValue='참가자 많은 순'
+      defaultValue='participant'
       segmentOptions={segmentOptions}
       style='weak'
     >
-      <SegmentControl.Content className={segmentControlContentsStyle} value='참가자 많은 순'>
+      <SegmentControl.Content className={segmentControlContentsStyle} value='participant'>
         {!isLoading && <RankContents data={rank?.eventsRankedDefault || []} />}
       </SegmentControl.Content>
-      <SegmentControl.Content className={segmentControlContentsStyle} value='빠른 시간 순'>
+      <SegmentControl.Content className={segmentControlContentsStyle} value='time'>
         {!isLoading && <RankContents data={rank?.eventsRankedOfTime || []} />}
       </SegmentControl.Content>
     </SegmentControl>

--- a/frontend/src/hooks/useFormRef.ts
+++ b/frontend/src/hooks/useFormRef.ts
@@ -3,7 +3,8 @@ import { useRef } from 'react';
 // Form의 value로는 다양한 값이 올 수 있습니다.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FormValues<T> = { [K in keyof T]: any };
-export type ChangeEvent<T> = { name: keyof T; value: string | boolean };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ChangeEvent<T> = { name: keyof T; value: any };
 
 export interface FormRef<T> {
   valuesRef: { current: FormValues<T> };

--- a/frontend/src/hooks/useFormRef.ts
+++ b/frontend/src/hooks/useFormRef.ts
@@ -3,8 +3,7 @@ import { useRef } from 'react';
 // Form의 value로는 다양한 값이 올 수 있습니다.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FormValues<T> = { [K in keyof T]: any };
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ChangeEvent<T> = { name: keyof T; value: any };
+export type ChangeEvent<T> = { name: keyof T; value: T[keyof T] };
 
 export interface FormRef<T> {
   valuesRef: { current: FormValues<T> };

--- a/frontend/src/hooks/useGroup.ts
+++ b/frontend/src/hooks/useGroup.ts
@@ -1,4 +1,4 @@
-import { useReducer } from 'react';
+import { useEffect, useReducer } from 'react';
 
 type State = {
   checkedList: Set<number>;
@@ -70,6 +70,10 @@ export const useGroup = ({
       checkedList: new Set(defaultCheckedList), 
       isAllChecked: defaultCheckedList.length === itemIds.length, 
     });
+
+  useEffect(() => {
+    dispatch({ type: 'INIT', defaultCheckedList, itemIds });
+  }, [defaultCheckedList, itemIds]);
 
   const handleToggleCheck = (id: number) => {
     dispatch({ type: 'TOGGLE_ITEM', id, itemIds });

--- a/frontend/src/hooks/useGroup.ts
+++ b/frontend/src/hooks/useGroup.ts
@@ -9,7 +9,7 @@ type Action =
   | { type: 'TOGGLE_ITEM'; id: number; itemIds: number[] }
   | { type: 'TOGGLE_ALL'; itemIds: number[] }
   | { type: 'RESET' }
-  | { type: 'INIT'; defaultCheckedList: number[] };
+  | { type: 'INIT'; defaultCheckedList: number[]; itemIds: number[] };
   
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
@@ -38,7 +38,7 @@ const reducer = (state: State, action: Action): State => {
     case 'INIT': {
       return { 
         checkedList: new Set(action.defaultCheckedList),
-        isAllChecked: state.isAllChecked,
+        isAllChecked: action.defaultCheckedList.length === action.itemIds.length,
       };
     }
 
@@ -72,8 +72,8 @@ export const useGroup = ({
     });
 
   useEffect(() => {
-    dispatch({ type: 'INIT', defaultCheckedList });
-  }, [defaultCheckedList]);
+    dispatch({ type: 'INIT', defaultCheckedList, itemIds });
+  }, [defaultCheckedList, itemIds]);
 
   const handleToggleCheck = (id: number) => {
     dispatch({ type: 'TOGGLE_ITEM', id, itemIds });
@@ -93,6 +93,6 @@ export const useGroup = ({
     isAllChecked: state.isAllChecked,
     handleToggleAllCheck, 
     reset,
-    init: () => dispatch({ type: 'INIT', defaultCheckedList }),
+    init: () => dispatch({ type: 'INIT', defaultCheckedList, itemIds }),
   };
 };

--- a/frontend/src/hooks/useGroup.ts
+++ b/frontend/src/hooks/useGroup.ts
@@ -9,7 +9,7 @@ type Action =
   | { type: 'TOGGLE_ITEM'; id: number; itemIds: number[] }
   | { type: 'TOGGLE_ALL'; itemIds: number[] }
   | { type: 'RESET' }
-  | { type: 'INIT'; defaultCheckedList: number[]; itemIds: number[] };
+  | { type: 'INIT'; defaultCheckedList: number[] };
   
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
@@ -38,7 +38,7 @@ const reducer = (state: State, action: Action): State => {
     case 'INIT': {
       return { 
         checkedList: new Set(action.defaultCheckedList),
-        isAllChecked: action.defaultCheckedList.length === action.itemIds.length, 
+        isAllChecked: state.isAllChecked,
       };
     }
 
@@ -72,8 +72,8 @@ export const useGroup = ({
     });
 
   useEffect(() => {
-    dispatch({ type: 'INIT', defaultCheckedList, itemIds });
-  }, [defaultCheckedList, itemIds]);
+    dispatch({ type: 'INIT', defaultCheckedList });
+  }, [defaultCheckedList]);
 
   const handleToggleCheck = (id: number) => {
     dispatch({ type: 'TOGGLE_ITEM', id, itemIds });
@@ -93,6 +93,6 @@ export const useGroup = ({
     isAllChecked: state.isAllChecked,
     handleToggleAllCheck, 
     reset,
-    init: () => dispatch({ type: 'INIT', defaultCheckedList, itemIds }),
+    init: () => dispatch({ type: 'INIT', defaultCheckedList }),
   };
 };

--- a/frontend/src/pages/DiscussionPage/MemberContext.ts
+++ b/frontend/src/pages/DiscussionPage/MemberContext.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+import type { FormState } from '@/hooks/useFormState';
+
+export interface MemberContextProps {
+  checkedList: number[] | null;
+}
+  
+export const MemberContext = createContext<FormState<MemberContextProps> | null>(null);
+  
+export const useMemberContext = () => useContext(MemberContext);

--- a/frontend/src/pages/DiscussionPage/index.tsx
+++ b/frontend/src/pages/DiscussionPage/index.tsx
@@ -2,10 +2,13 @@ import { Flex } from '@/components/Flex';
 import DiscussionMemberCheckbox from '@/features/discussion/ui/DiscussionMemberCheckbox';
 import DiscussionTab from '@/features/discussion/ui/DiscussionTab';
 import DiscussionTitle from '@/features/discussion/ui/DiscussionTitle';
+import { useFormState } from '@/hooks/useFormState';
 
 import { discussionContentStyle } from './index.css';
+import type { MemberContextProps } from './MemberContext';
+import { MemberContext } from './MemberContext';
 
-const DiscussionPage = () =>(
+const DiscussionPage = () => (
   <Flex
     direction='column'
     height='calc(100vh - 112px)'
@@ -19,8 +22,10 @@ const DiscussionPage = () =>(
       height='calc(100% - 48px)'
       width='100%'
     >
-      <DiscussionMemberCheckbox />
-      <DiscussionTab />
+      <MemberContext.Provider value={useFormState<MemberContextProps>({ checkedList: null })}>
+        <DiscussionMemberCheckbox />
+        <DiscussionTab />
+      </MemberContext.Provider>
     </Flex>
   </Flex>
 );


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #124 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 쿼리키를 `JSON.stringify` 로 작성하여 캐싱이 제대로 되지 않았던 문제를 해결합니다.
<img width="762" alt="image" src="https://github.com/user-attachments/assets/b348b165-91d8-496a-b13f-dd446d30fe97" />

- 체크박스 [확인] 버튼 누를 시, 상위에서 내려준 폼 컨텍스트의 상태를 변경해 주어서 해당 상태를 갖고 있는 `useQuery` 로직이 재실행 되도록 합니다.

https://github.com/user-attachments/assets/02cab4e7-152f-4f92-aa92-a9e412b80217

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced unified candidate management for discussion calendar and ranking.
  - Enabled dynamic member selection, delivering a more personalized experience.
  - Implemented a new context for managing member-related state.

- **Refactor**
  - Enhanced loading state indicators for smoother, more responsive interactions.
  - Optimized list rendering with improved key handling.
  - Adjusted input parameters for discussion requests to allow greater flexibility.
  - Integrated context-based state management in the discussion page components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->