### PR TITLE
[BE-Feat] 개인 일정 SSE 알림 구현

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -76,7 +76,6 @@ public class DiscussionService {
 
         if (request.password() != null) {
             discussion.setPassword(passwordEncoder.encode(discussion.getId(), request.password()));
-            discussion = discussionRepository.save(discussion);
         }
 
         discussionParticipantService.addDiscussionParticipant(discussion, currentUser);

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventController.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventController.java
@@ -115,7 +115,7 @@ public class PersonalEventController {
     public ResponseEntity<Void> deletePersonalEvent(
         @PathVariable("personalEventId") Long personalEventId,
         @RequestParam("syncWithGoogleCalendar") Boolean syncWithGoogleCalendar) {
-        personalEventService.deletePersonalEvent(personalEventId, syncWithGoogleCalendar);
+        personalEventService.deleteWithRequest(personalEventId, syncWithGoogleCalendar);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -161,7 +161,7 @@ public class PersonalEventService {
         return personalEventRepository.save(personalEvent);
     }
 
-    public void deletePersonalEvent(Long personalEventId, Boolean syncWithGoogleCalendar) {
+    public void deleteWithRequest(Long personalEventId, Boolean syncWithGoogleCalendar) {
         PersonalEvent personalEvent = getPersonalEvent(personalEventId);
         User user = userService.getCurrentUser();
         validatePersonalEventUser(personalEvent, user);

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -26,8 +26,10 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -192,10 +194,11 @@ public class PersonalEventService {
         personalEventPreprocessor.preprocess(personalEvents, discussion, user);
     }
 
-    public void syncWithGoogleEvents(List<GoogleEvent> googleEvents, User user,
+    public Set<LocalDate> syncWithGoogleEvents(List<GoogleEvent> googleEvents, User user,
         String googleCalendarId) {
         List<Discussion> discussions = discussionParticipantService.getDiscussionsByUserId(
             user.getId());
+        Set<LocalDate> changedDates = new HashSet<>();
         for (GoogleEvent googleEvent : googleEvents) {
             if (googleEvent.status().equals(GoogleEventStatus.CONFIRMED)) {
                 upsertPersonalEventByGoogleEvent(googleEvent, discussions, user, googleCalendarId);
@@ -203,6 +206,7 @@ public class PersonalEventService {
                 deletePersonalEventByGoogleEvent(googleEvent, discussions, user, googleCalendarId);
             }
         }
+        return changedDates;
     }
 
     private void validatePersonalEventUser(PersonalEvent personalEvent, User user) {

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/event/handler/PersonalEventHandler.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/event/handler/PersonalEventHandler.java
@@ -4,7 +4,10 @@ import endolphin.backend.domain.personal_event.PersonalEventService;
 import endolphin.backend.domain.user.entity.User;
 import endolphin.backend.global.google.dto.GoogleEvent;
 import endolphin.backend.global.google.event.GoogleEventChanged;
+import endolphin.backend.global.sse.SseEmitters;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -13,12 +16,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PersonalEventHandler {
     private final PersonalEventService personalEventService;
+    private final SseEmitters sseEmitters;
 
     @EventListener(classes = {GoogleEventChanged.class})
     public void sync(GoogleEventChanged event) {
         List<GoogleEvent> events = event.events();
         User user = event.user();
         String googleCalendarId = event.googleCalendarId();
-        personalEventService.syncWithGoogleEvents(events, user, googleCalendarId);
+        Set<LocalDate> changedDates = personalEventService.syncWithGoogleEvents(events, user, googleCalendarId);
+
+        sseEmitters.sendToUser(user.getId(), changedDates);
     }
 }

--- a/backend/src/main/java/endolphin/backend/global/sse/CalendarEventController.java
+++ b/backend/src/main/java/endolphin/backend/global/sse/CalendarEventController.java
@@ -1,0 +1,25 @@
+package endolphin.backend.global.sse;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/v1/sse/events")
+public class CalendarEventController {
+
+    private final SseEmitters emitters = new SseEmitters();
+
+    // SSE 구독 (유저별 구독 가능)
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@RequestParam("userId") Long userId) {
+        return emitters.add(userId);
+    }
+}

--- a/backend/src/main/java/endolphin/backend/global/sse/CalendarEventController.java
+++ b/backend/src/main/java/endolphin/backend/global/sse/CalendarEventController.java
@@ -1,23 +1,26 @@
 package endolphin.backend.global.sse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@Tag(name = "SSE", description = "Server-Sent Events")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/sse/events")
 public class CalendarEventController {
 
-    private final SseEmitters emitters = new SseEmitters();
+    private final SseEmitters emitters;
 
-    // SSE 구독 (유저별 구독 가능)
+    @Operation(summary = "구독", description = "사용자의 캘린더 이벤트를 구독합니다.")
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@RequestParam("userId") Long userId) {
         return emitters.add(userId);

--- a/backend/src/main/java/endolphin/backend/global/sse/SseEmitters.java
+++ b/backend/src/main/java/endolphin/backend/global/sse/SseEmitters.java
@@ -1,0 +1,43 @@
+package endolphin.backend.global.sse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class SseEmitters {
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private static final Long TIMEOUT = 1000L * 60 * 30;
+
+    public SseEmitter add(Long userId) {
+        SseEmitter emitter = new SseEmitter(TIMEOUT);
+
+        emitter.onCompletion(() -> emitters.remove(userId));
+        emitter.onTimeout(() -> emitters.remove(userId));
+
+        emitters.put(userId, emitter);
+
+        try {
+            emitter.send(SseEmitter.event().comment("connected"));
+        } catch (IOException e) {
+            emitters.remove(userId);
+        }
+
+        return emitter;
+    }
+
+    public void sendToUser(Long userId, Object data) {
+        SseEmitter emitter = emitters.get(userId);
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event().data(data));
+            } catch (IOException e) {
+                emitters.remove(userId);
+            }
+        }
+    }
+}
+

--- a/backend/src/main/java/endolphin/backend/global/sse/SseEmitters.java
+++ b/backend/src/main/java/endolphin/backend/global/sse/SseEmitters.java
@@ -1,5 +1,6 @@
 package endolphin.backend.global.sse;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -8,12 +9,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
+@Slf4j
 public class SseEmitters {
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
     private static final Long TIMEOUT = 1000L * 60 * 30;
 
     public SseEmitter add(Long userId) {
         SseEmitter emitter = new SseEmitter(TIMEOUT);
+        log.info("User {} connected", userId);
 
         emitter.onCompletion(() -> emitters.remove(userId));
         emitter.onTimeout(() -> emitters.remove(userId));
@@ -22,6 +25,7 @@ public class SseEmitters {
 
         try {
             emitter.send(SseEmitter.event().comment("connected"));
+            log.info("Dummy Data sent to User {}", userId);
         } catch (IOException e) {
             emitters.remove(userId);
         }
@@ -33,6 +37,7 @@ public class SseEmitters {
         SseEmitter emitter = emitters.get(userId);
         if (emitter != null) {
             try {
+                log.info("Data {} sent to User {}", data, userId);
                 emitter.send(SseEmitter.event().data(data));
             } catch (IOException e) {
                 emitters.remove(userId);

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -332,7 +332,7 @@ public class DiscussionServiceTest {
         // passwordEncoder.encode가 올바른 인자로 호출되었음을 검증
         verify(passwordEncoder).encode(100L, "secretPassword");
         // discussionRepository.save가 두 번 호출되었는지 확인 (최초 저장, 비밀번호 업데이트)
-        verify(discussionRepository, atLeast(2)).save(any(Discussion.class));
+        verify(discussionRepository, atLeast(1)).save(any(Discussion.class));
     }
 
     @DisplayName("Discussion 정보 조회 테스트")

--- a/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/personal_event/PersonalEventServiceTest.java
@@ -12,11 +12,9 @@ import endolphin.backend.global.dto.ListResponse;
 import java.time.LocalDate;
 import endolphin.backend.global.google.dto.GoogleEvent;
 import endolphin.backend.global.google.enums.GoogleEventStatus;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -178,7 +176,7 @@ class PersonalEventServiceTest {
 
     @Test
     @DisplayName("개인 일정 삭제 사용자 매칭 에러")
-    void testDeletePersonalEvent() {
+    void testDeleteWithRequest() {
         User anotherUser = User.builder().name("anotherUser").email("another@email.com")
             .picture("another_picture").build();
 
@@ -186,7 +184,7 @@ class PersonalEventServiceTest {
         given(personalEventRepository.findById(anyLong())).willReturn(Optional.of(existingEvent));
         given(userService.getCurrentUser()).willReturn(testUser);
 
-        assertThatThrownBy(() -> personalEventService.deletePersonalEvent(anyLong(), false))
+        assertThatThrownBy(() -> personalEventService.deleteWithRequest(anyLong(), false))
             .isInstanceOf(RuntimeException.class);
 
         then(personalEventRepository).should(times(1)).findById(anyLong());
@@ -196,7 +194,7 @@ class PersonalEventServiceTest {
 
     @Test
     @DisplayName("개인 일정 삭제 성공")
-    void testDeletePersonalEvent_Success() {
+    void testDeleteWithRequest_Success() {
         // given
         PersonalEvent event = createWithRequest("test Title", 0, testUser);
 
@@ -204,7 +202,7 @@ class PersonalEventServiceTest {
         given(userService.getCurrentUser()).willReturn(testUser);
 
         // when
-        personalEventService.deletePersonalEvent(anyLong(), false);
+        personalEventService.deleteWithRequest(anyLong(), false);
 
         // then
         then(personalEventRepository).should(times(1)).delete(any(PersonalEvent.class));


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #236 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 구글 캘린더 일정 변동 시 syncWithGoogleEvent에서 Set<> ChangedDates 반환합니다.
- 반환한 Set을 SSE 응답으로 user에게 전송합니다.
- deletePersonalEvent 일부 리팩토링했습니다
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a real-time notifications feature for calendar events. Users can now subscribe to get immediate updates on changes in their personal calendar events.

- **Refactor**
  - Streamlined the handling and synchronization of personal events, ensuring a smoother and more efficient update and deletion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->