### PR TITLE
[BE-Fix] 비트맵 삭제되지 않는 버그 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventRepository.java
@@ -42,8 +42,8 @@ public interface PersonalEventRepository extends JpaRepository<PersonalEvent, Lo
     @Query("SELECT COUNT(p) "
         + "FROM PersonalEvent p "
         + "WHERE p.user.id = :userId "
-        + "AND p.startTime <= :endDateTime "
-        + "AND p.endTime >= :startDateTime")
+        + "AND p.startTime < :endDateTime "
+        + "AND p.endTime > :startDateTime")
     Long countByUserIdAndDateTimeRange(
         @Param("userId") Long userId,
         @Param("startDateTime") LocalDateTime start,


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #105 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 비트를 0으로 만들 때 해당 비트에 일정이 2개가 있는 경우 0으로 바꾸지 않아야 합니다. 이 때 특정 기간동안 일정이 몇개인지 확인하는 데에서 등호때문에 실제 개수보다 1개 더 많다고 확인되는 문제가 있었습니다. 
- 그래서 등호를 제거하여 해당 문제를 해결하였습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted event filtering so that events now use strict start and end time criteria. This change enhances the accuracy of event counts and may affect how events scheduled at boundary times are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->