### PR TITLE
[FE-Feat] 초대장 페이지 OG태그 설정

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.66.0",
-    "@tanstack/react-router": "^1.99.0",
+    "@tanstack/react-router": "^1.109.2",
     "@vanilla-extract/css": "^1.17.0",
     "@vanilla-extract/dynamic": "^2.1.2",
     "@vanilla-extract/recipes": "^0.5.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^5.66.0
         version: 5.66.0(react@19.0.0)
       '@tanstack/react-router':
-        specifier: ^1.99.0
-        version: 1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^1.109.2
+        version: 1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@vanilla-extract/css':
         specifier: ^1.17.0
         version: 1.17.1
@@ -71,10 +71,10 @@ importers:
         version: 5.66.1(eslint@9.19.0)(typescript@5.6.3)
       '@tanstack/router-devtools':
         specifier: ^1.99.0
-        version: 1.99.0(@tanstack/react-router@1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(csstype@3.1.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 1.99.0(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(csstype@3.1.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/router-plugin':
         specifier: ^1.99.3
-        version: 1.99.3(@tanstack/react-router@1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.0.11(@types/node@22.12.0)(tsx@4.19.2))
+        version: 1.99.3(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.0.11(@types/node@22.12.0)(tsx@4.19.2))
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -1069,8 +1069,8 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
-  '@tanstack/history@1.99.0':
-    resolution: {integrity: sha512-MQS1Lg8D+1vpasEJKf4zs1sxhxbXcoejmVCZDbo0bq2wq+xVK+kRixj5Pae2kb2APzdXYga4u236GBbgCKTcnQ==}
+  '@tanstack/history@1.99.13':
+    resolution: {integrity: sha512-JMd7USmnp8zV8BRGIjALqzPxazvKtQ7PGXQC7n39HpbqdsmfV2ePCzieO84IvN+mwsTrXErpbjI4BfKCa+ZNCg==}
     engines: {node: '>=12'}
 
   '@tanstack/query-core@5.66.0':
@@ -1081,8 +1081,8 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-router@1.99.0':
-    resolution: {integrity: sha512-MwKQxckJMdxpYwpZsItM1SCodcAKu1bqWha2s2d5/Iy1F/9XzqT8gZXpZW5fvC7+21YOuwMxvJmwbSPkpVeWRw==}
+  '@tanstack/react-router@1.109.2':
+    resolution: {integrity: sha512-cJZGIvYIrd5lcwbwoB2vxJe379TQZIM5/RAzlDSrvV5KAPlkmK3cqZHZ8zPrsZIBASEyERM8Od+jM9s3qDTXkA==}
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
@@ -1094,8 +1094,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/router-core@1.99.0':
-    resolution: {integrity: sha512-/9HMagUilxdjHNfgZaRSjyMvuJ+BL8/IXLTN9NtbXOJZvB2q4Vu0GIWZJfwMiz9czXqdQ/NxtPxeG/b+YTnUOg==}
+  '@tanstack/router-core@1.108.0':
+    resolution: {integrity: sha512-lo6Nqdp8gxWNZ8YZ6UhiQgR0CgcAiMaw1cxgKK7M4u3nFFwqW7Hzycl5ik1l3NRh5/pQVK+OVzlKok5rrrHxSg==}
     engines: {node: '>=12'}
 
   '@tanstack/router-devtools@1.99.0':
@@ -4073,7 +4073,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tanstack/history@1.99.0': {}
+  '@tanstack/history@1.99.13': {}
 
   '@tanstack/query-core@5.66.0': {}
 
@@ -4082,11 +4082,11 @@ snapshots:
       '@tanstack/query-core': 5.66.0
       react: 19.0.0
 
-  '@tanstack/react-router@1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@tanstack/history': 1.99.0
+      '@tanstack/history': 1.99.13
       '@tanstack/react-store': 0.7.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@tanstack/router-core': 1.99.0
+      '@tanstack/router-core': 1.108.0
       jsesc: 3.1.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -4100,14 +4100,14 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       use-sync-external-store: 1.4.0(react@19.0.0)
 
-  '@tanstack/router-core@1.99.0':
+  '@tanstack/router-core@1.108.0':
     dependencies:
-      '@tanstack/history': 1.99.0
+      '@tanstack/history': 1.99.13
       '@tanstack/store': 0.7.0
 
-  '@tanstack/router-devtools@1.99.0(@tanstack/react-router@1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(csstype@3.1.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@tanstack/router-devtools@1.99.0(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(csstype@3.1.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@tanstack/react-router': 1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@tanstack/react-router': 1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       clsx: 2.1.1
       goober: 2.1.16(csstype@3.1.3)
       react: 19.0.0
@@ -4115,16 +4115,16 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/router-generator@1.99.0(@tanstack/react-router@1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@tanstack/router-generator@1.99.0(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@tanstack/virtual-file-routes': 1.99.0
       prettier: 3.4.2
       tsx: 4.19.2
       zod: 3.24.1
     optionalDependencies:
-      '@tanstack/react-router': 1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@tanstack/react-router': 1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
-  '@tanstack/router-plugin@1.99.3(@tanstack/react-router@1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.0.11(@types/node@22.12.0)(tsx@4.19.2))':
+  '@tanstack/router-plugin@1.99.3(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.0.11(@types/node@22.12.0)(tsx@4.19.2))':
     dependencies:
       '@babel/core': 7.26.7
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.7)
@@ -4132,7 +4132,7 @@ snapshots:
       '@babel/template': 7.25.9
       '@babel/traverse': 7.26.7
       '@babel/types': 7.26.7
-      '@tanstack/router-generator': 1.99.0(@tanstack/react-router@1.99.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@tanstack/router-generator': 1.99.0(@tanstack/react-router@1.109.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@tanstack/router-utils': 1.99.3
       '@tanstack/virtual-file-routes': 1.99.0
       '@types/babel__core': 7.20.5

--- a/frontend/src/pages/DiscussionPage/DiscussionInvitePage/index.tsx
+++ b/frontend/src/pages/DiscussionPage/DiscussionInvitePage/index.tsx
@@ -1,13 +1,11 @@
-import { useInviteInfoQuery } from '@/features/discussion/api/queries';
+import { useParams } from '@tanstack/react-router';
+
+import type { InviteResponse } from '@/features/discussion/model/invitation';
 import DiscussionInviteCard from '@/features/discussion/ui/DiscussionInviteCard';
 
-const DiscussionInvitePage = ({ discussionId }:
-{ discussionId: number },
-) => {
-  const { data, isPending } = useInviteInfoQuery(discussionId);
+const DiscussionInvitePage = ({ invitation }: { invitation: InviteResponse }) => {
+  const { id } = useParams({ from: '/_main/discussion/invite/$id' });
 
-  if (isPending) return <div>Loading...</div>;
-  if (!data) return <div>response contains no data</div>;
   const {
     host,
     title,
@@ -18,13 +16,13 @@ const DiscussionInvitePage = ({ discussionId }:
     duration,
     isFull,
     requirePassword,
-  } = data;
+  } = invitation;
 
   return (
     <DiscussionInviteCard 
       canJoin={!isFull}
       dateRange={{ start: dateRangeStart, end: dateRangeEnd }}
-      discussionId={discussionId}
+      discussionId={+id}
       hostName={host}
       meetingDuration={duration}
       requirePassword={requirePassword}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,8 +1,8 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { 
   createRootRouteWithContext, 
-  Outlet, 
-} from '@tanstack/react-router';
+  HeadContent,
+  Outlet } from '@tanstack/react-router';
 import { lazy } from 'react';
 
 import { defaultENV } from '@/envconfig';
@@ -25,6 +25,7 @@ const TanStackRouterDevtools =
 export const Route = createRootRouteWithContext<QueryClientContext>()({
   component: () => (
     <>
+      <HeadContent />
       <Outlet />
       <TanStackRouterDevtools />
     </>
@@ -35,4 +36,15 @@ export const Route = createRootRouteWithContext<QueryClientContext>()({
       <ErrorPage />
     </>
   ),
+  head: () => ({
+    meta: [
+      {
+        title: '언제만나',
+      },
+      { 
+        name: 'description', 
+        content: '당신과 모두의 일정을 하나로 연결해 가장 완벽한 약속 시간을 찾아드려요\n당신과 모두의 시간을 위해, 지금 바로 시작하세요.', 
+      },
+    ],
+  }),
 });

--- a/frontend/src/routes/_main/discussion/invite/$id.tsx
+++ b/frontend/src/routes/_main/discussion/invite/$id.tsx
@@ -1,21 +1,51 @@
-import { createFileRoute, useParams } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 
+import { invitationQueryOption } from '@/features/discussion/api/queryOptions';
 import GlobalNavBar from '@/layout/GlobalNavBar';
 import DiscussionInvitePage from '@/pages/DiscussionPage/DiscussionInvitePage';
 
 const DiscussionInvite = () => {
-  const { id } = useParams({ from: '/_main/discussion/invite/$id' });
+  const { invitation } = Route.useLoaderData();
   return  (
     <>
       <GlobalNavBar>
         <GlobalNavBar.MyCalendarLink />
         <GlobalNavBar.NewDiscussionLink />
       </GlobalNavBar>
-      <DiscussionInvitePage discussionId={Number(id)} />
+      <DiscussionInvitePage invitation={invitation} />
     </>
   );
 };
 
 export const Route = createFileRoute('/_main/discussion/invite/$id')({
+  loader: async ({ params: { id }, context }) => {
+    const invitation = await context.queryClient.fetchQuery(invitationQueryOption(Number(id)));
+    return { invitation };
+  },
   component: DiscussionInvite,
+  head: ({ loaderData }) => ({
+    meta: [
+      {
+        title: `언제만나 - ${loaderData.invitation.host}님의 초대장`,
+      },
+      {
+        name: 'og:title',
+        content: `언제만나 - ${loaderData.invitation.host}님의 초대장`,
+      },
+      { 
+        name: 'description', 
+        content: 
+        `${loaderData.invitation.title} 일정에 ${loaderData.invitation.host}님이 초대했어요.\n지금 참여해 보세요!🗓️`, 
+      },
+      { 
+        name: 'og:description', 
+        content: 
+        `${loaderData.invitation.title} 일정에 ${loaderData.invitation.host}님이 초대했어요.\n지금 참여해 보세요!🗓️`, 
+      },
+      {
+        name: 'og:image',
+        content: '/images/assets/calendar.webp',
+      },
+    ],
+  }),
 });


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #268 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 초대장만을 위해 SSR을 도입하는 것은 시간이 부족하기도 하고, 비효율적이라고 생각되어 다른 방법들을 알아보게 되었습니다.
- https://www.npmjs.com/package/react-helmet-async 이런 라이브러리도 있었지만, 최대한 존재하는 라이브러리에서 기능을 찾아보다가 `tanstack router`가 정말 얼마 전에 새 기능을 업데이트했다는 것을 알게 되었고 도입했습니다. ([이 디스커션](https://github.com/TanStack/router/discussions/1056) 보다가 알게 되었어요.)
- 초대장 페이지 `loader`에서 데이터 가져오도록 수정
- 초대장 페이지 OG태그 설정

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 헤더를 세팅해주는 부분이 업데이트되어 `tanstack router` 버전업했습니다. 설치해주세요!