### PR TITLE
[FE-Fix] 체크박스 [확인] 버튼 누를 때마다 요청 보내기 & QA사항

### DIFF
--- a/frontend/src/components/Calendar/Core/SelectedWeek.tsx
+++ b/frontend/src/components/Calendar/Core/SelectedWeek.tsx
@@ -25,7 +25,7 @@ export const SelectedWeek = () => {
           day={day}
           isToday={isSameDate(dates[i], today)}
           key={day}
-          selected={isSameDate(dates[i], selected)}
+          selected={selected}
         />)}
     </div>
   );

--- a/frontend/src/components/Calendar/Core/WeekCell.tsx
+++ b/frontend/src/components/Calendar/Core/WeekCell.tsx
@@ -1,4 +1,5 @@
 import type { WEEKDAY } from '@/constants/date';
+import { isSameDate } from '@/utils/date';
 
 import { Text } from '../../Text';
 import { weekCellBoxStyle, weekCellStyle } from './index.css';
@@ -7,7 +8,7 @@ interface WeekCellProps {
   day: WEEKDAY;
   date: Date;
   isToday: boolean;
-  selected: boolean;
+  selected: Date;
 }
 
 export const WeekCell = ({ day, date, isToday, selected }: WeekCellProps) => {
@@ -26,9 +27,9 @@ export const WeekCell = ({ day, date, isToday, selected }: WeekCellProps) => {
     <div
       className={weekCellStyle({ 
         day: dayStyleName(day), 
-        state: selected ? 'selected' : 'default', 
+        state: isSameDate(date, selected) ? 'selected' : 'default', 
       })}
-      key={selected ? Date.now() : ''}
+      key={`${selected.getTime()} ${day}`}
     >
       <Text typo='b3M'>{day}</Text>
       <div className={weekCellBoxStyle({ day: isToday ? 'today' : dayStyleName(day) })}>

--- a/frontend/src/components/Chip/index.css.ts
+++ b/frontend/src/components/Chip/index.css.ts
@@ -18,35 +18,15 @@ export const chipStyle = recipe({
     color: {
       blue: { 
         backgroundColor: vars.color.Ref.Primary[500],
-        ':hover': {
-          backgroundColor: vars.color.Ref.Primary[100],
-          color: vars.color.Ref.Primary[500],
-          cursor: 'pointer',
-        }, 
       },
       green: { 
         backgroundColor: vars.color.Ref.Green[500],
-        ':hover': {
-          backgroundColor: vars.color.Ref.Green[100],
-          color: vars.color.Ref.Green[500],
-          cursor: 'pointer',
-        }, 
       },
       red: { 
         backgroundColor: vars.color.Ref.Red[500],
-        ':hover': {
-          backgroundColor: vars.color.Ref.Red[100],
-          color: vars.color.Ref.Red[500],
-          cursor: 'pointer',
-        }, 
       },
       black: {
         backgroundColor: vars.color.Ref.Netural[800],
-        ':hover': {
-          backgroundColor: vars.color.Ref.Netural[200],
-          color: vars.color.Ref.Netural[800],
-          cursor: 'pointer',
-        }, 
       },
       coolGray: { 
         backgroundColor: vars.color.Ref.CoolGrey[100],
@@ -57,11 +37,6 @@ export const chipStyle = recipe({
       borderless: { 
         backgroundColor: 'transparent', 
         color: vars.color.Ref.Netural[600],
-        ':hover': {
-          backgroundColor: vars.color.Ref.Netural[200],
-          color: vars.color.Ref.Netural[800],
-          cursor: 'pointer',
-        }, 
       },
       weak: {},
       filled: {},

--- a/frontend/src/features/discussion/api/keys.ts
+++ b/frontend/src/features/discussion/api/keys.ts
@@ -7,15 +7,16 @@ export const discussionKeys = {
 
 export const candidateKeys = {
   all: ['candidates'],
+  detail: (id: string) => [...candidateKeys.all, id],
   calendar: (
     id: string, {
       startDate,
       endDate,
       selectedUserIdList,
     }: DiscussionCalendarRequest) => 
-    [...candidateKeys.all, id, 'calendar', startDate, endDate, selectedUserIdList?.join(',')],
+    [...candidateKeys.detail(id), 'calendar', startDate, endDate, selectedUserIdList?.join(',')],
   rank: (id: string, { selectedUserIdList }: DiscussionRankRequest) => 
-    [...candidateKeys.all, id, 'rank', selectedUserIdList?.join(',')],
+    [...candidateKeys.detail(id), 'rank', selectedUserIdList?.join(',')],
 };
 
 export const participantKeys = {

--- a/frontend/src/features/discussion/ui/DiscussionCalendar/CalendarDate.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCalendar/CalendarDate.tsx
@@ -1,17 +1,19 @@
 import { Flex } from '@/components/Flex';
 import { WEEK } from '@/constants/date';
+import { isSameDate } from '@/utils/date';
 
 import type { DiscussionDTO } from '../../model';
 import DiscussionCard from '../DiscussionCard';
 import { dayStyle } from './index.css';
 
 export const CalendarDate = (
-  { date, groupMap }: { date: Date; groupMap: Map<string, DiscussionDTO[]> },
+  { date, groupMap, selected }: 
+  { date: Date; groupMap: Map<string, DiscussionDTO[]>; selected: Date },
 ) => {
   const day = WEEK[date.getDay()];
   return (
     <Flex
-      className={dayStyle}
+      className={dayStyle({ selected: isSameDate(date, selected) })}
       direction='column'
       gap={400}
       height='100%'

--- a/frontend/src/features/discussion/ui/DiscussionCalendar/CalendarTable.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCalendar/CalendarTable.tsx
@@ -45,6 +45,7 @@ export const CalendarTable = () => {
           date={date}
           groupMap={groupByDayOfWeek(calendar || [])}
           key={date.getTime()}
+          selected={selected}
         />,
       )}
     </Flex>

--- a/frontend/src/features/discussion/ui/DiscussionCalendar/CalendarTable.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCalendar/CalendarTable.tsx
@@ -37,7 +37,7 @@ export const CalendarTable = () => {
   return (
     <Flex
       className={calendarTableStyle}
-      height='36.5rem'
+      height='34rem'
       width='100%'
     >
       {dates.map((date) => 

--- a/frontend/src/features/discussion/ui/DiscussionCalendar/index.css.ts
+++ b/frontend/src/features/discussion/ui/DiscussionCalendar/index.css.ts
@@ -1,5 +1,7 @@
 import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
+import { fadeHighlightGrayProps } from '@/theme/animation.css';
 import { vars } from '@/theme/index.css';
 
 export const calendarTableStyle = style({
@@ -9,20 +11,30 @@ export const calendarTableStyle = style({
   overflow: 'hidden',
 });
 
-export const dayStyle = style({
-  overflowY: 'scroll',
-  padding: vars.spacing[200],
-  flexGrow: 1,
+export const dayStyle = recipe({
+  base: {
+    overflowY: 'scroll',
+    padding: vars.spacing[200],
+    flexGrow: 1,
 
-  borderTop: `3px solid ${vars.color.Ref.Netural[200]}`,
-  borderRight: `1px solid ${vars.color.Ref.Netural[200]}`,
-  backgroundColor: vars.color.Ref.Netural[50],
+    borderTop: `3px solid ${vars.color.Ref.Netural[200]}`,
+    borderRight: `1px solid ${vars.color.Ref.Netural[200]}`,
+    backgroundColor: vars.color.Ref.Netural[50],
 
-  ':last-child': {
-    borderRight: 'none',
+    ':last-child': {
+      borderRight: 'none',
+    },
+
+    '::-webkit-scrollbar': {
+      display: 'none',
+    },
   },
-
-  '::-webkit-scrollbar': {
-    display: 'none',
+  variants: {
+    selected: {
+      true: {
+        ...fadeHighlightGrayProps,
+      },
+      false: {},
+    },
   },
 });

--- a/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionMemberCheckbox/index.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { useMemo } from 'react';
 
@@ -8,6 +9,7 @@ import { Group } from '@/components/Group';
 import { useGroup } from '@/hooks/useGroup';
 import { useMemberContext } from '@/pages/DiscussionPage/MemberContext';
 
+import { candidateKeys } from '../../api/keys';
 import { useDiscussionParticipantsQuery } from '../../api/queries';
 import type { DiscussionParticipantResponse } from '../../model';
 import { checkboxContainerStyle } from './index.css';
@@ -51,10 +53,14 @@ const DiscussionMemberCheckbox = () => {
     itemIds: participantsIds,
   });
 
+  const queryClient = useQueryClient();
   const members = useMemberContext();
   const handleClickSearch = async () => {
     if (!members) return;
     members.handleUpdateField('checkedList', Array.from(groupInfos.checkedList));
+    queryClient.invalidateQueries({
+      queryKey: candidateKeys.detail(params.id),
+    });
   };
       
   return (

--- a/frontend/src/features/discussion/ui/DiscussionTab/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionTab/index.tsx
@@ -22,7 +22,7 @@ const DiscussionTab = () => {
         <Tab.Item value='calendar'>캘린더로 보기</Tab.Item>
         <Tab.Item value='rank'>순위로 보기</Tab.Item>
       </Tab.List>
-      <Tab.Content value='calendar'>
+      <Tab.Content className={tabContentStyle} value='calendar'>
         <DiscussionCalendar />
       </Tab.Content>
       <Tab.Content className={tabContentStyle} value='rank'>

--- a/frontend/src/features/my-calendar/ui/CalendarCard/Card.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCard/Card.tsx
@@ -33,7 +33,7 @@ export const Card = ({
         status={status}
         title={title}
       />
-      {calendarId && <CardBottom />}
+      {calendarId && size !== 'sm' && <CardBottom />}
     </Flex>
   </div>
 );

--- a/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTable.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/CalendarTable.tsx
@@ -19,6 +19,7 @@ const CalendarTable = (
   const { tableRef, height } = useScrollToCurrentTime();
   
   const handleMouseUpAddSchedule = () => {
+    if (!time.selectedStartTime && !time.selectedEndTime) return;
     setOpen(true);
   };
   

--- a/frontend/src/theme/animation.css.ts
+++ b/frontend/src/theme/animation.css.ts
@@ -46,6 +46,21 @@ export const fadeHighlight = keyframes({
   },
 });
 
+export const fadeHighlightGray = keyframes({
+  '0%': { backgroundColor: vars.color.Ref.Netural[50] },
+  '5%': { 
+    backgroundColor: vars.color.Ref.Primary[50],         
+    boxShadow: `inset 0 0 0 0.5px ${vars.color.Ref.Primary[100]}`, 
+  },
+  '50%': { 
+    backgroundColor: vars.color.Ref.Primary[50],
+    boxShadow: `inset 0 0 0 0.5px ${vars.color.Ref.Primary[100]}`,
+  },
+  '100%': { 
+    backgroundColor: vars.color.Ref.Netural[50],
+  },
+});
+
 export const fadeTimeBar = keyframes({
   '0%': { opacity: 0 },
   '5%': { opacity: 1 },
@@ -64,6 +79,12 @@ export const fadeHighlightProps: CSSProperties = {
 
 export const fadeTimeBarProps: CSSProperties = {
   animationName: fadeTimeBar,
+  animationDuration: '2s',
+  animationFillMode: 'forwards',
+};
+
+export const fadeHighlightGrayProps: CSSProperties = {
+  animationName: fadeHighlightGray,
   animationDuration: '2s',
   animationFillMode: 'forwards',
 };


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 조율 결과를 캐싱하지 않고, [확인] 버튼을 누를 때마다 날짜와 유저 리스트가 같더라도 HTTP 요청을 날립니다.
- 리렌더링 시마다 하이라이팅 하지 않고, 선택된 날짜가 바뀌었을 때만 하이라이팅합니다.
- 일정 조율 페이지의 컨테이너 부분도 선택된 날이면 하이라이팅합니다.
- 일정 조율 페이지의 컨테이너 부분에서 끝까지 스크롤되지 않았던 문제를 해결합니다.
- Chip 컴포넌트의 호버 스타일링을 모두 제외합니다.
- 캘린더 외부에서 내부로 드래그 했을 때 팝오버를 띄우지 않습니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced calendar selection for both discussion and personal calendars with improved date highlighting.
	- Schedule popover now appears only when a valid time range is selected.
	- Discussion member interactions auto-refresh to display up-to-date participant details.
- **Style**
	- Refined chip components now feature a consistent, static appearance.
	- Calendar layouts have been adjusted with reduced height and dynamic day animations.
	- Tab styling for the calendar view has been improved for a more cohesive look.
- **Refactor**
	- Streamlined internal logic for more reliable calendar state management and data refresh flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->