### PR TITLE
[FE-Fix] 초대 모달 CSS 삭제

### DIFF
--- a/frontend/src/features/discussion/ui/DiscussionInviteCard/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionInviteCard/index.tsx
@@ -10,7 +10,6 @@ import { vars } from '@/theme/index.css';
 import type { Time } from '@/utils/date';
 
 import { useInvitationJoinMutation } from '../../api/mutations';
-import { modalContainerStyle } from '../DiscussionConfirmCard/index.css';
 import Badges from './Badges';
 import {
   inputStyle,
@@ -57,7 +56,6 @@ const DiscussionInviteCard = ({
 
   return (
     <Modal
-      className={modalContainerStyle}
       isOpen
       subTitle={`${hostName}님이 일정 조율에 초대했어요!`}
       title={title}


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
초대 모달에서 사용하고 있던 클래스를 삭제합니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the visual appearance of the discussion invite modal for a streamlined look. The change may alter how the modal is styled, enhancing UI consistency while keeping core functionality intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->