### PR TITLE
[BE-Fix] 스케줄러 실행 시간 기준을 KST로 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/global/scheduler/DiscussionStatusScheduler.java
+++ b/backend/src/main/java/endolphin/backend/global/scheduler/DiscussionStatusScheduler.java
@@ -5,6 +5,7 @@ import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.shared_event.SharedEventService;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +23,9 @@ public class DiscussionStatusScheduler {
     private final SharedEventService sharedEventService;
 
     @Transactional
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void updateDiscussionStatusAtMidnight() {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         log.info("Scheduler 실행: {}. 논의 상태 업데이트 시작", today);
 
         List<Discussion> discussions = discussionRepository.findByDiscussionStatusNot(


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 기존 코드가 UTC 기준으로 수행되고 있어 한국 시간대로 명시적으로 실행시키도록 수정했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Discussion status updates now adhere to the local Asia/Seoul time zone. This improvement ensures that automatic updates occur precisely at midnight local time, providing more predictable and reliable status transitions. Users will notice that discussions are updated seamlessly in line with expected local timings, ensuring a smoother and more cohesive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->