### PR TITLE
[FE-Fix] 마감기한을 잘못 계산하던 문제, 다가오는일정 세부 타임라인 화면에서 실제보다 달이 1 적게 출력되던 문제 수정

### DIFF
--- a/frontend/src/features/discussion/ui/DiscussionConfirmButton/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionConfirmButton/index.tsx
@@ -11,7 +11,7 @@ import type { DiscussionDTO } from '../../model';
 const DiscussionConfirmButton = (
   { startDateTime, endDateTime }: Omit<DiscussionDTO, 'usersForAdjust'>,
 ) => {
-  const param: { id: string } = useParams({ from: '/_main/discussion/$id' });
+  const param: { id: string } = useParams({ from: '/_main/discussion/candidate/$id' });
   const { isHost, isPending } = useDiscussionHostQuery(param.id);
   const { mutate } = useDiscussionConfirmMutation();
   const queryClient = useQueryClient();

--- a/frontend/src/features/discussion/ui/DiscussionConfirmButton/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionConfirmButton/index.tsx
@@ -1,6 +1,8 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 
 import Button from '@/components/Button';
+import { ongoingQueryKey, upcomingQueryKey } from '@/features/shared-schedule/api/keys';
 
 import { useDiscussionConfirmMutation } from '../../api/mutations';
 import { useDiscussionHostQuery } from '../../api/queries';
@@ -12,11 +14,14 @@ const DiscussionConfirmButton = (
   const param: { id: string } = useParams({ from: '/_main/discussion/$id' });
   const { isHost, isPending } = useDiscussionHostQuery(param.id);
   const { mutate } = useDiscussionConfirmMutation();
+  const queryClient = useQueryClient();
 
   if (isPending || !isHost) return null;
   
   const handleClickConfirm = () => {
     if (!param.id) return;
+    queryClient.invalidateQueries({ queryKey: upcomingQueryKey });
+    queryClient.invalidateQueries({ queryKey: ongoingQueryKey.all });
     mutate({
       id: param.id, 
       body: { startDateTime, endDateTime }, 

--- a/frontend/src/features/shared-schedule/ui/OngoingSchedules/OngoingScheduleListItem.tsx
+++ b/frontend/src/features/shared-schedule/ui/OngoingSchedules/OngoingScheduleListItem.tsx
@@ -3,7 +3,8 @@ import Avatar from '@/components/Avatar';
 import { Flex } from '@/components/Flex';
 import { Text } from '@/components/Text';
 import { vars } from '@/theme/index.css';
-import { getDateRangeString } from '@/utils/date';
+import { getDateRangeString, getTimeLeftInfoFromMilliseconds } from '@/utils/date';
+import { formatTimeToDeadlineString } from '@/utils/date/format';
 
 import type { OngoingSchedule } from '../../model';
 import {
@@ -35,10 +36,7 @@ const OngoingScheduleListItem = ({
     >
       <span className={updateIndicatorStyle({ isUpdated })} />
       <Text typo='t2'>{schedule.title}</Text>
-      {/* {isUpdated && 
-      <Text color={vars.color.Ref.Primary[600]} typo='b3M'>
-        일정을 업데이트한 사람이 있어요!
-      </Text>} */}
+      <Deadline timeLeft={schedule.timeLeft} />
     </Flex>
     <Flex
       align='center'
@@ -55,5 +53,19 @@ const OngoingScheduleListItem = ({
     </Flex>
   </div>
 );
+
+const Deadline = ({ timeLeft }: { timeLeft: number }) => {
+  const timeLeftInfo = getTimeLeftInfoFromMilliseconds(timeLeft);
+  if (timeLeftInfo.days > 3) return null;
+  const isExpired = timeLeft < 0;
+  return (
+    <Text color={vars.color.Ref.Red[500]} typo='b3M'>
+      {isExpired ? 
+        `마감 기한이 ${formatTimeToDeadlineString(timeLeftInfo)} 지났어요`
+        : 
+        `마감 기한까지 ${formatTimeToDeadlineString(timeLeftInfo)} 남았어요!`}
+    </Text>
+  );
+};
 
 export default OngoingScheduleListItem;

--- a/frontend/src/features/shared-schedule/ui/OngoingSchedules/ScheduleDetails.tsx
+++ b/frontend/src/features/shared-schedule/ui/OngoingSchedules/ScheduleDetails.tsx
@@ -100,7 +100,6 @@ const ScheduleInfo = ({ discussion }: {
   );
 };
 
-// TODO: d-day일 경우도 분기 처리 ?
 const Deadline = ({ timeLeft }: { timeLeft: number }) => {
   const timeLeftInfo = getTimeLeftInfoFromMilliseconds(timeLeft);
   const isExpired = timeLeft < 0;

--- a/frontend/src/features/shared-schedule/ui/OngoingSchedules/ScheduleDetails.tsx
+++ b/frontend/src/features/shared-schedule/ui/OngoingSchedules/ScheduleDetails.tsx
@@ -11,8 +11,11 @@ import {
 import type { DiscussionResponse } from '@/features/discussion/model';
 import { useClipboard } from '@/hooks/useClipboard';
 import { vars } from '@/theme/index.css';
-import { getDateRangeString } from '@/utils/date';
-import { formatMinutesToTimeDuration } from '@/utils/date/format';
+import { 
+  getDateRangeString,
+  getTimeLeftInfoFromMilliseconds, 
+} from '@/utils/date';
+import { formatMinutesToTimeDuration, formatTimeToDeadlineString } from '@/utils/date/format';
 
 import RecommendedSchedules from './RecommendedSchedules';
 import {
@@ -97,13 +100,16 @@ const ScheduleInfo = ({ discussion }: {
   );
 };
 
-// TODO: 계산로직 util로 분리
 // TODO: d-day일 경우도 분기 처리 ?
 const Deadline = ({ timeLeft }: { timeLeft: number }) => {
-  const daysLeft = Math.floor(timeLeft / (1000 * 60 * 60 * 24));
+  const timeLeftInfo = getTimeLeftInfoFromMilliseconds(timeLeft);
+  const isExpired = timeLeft < 0;
   return (
     <Text color={vars.color.Ref.Red[500]} typo='b3M'>
-      {daysLeft >= 0 ? `마감까지 ${daysLeft}일` : `마감일로부터 ${daysLeft}일 지났어요`}
+      {isExpired ? 
+        `마감일로부터 ${formatTimeToDeadlineString(timeLeftInfo)} 지났어요`
+        : 
+        `마감까지 ${formatTimeToDeadlineString(timeLeftInfo)}`}
     </Text>
   );
 };

--- a/frontend/src/features/shared-schedule/ui/OngoingSchedules/ScheduleDetails.tsx
+++ b/frontend/src/features/shared-schedule/ui/OngoingSchedules/ScheduleDetails.tsx
@@ -11,7 +11,7 @@ import {
 import type { DiscussionResponse } from '@/features/discussion/model';
 import { useClipboard } from '@/hooks/useClipboard';
 import { vars } from '@/theme/index.css';
-import { getDateRangeString, getDday } from '@/utils/date';
+import { getDateRangeString } from '@/utils/date';
 import { formatMinutesToTimeDuration } from '@/utils/date/format';
 
 import RecommendedSchedules from './RecommendedSchedules';
@@ -78,9 +78,7 @@ const ScheduleInfo = ({ discussion }: {
       justify='flex-start'
       width='full'
     >
-      <Text color={vars.color.Ref.Red[500]} typo='b3M'>
-        {`마감까지 ${getDday(new Date(rangeEnd))}일`}
-      </Text>
+      <Deadline timeLeft={discussion.timeLeft} />
       <Text typo='h3'>{title}</Text>
       <Flex
         className={subTextContainerStyle}
@@ -96,6 +94,17 @@ const ScheduleInfo = ({ discussion }: {
         </Text>
       </Flex>
     </Flex>
+  );
+};
+
+// TODO: 계산로직 util로 분리
+// TODO: d-day일 경우도 분기 처리 ?
+const Deadline = ({ timeLeft }: { timeLeft: number }) => {
+  const daysLeft = Math.floor(timeLeft / (1000 * 60 * 60 * 24));
+  return (
+    <Text color={vars.color.Ref.Red[500]} typo='b3M'>
+      {daysLeft >= 0 ? `마감까지 ${daysLeft}일` : `마감일로부터 ${daysLeft}일 지났어요`}
+    </Text>
   );
 };
 

--- a/frontend/src/pages/CandidateSchedulePage/Header.tsx
+++ b/frontend/src/pages/CandidateSchedulePage/Header.tsx
@@ -1,57 +1,34 @@
-import { useQueryClient } from '@tanstack/react-query';
 
-import Button from '@/components/Button';
 import { Flex } from '@/components/Flex';
 import { Text } from '@/components/Text';
-import { useDiscussionConfirmMutation } from '@/features/discussion/api/mutations';
-import { ongoingQueryKey, upcomingQueryKey } from '@/features/shared-schedule/api/keys';
+import DiscussionConfirmButton from '@/features/discussion/ui/DiscussionConfirmButton';
 import { vars } from '@/theme/index.css';
-import { formatDateToDateTimeString, formatTimeToColonString } from '@/utils/date/format';
+import { formatTimeToColonString } from '@/utils/date/format';
 
 interface HeaderProps {
   adjustCount: number;
   discussionId: number;
-  startDateTime: Date;
-  endDateTime: Date;
+  startDateTime: string;
+  endDateTime: string;
 }
 
-const Header = ({ adjustCount, discussionId, startDateTime, endDateTime }: HeaderProps) => {
-  const { mutate } = useDiscussionConfirmMutation();
-  const queryClient = useQueryClient();
-
-  return(
-    <Flex
-      align='center'
-      justify='space-between'
-      width='full'
-    >
-      <HeaderTextInfo
-        adjustCount={adjustCount}
-        endTime={endDateTime}
-        startTime={startDateTime}
-      />
-      <Flex align='center' gap={200}>
-        {/* TODO: date 관리 방식 통합 (string OR Date) */}
-        <Button
-          onClick={() => {
-            mutate({
-              id: discussionId.toString(), 
-              body: { 
-                startDateTime: formatDateToDateTimeString(startDateTime),
-                endDateTime: formatDateToDateTimeString(endDateTime),
-              },
-            });
-            queryClient.invalidateQueries({ queryKey: upcomingQueryKey });
-            queryClient.invalidateQueries({ queryKey: ongoingQueryKey.all });
-          }}
-          size='lg'
-        >
-          일정 확정하기
-        </Button>
-      </Flex>
+const Header = ({ adjustCount, startDateTime, endDateTime }: HeaderProps) => (
+  <Flex
+    align='center'
+    justify='space-between'
+    width='full'
+  >
+    <HeaderTextInfo
+      adjustCount={adjustCount}
+      endTime={new Date(endDateTime)}
+      startTime={new Date(startDateTime)}
+    />
+    <Flex align='center' gap={200}>
+      {/* TODO: date 관리 방식 통합 (string OR Date) */}
+      <DiscussionConfirmButton endDateTime={endDateTime} startDateTime={startDateTime} />
     </Flex>
-  ); 
-};
+  </Flex>
+);
 
 const HeaderTextInfo = ({ adjustCount, startTime, endTime }: {
   adjustCount: number;

--- a/frontend/src/pages/CandidateSchedulePage/index.tsx
+++ b/frontend/src/pages/CandidateSchedulePage/index.tsx
@@ -12,7 +12,6 @@ const CandidateSchedulePage = (candidate: {
   selectedParticipantIds?: number[];
 }) => {
   const { id } = useParams({ from: '/_main/discussion/candidate/$id' });
-  const [start, end] = [new Date(candidate.startDateTime), new Date(candidate.endDateTime)];
 
   return (
     <>
@@ -27,8 +26,8 @@ const CandidateSchedulePage = (candidate: {
           <Header
             adjustCount={candidate.adjustCount}
             discussionId={Number(id)}
-            endDateTime={end}
-            startDateTime={start}
+            endDateTime={candidate.endDateTime}
+            startDateTime={candidate.startDateTime}
           />
         </TimelineScheduleModal.Header>
       </TimelineScheduleModal>

--- a/frontend/src/pages/UpcomingScheduleDetailPage/Header.tsx
+++ b/frontend/src/pages/UpcomingScheduleDetailPage/Header.tsx
@@ -39,6 +39,7 @@ const HeaderTextInfo = ({ startDateTime, endDateTime }: {
   startDateTime: Date;
   endDateTime: Date;
 }) => {
+// TODO: format 메서드 통합하기
   const { month, day } = getDateParts(startDateTime);
   return (
     <Flex
@@ -47,7 +48,7 @@ const HeaderTextInfo = ({ startDateTime, endDateTime }: {
     >
       <span>
         <Text color={vars.color.Ref.Primary[500]} typo='t1'>
-          {`${month}월 ${day}일`}
+          {`${month + 1}월 ${day}일`}
         </Text>
       </span>
       <Text typo='h2'>

--- a/frontend/src/routes/_main/home/index.tsx
+++ b/frontend/src/routes/_main/home/index.tsx
@@ -13,6 +13,7 @@ const Home = () => (
     <HomePage />
   </>
 );
+
 export const Route = createFileRoute('/_main/home/')({
   loader: async ({
     context: { queryClient },

--- a/frontend/src/utils/date/date.ts
+++ b/frontend/src/utils/date/date.ts
@@ -1,6 +1,6 @@
 import { WEEK_MAP } from '@/constants/date';
 
-import { getTimeParts } from './time';
+import { getTimeParts, HOUR_IN_MILLISECONDS, MINUTE_IN_MILLISECONDS } from './time';
 
 export const DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
 
@@ -246,4 +246,15 @@ export const getDday = (date: Date): number => {
   const today = new Date();
   const diff = date.getTime() - today.getTime();
   return Math.floor(diff / DAY_IN_MILLISECONDS);
+};
+
+export const getTimeLeftInfoFromMilliseconds = (milliseconds: number) => {
+  const days = Math.floor(milliseconds / DAY_IN_MILLISECONDS);
+  const remainingAfterDays = milliseconds % DAY_IN_MILLISECONDS;
+
+  const hours = Math.floor(remainingAfterDays / HOUR_IN_MILLISECONDS);
+  const remainingAfterHours = remainingAfterDays % HOUR_IN_MILLISECONDS;
+  const minutes = Math.floor(remainingAfterHours / MINUTE_IN_MILLISECONDS);
+
+  return { days, hours, minutes };
 };

--- a/frontend/src/utils/date/format.ts
+++ b/frontend/src/utils/date/format.ts
@@ -105,3 +105,13 @@ export const formatDateToDdayString = (date: Date): string => {
 
 export const getDowString = (date: Date): string => 
   date.toLocaleString('ko-KR', { weekday: 'short' });
+
+export const formatTimeToDeadlineString = ({ days, hours, minutes }: {
+  days: number;
+  hours: number;
+  minutes: number;
+}): string => {
+  if (days !== 0) return `${days}일`;
+  if (hours !== 0) return `${hours}시간`;
+  return `${minutes}분`;
+};

--- a/frontend/src/utils/date/time.ts
+++ b/frontend/src/utils/date/time.ts
@@ -1,5 +1,5 @@
 export const HOUR = 60;
-const HOUR_IN_MILLISECONDS = 1000 * 60 * 60;
+export const HOUR_IN_MILLISECONDS = 1000 * 60 * 60;
 export const MINUTE_IN_MILLISECONDS = 60000;
 
 export const formatDateToTimeString = (date: Date | null): string => {


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 마감기한을 잘못 계산하던 문제 수정
- 다가오는일정 세부 타임라인 화면에서 실제보다 달이 1 적게 출력되던 문제 수정

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `Deadline` component for enhanced deadline display, showing time remaining or elapsed.
  - Added query invalidation logic to the `DiscussionConfirmButton` for improved data refresh upon discussion confirmation.
- **Bug Fixes**
  - Updated the schedule detail header to correctly display the month by adjusting the displayed value.
- **Refactor**
  - Simplified the `Header` component in the `CandidateSchedulePage` by removing direct mutation logic and introducing a dedicated button component.
  - Streamlined date handling in the `CandidateSchedulePage` by passing string values directly to the `Header` component.
- **New Utilities**
  - Added functions for calculating time left from milliseconds and formatting time to deadline strings.
- **Chores**
  - Changed visibility of the `HOUR_IN_MILLISECONDS` constant to be accessible across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->