### PR TITLE
[BE-Fix] 개인 일정 수정 시 구글 캘린더에 반영되지 않는 버그 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -128,8 +128,9 @@ public class PersonalEventService {
         PersonalEvent result = updatePersonalEvent(request, personalEvent, user, discussions);
 
         if (request.syncWithGoogleCalendar()) {
-            if (result.getGoogleEventId() == null) {
-                eventPublisher.publishEvent(new InsertPersonalEvent(List.of(personalEvent)));
+            if (result.getGoogleEventId() == null && result.getCalendarId() == null) {
+                result.update(IdGenerator.generateId(user.getId()), PRIMARY);
+                eventPublisher.publishEvent(new InsertPersonalEvent(List.of(result)));
             } else {
                 eventPublisher.publishEvent(new UpdatePersonalEvent(result));
             }
@@ -145,12 +146,6 @@ public class PersonalEventService {
         PersonalEvent oldEvent = personalEvent.copy();
 
         personalEvent.update(request);
-
-        if (request.syncWithGoogleCalendar()
-            && personalEvent.getGoogleEventId() == null
-            && personalEvent.getCalendarId() == null) {
-            personalEvent.update(IdGenerator.generateId(user.getId()), PRIMARY);
-        }
 
         if (isChanged(personalEvent, request)) {
             discussions.forEach(discussion -> {

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -146,7 +146,9 @@ public class PersonalEventService {
 
         personalEvent.update(request);
 
-        if (request.syncWithGoogleCalendar()) {
+        if (request.syncWithGoogleCalendar()
+            && personalEvent.getGoogleEventId() == null
+            && personalEvent.getCalendarId() == null) {
             personalEvent.update(IdGenerator.generateId(user.getId()), PRIMARY);
         }
 


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #220 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
개인 일정 수정할 때 구글 캘린더에 반영되지 않는 버그를 수정했습니다. 
syncWithGoogleCalendar가 true면 새로 googleEventId를 만드는데, 이미 존재하는 경우에도 새로 만들어서 생기는 문제였습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the synchronization of personal events with your calendar, ensuring that updates occur only when all required identifiers are present.
  - Adjusted deletion handling so that events are removed from your calendar only when both Google Event ID and Calendar ID are available, reducing unintended changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->