### PR TITLE
[FE-Feat] 로그인 state 추적하여 헤더에 아바타 혹은 로그인 버튼 표시

### DIFF
--- a/frontend/src/components/Avatar/index.tsx
+++ b/frontend/src/components/Avatar/index.tsx
@@ -1,3 +1,5 @@
+import clsx from '@/utils/clsx';
+
 import AvatarCount from './AvatarCount';
 import AvatarItem from './AvatarItem';
 import { avatarContainerStyle } from './index.css';
@@ -7,16 +9,17 @@ export type Size = 'sm' | 'lg';
 interface AvatarProps {
   size: Size;
   imageUrls: string[];
+  className?: string;
 }
 
 const MAX_IMAGE_COUNT = 4;
 
-const Avatar = ({ size, imageUrls }: AvatarProps) => {
+const Avatar = ({ size, imageUrls, className }: AvatarProps) => {
   const ENTIRE_LENGTH = imageUrls.length;
   const limitedUrls = imageUrls.slice(0, MAX_IMAGE_COUNT);
 
   return (
-    <div className={avatarContainerStyle}>
+    <div className={clsx(avatarContainerStyle, className)}>
       {limitedUrls.map((url, index) => (
         <AvatarItem
           key={`${index}-${url}`}

--- a/frontend/src/features/user/api/index.ts
+++ b/frontend/src/features/user/api/index.ts
@@ -1,0 +1,11 @@
+import { request } from '@/utils/fetch';
+
+import { UserInfoSchema } from '../model';
+
+export const userApi = {
+  getUserInfo: async () => {
+    const response = await request.get('/api/v1/user/current');
+    const parsedData = UserInfoSchema.parse(response);
+    return parsedData;
+  },
+};

--- a/frontend/src/features/user/api/keys.ts
+++ b/frontend/src/features/user/api/keys.ts
@@ -1,0 +1,3 @@
+
+// TODO: accessToken의 해시값 등으로 변경 필
+export const userInfoQueryKey = (accessToken: string | null) => ['userInfo', accessToken];

--- a/frontend/src/features/user/api/queries.ts
+++ b/frontend/src/features/user/api/queries.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getAccessToken } from '@/utils/auth';
+
+import { userApi } from '.';
+import { userInfoQueryKey } from './keys';
+
+export const useUserInfoQuery = () => useQuery({
+  queryKey: userInfoQueryKey(getAccessToken()),
+  queryFn: () => userApi.getUserInfo(),
+});

--- a/frontend/src/features/user/model/index.ts
+++ b/frontend/src/features/user/model/index.ts
@@ -7,4 +7,10 @@ export const UserDTO = z.object({
   picture: z.string().url(),
 });
 
+export const UserInfoSchema = z.object({
+  name: z.string(),
+  picture: z.string().url(),
+});
+
 export type UserDTO = z.infer<typeof UserDTO>;
+export type UserInfo = z.infer<typeof UserInfoSchema>;

--- a/frontend/src/layout/GlobalNavBar/index.css.ts
+++ b/frontend/src/layout/GlobalNavBar/index.css.ts
@@ -3,6 +3,10 @@ import { recipe } from '@vanilla-extract/recipes';
 
 import { vars } from '@/theme/index.css';
 
+export const avatarContainerStyle = style({
+  marginLeft: vars.spacing[300],
+});
+
 export const containerStyle = recipe({
   base: {
     width: '100vw',

--- a/frontend/src/layout/GlobalNavBar/index.tsx
+++ b/frontend/src/layout/GlobalNavBar/index.tsx
@@ -5,6 +5,8 @@ import type { PropsWithChildren } from 'react';
 import Avatar from '@/components/Avatar';
 import { Flex } from '@/components/Flex';
 import { Logo } from '@/components/Icon/component/Logo';
+import { useUserInfoQuery } from '@/features/user/api/queries';
+import { isLogin } from '@/utils/auth';
 
 import { LoginLink, MyCalendarLink, NewDiscussionLink } from './buttons';
 import { containerStyle } from './index.css';
@@ -15,6 +17,9 @@ interface GlobalNavBarProps extends PropsWithChildren {
 
 const GlobalNavBar = ({ background = 'white', children }: GlobalNavBarProps) => {
   const navigate = useNavigate();
+  const { data, isPending } = useUserInfoQuery();
+  if (isPending) return <div>pending ...</div>;
+  if (!data) return <div>user data is undefined or null</div>;
 
   const onClickLogo = () => {
     navigate({ to: '/', replace: true });
@@ -29,7 +34,17 @@ const GlobalNavBar = ({ background = 'white', children }: GlobalNavBarProps) => 
         width={80}
       />
       <Flex direction='row'>
-        {children}
+        {isLogin() ? 
+          <Flex
+            align='center'
+            direction='row'
+            gap={300}
+          >
+            {children}
+            <Avatar imageUrls={[data.picture]} size='lg' />
+          </Flex>
+          :
+          <LoginLink />}
       </Flex>
     </header>
   );

--- a/frontend/src/layout/GlobalNavBar/index.tsx
+++ b/frontend/src/layout/GlobalNavBar/index.tsx
@@ -17,9 +17,6 @@ interface GlobalNavBarProps extends PropsWithChildren {
 
 const GlobalNavBar = ({ background = 'white', children }: GlobalNavBarProps) => {
   const navigate = useNavigate();
-  const { data, isPending } = useUserInfoQuery();
-  if (isPending) return <div>pending ...</div>;
-  if (!data) return <div>user data is undefined or null</div>;
 
   const onClickLogo = () => {
     navigate({ to: '/', replace: true });
@@ -41,7 +38,7 @@ const GlobalNavBar = ({ background = 'white', children }: GlobalNavBarProps) => 
             gap={300}
           >
             {children}
-            <Avatar imageUrls={[data.picture]} size='lg' />
+            <UserAvatar />
           </Flex>
           :
           <LoginLink />}
@@ -50,10 +47,16 @@ const GlobalNavBar = ({ background = 'white', children }: GlobalNavBarProps) => 
   );
 };
 
-// TODO: 로그인 상태에 따라 로그인 버튼 | 다른 버튼들 + 아바타 표시
-GlobalNavBar.LoginLink = LoginLink;
+const UserAvatar = () => {
+  const { data, isPending } = useUserInfoQuery();
+  if (isPending) return <div>pending ...</div>;
+  if (!data) return <div>user data is undefined or null</div>;
+  return (
+    <Avatar imageUrls={[data.picture]} size='lg' />
+  );
+};
+
 GlobalNavBar.MyCalendarLink = MyCalendarLink;
 GlobalNavBar.NewDiscussionLink = NewDiscussionLink;
-GlobalNavBar.Avatar = Avatar;
 
 export default GlobalNavBar;

--- a/frontend/src/layout/GlobalNavBar/index.tsx
+++ b/frontend/src/layout/GlobalNavBar/index.tsx
@@ -9,7 +9,7 @@ import { useUserInfoQuery } from '@/features/user/api/queries';
 import { isLogin } from '@/utils/auth';
 
 import { LoginLink, MyCalendarLink, NewDiscussionLink } from './buttons';
-import { containerStyle } from './index.css';
+import { avatarContainerStyle, containerStyle } from './index.css';
 
 interface GlobalNavBarProps extends PropsWithChildren {
   background?: 'white' | 'transparent';
@@ -35,7 +35,6 @@ const GlobalNavBar = ({ background = 'white', children }: GlobalNavBarProps) => 
           <Flex
             align='center'
             direction='row'
-            gap={300}
           >
             {children}
             <UserAvatar />
@@ -52,7 +51,11 @@ const UserAvatar = () => {
   if (isPending) return <div>pending ...</div>;
   if (!data) return <div>user data is undefined or null</div>;
   return (
-    <Avatar imageUrls={[data.picture]} size='lg' />
+    <Avatar
+      className={avatarContainerStyle}
+      imageUrls={[data.picture]}
+      size='lg'
+    />
   );
 };
 

--- a/frontend/src/routes/landing/index.tsx
+++ b/frontend/src/routes/landing/index.tsx
@@ -5,9 +5,7 @@ import LandingPage from '@/pages/LandingPage';
 
 const Landing = () => (
   <>
-    <GlobalNavBar background='transparent'>
-      <GlobalNavBar.LoginLink />
-    </GlobalNavBar>
+    <GlobalNavBar background='transparent' />
     <LandingPage />
   </>
 );

--- a/frontend/src/routes/login/index.lazy.tsx
+++ b/frontend/src/routes/login/index.lazy.tsx
@@ -1,14 +1,11 @@
 import { createLazyFileRoute } from '@tanstack/react-router';
 
 import GlobalNavBar from '@/layout/GlobalNavBar';
-import { LoginLink } from '@/layout/GlobalNavBar/buttons';
 import LoginPage from '@/pages/LoginPage';
 
 const Login = () => (
   <>
-    <GlobalNavBar>
-      <LoginLink />
-    </GlobalNavBar>
+    <GlobalNavBar />
     <LoginPage />
   </>
 );

--- a/frontend/src/utils/auth/index.ts
+++ b/frontend/src/utils/auth/index.ts
@@ -1,1 +1,4 @@
-export const isLogin = () => localStorage.getItem('accessToken') !== null;
+const ACCESS_TOKEN_KEY = 'accessToken';
+
+export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY);
+export const isLogin = () => localStorage.getItem(ACCESS_TOKEN_KEY) !== null;


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 로그인 상태에 따라, 헤더에 아바타 혹은 로그인 버튼을 표시합니다.

- 로그인 상태

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/f01645ae-1b90-4968-aa8f-8a8e093e1c0b" />

- 비로그인 상태

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/02885dc6-bcf1-4309-8191-bbe2c0bfd49e" />


## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the navigation header to display a user avatar when logged in, offering a more personalized experience.
  - Improved the integration of user profile data for a responsive and consistent interface across login and landing pages.

- **Refactor**
  - Streamlined the header structure and simplified login state handling to deliver a cleaner and more intuitive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->