### PR TITLE
[FE-Fix] 랭크뷰에서의 조정해야 할 유저 수 처리, 노티피케이션 CSS

### DIFF
--- a/frontend/src/components/Notification/index.css.ts
+++ b/frontend/src/components/Notification/index.css.ts
@@ -53,4 +53,5 @@ export const notificationsStyle = style({
 
   position: 'fixed',
   top: 'calc(56px + 3rem)',
+  zIndex: 9999,
 });

--- a/frontend/src/features/discussion/ui/DiscussionCard/DiscussionLarge.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionCard/DiscussionLarge.tsx
@@ -11,8 +11,11 @@ const formatUserListToString = (users: DiscussionDTO['usersForAdjust']) => {
   const ADJUSTMENT_LENGTH = users.length;
   if (ADJUSTMENT_LENGTH === 0) return '조율이 필요하지 않아요';
 
-  const userNames = users.map((user) => user.name).join(' · ');
-  return `${userNames} 외 ${ADJUSTMENT_LENGTH}명`;
+  const userNameList = users.map((user) => user.name).slice(0, 3);
+  const userNames = userNameList.join(', ');
+
+  if (ADJUSTMENT_LENGTH <= 3) return userNames;
+  return `${userNames} 외 ${ADJUSTMENT_LENGTH - userNameList.length}명`;
 };
 
 const DiscussionContents = (


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 랭크뷰에서 조정해야 할 유저는 3명까지 노출, 그 외는 "외 N명" 으로 표시합니다.
- 노티피케이션을 최상위에서 렌더링하도록 합니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted notification layering so alerts consistently appear above other page elements.
  
- **New Features**
  - Enhanced discussion card display by limiting user name listings to three, with an indicator showing additional user count when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->