### PR TITLE
[BE-Fix] 후보 일정 디테일 뷰에서 유저 리스트 null 요청시 전체 유저 리스트에 대해 수행하도록 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -229,7 +229,11 @@ public class DiscussionService {
         }
 
         List<Long> selectedIds = request.selectedUserIdList() != null ?
-            request.selectedUserIdList() : List.of();
+            request.selectedUserIdList() : participants.stream().map(User::getId).toList();
+
+        if (request.selectedUserIdList().isEmpty()) {
+            throw new ApiException(ErrorCode.INVALID_DISCUSSION_PARTICIPANT);
+        }
 
         Map<Long, Integer> selectedUserIdMap = new HashMap<>();
         for (int i = 0; i < selectedIds.size(); i++) {


### PR DESCRIPTION
- 유저 리스트가 비어있을 시 400 리턴

<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 메인뷰에서 사용을 위해 null -> 전체 참여자로 치환했습니다.
- 빈 유저리스트 요청 시 400 리턴합니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced participant selection during event details retrieval. The system now defaults to include all available participants when none are specified and provides a clear error if no valid selection is made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->