### PR TITLE
[FE-Fix] 일정 확정하기 페이지 CSS 수정

### DIFF
--- a/frontend/src/features/discussion/ui/DiscussionConfirmCard/index.css.ts
+++ b/frontend/src/features/discussion/ui/DiscussionConfirmCard/index.css.ts
@@ -3,7 +3,9 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '@/theme/index.css';
 
 export const modalContainerStyle = style({
-  height: '20rem',
+  position: 'static',
+  transform: 'translate(0, 0)',
+  zIndex: 0,
 });
 
 export const modalContentsStyle = style({

--- a/frontend/src/features/discussion/ui/DiscussionConfirmCard/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionConfirmCard/index.tsx
@@ -18,32 +18,30 @@ import {
 const DiscussionConfirmCard = (
   { title, participantPictureUrls, ...badgeProps }: DiscussionConfirmResponse,
 ) => (
-  <>
-    <Modal
-      className={modalContainerStyle}
-      isOpen
-      subTitle={'확정된 일정'}
-      title={title}
-    >
-      <Modal.Contents className={modalContentsStyle}>
-        <BadgeContainer
-          endDateTime={new Date(badgeProps.sharedEventDto.endDateTime)}
-          location={badgeProps.meetingMethodOrLocation}
-          startDateTime={new Date(badgeProps.sharedEventDto.startDateTime)}
-        />
-        <Flex
-          align='center'
-          className={avatarWrapperStyle}
-          justify='flex-start'
-        >
-          <Avatar imageUrls={participantPictureUrls} size='lg' />
-        </Flex>
-      </Modal.Contents>
-      <Modal.Footer className={modalFooterStyle}>
-        <Buttons />
-      </Modal.Footer>
-    </Modal>
-  </>
+  <Modal
+    className={modalContainerStyle}
+    isOpen
+    subTitle={'확정된 일정'}
+    title={title}
+  >
+    <Modal.Contents className={modalContentsStyle}>
+      <BadgeContainer
+        endDateTime={new Date(badgeProps.sharedEventDto.endDateTime)}
+        location={badgeProps.meetingMethodOrLocation}
+        startDateTime={new Date(badgeProps.sharedEventDto.startDateTime)}
+      />
+      <Flex
+        align='center'
+        className={avatarWrapperStyle}
+        justify='flex-start'
+      >
+        <Avatar imageUrls={participantPictureUrls} size='lg' />
+      </Flex>
+    </Modal.Contents>
+    <Modal.Footer className={modalFooterStyle}>
+      <Buttons />
+    </Modal.Footer>
+  </Modal>
 );
 
 const Buttons = () => (

--- a/frontend/src/pages/DiscussionPage/DiscussionConfirmPage/index.css.ts
+++ b/frontend/src/pages/DiscussionPage/DiscussionConfirmPage/index.css.ts
@@ -2,20 +2,13 @@ import { style } from '@vanilla-extract/css';
 
 import { vars } from '@/theme/index.css';
 
-export const backdropStyle = style({
-  position: 'absolute',
+export const containerStyle = style({
+  position: 'fixed',
   top: 0,
   left: 0,
   bottom: 0,
   right: 0,
   backgroundColor: vars.color.Ref.Netural[50], 
-});
-
-export const containerStyle = style({
-  position: 'fixed',
-  transform: 'translate(-50%, -58%)',
-  top: '50%',
-  left: '50%',
 });
 
 export const titleStyle = style({

--- a/frontend/src/pages/DiscussionPage/DiscussionConfirmPage/index.tsx
+++ b/frontend/src/pages/DiscussionPage/DiscussionConfirmPage/index.tsx
@@ -5,31 +5,28 @@ import type { DiscussionConfirmResponse } from '@/features/discussion/model';
 import DiscussionConfirmCard from '@/features/discussion/ui/DiscussionConfirmCard';
 import { vars } from '@/theme/index.css';
 
-import { backdropStyle, containerStyle, subtitleStyle, titleStyle } from './index.css';
+import { containerStyle, subtitleStyle, titleStyle } from './index.css';
 
 const DiscussionConfirmPage = ({ confirm }: { confirm: DiscussionConfirmResponse }) => (
-  <>
-    <div className={backdropStyle} />
-    <Flex
-      align='center'
-      className={containerStyle}
-      direction='column'
-      justify='center'
+  <Flex
+    align='center'
+    className={containerStyle}
+    direction='column'
+    justify='center'
+  >
+    <Text className={titleStyle}typo='h3'>일정이 확정되었어요!</Text>
+    <Text color={vars.color.Ref.Netural[600]} typo='b2M'>
+      일정 조율이 완료되었습니다.
+    </Text>
+    <Text
+      className={subtitleStyle}
+      color={vars.color.Ref.Netural[600]}
+      typo='b2M'
     >
-      <Text className={titleStyle}typo='h3'>일정이 확정되었어요!</Text>
-      <Text color={vars.color.Ref.Netural[600]} typo='b2M'>
-        일정 조율이 완료되었습니다.
-      </Text>
-      <Text
-        className={subtitleStyle}
-        color={vars.color.Ref.Netural[600]}
-        typo='b2M'
-      >
-        참여한 모든 인원의 개인 캘린더에 확정된 일정이 추가되었어요.
-      </Text>
-      <DiscussionConfirmCard {...confirm} />
-    </Flex>
-  </>
+      참여한 모든 인원의 개인 캘린더에 확정된 일정이 추가되었어요.
+    </Text>
+    <DiscussionConfirmCard {...confirm} />
+  </Flex>
 );
 
 export default DiscussionConfirmPage;


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

확정하기 페이지 백드랍 부분 삭제하고, 모달에 포지션을 없애줘서 디자인대로 렌더링되도록 수정했습니다.
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/2e91ef0a-7d06-421e-938e-61c467d99f86" />


## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the modal and page layouts to provide a more consistent and clear display across the discussion confirmation views.
  
- **Refactor**
  - Streamlined the interface by removing unnecessary wrappers and backdrops, simplifying the overall component structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->