### PR TITLE
[FE-Fix] 딤처리 레이아웃 문제, 다가오는 일정 모두보기 버튼, Date Picker 문제 해결

### DIFF
--- a/frontend/src/components/Calendar/context/SharedCalendarContext.ts
+++ b/frontend/src/components/Calendar/context/SharedCalendarContext.ts
@@ -7,6 +7,9 @@ export interface CalendarSharedInfo {
   selectedWeek: Date[];
   handleSelectDate: (date: Date) => void;
   today: Date;
+  baseDate: Date;
+  gotoPrevMonth: () => void;
+  gotoNextMonth: () => void;
 }
 
 export const SharedCalendarContext = createContext<CalendarSharedInfo | null>(null);

--- a/frontend/src/components/DatePicker/DatePicker.stories.tsx
+++ b/frontend/src/components/DatePicker/DatePicker.stories.tsx
@@ -52,6 +52,7 @@ export const InjectedContainerStyle = () => {
 export const Range = () => {
   const { setBaseDate, ...monthNavigation } = useMonthNavigation();
   const highlightProps = useHighlightRange();
+
   return (
     <DatePicker.Range
       {...monthNavigation}

--- a/frontend/src/components/DatePicker/DatePicker.stories.tsx
+++ b/frontend/src/components/DatePicker/DatePicker.stories.tsx
@@ -18,7 +18,7 @@ const meta = {
 export default meta;
 
 export const Default = () => {
-  const { setBaseDate, ...monthNavigation } = useMonthNavigation();
+  const monthNavigation = useMonthNavigation();
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   
   return (
@@ -31,7 +31,7 @@ export const Default = () => {
 };
 
 export const InjectedContainerStyle = () => {
-  const { setBaseDate, ...monthNavigation } = useMonthNavigation();
+  const monthNavigation = useMonthNavigation();
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   
   // width: 228
@@ -50,7 +50,7 @@ export const InjectedContainerStyle = () => {
 };
 
 export const Range = () => {
-  const { setBaseDate, ...monthNavigation } = useMonthNavigation();
+  const monthNavigation = useMonthNavigation();
   const highlightProps = useHighlightRange();
 
   return (
@@ -62,7 +62,7 @@ export const Range = () => {
 };
 
 export const RangeWithTrigger = () => {
-  const { setBaseDate, ...monthNavigation } = useMonthNavigation();
+  const monthNavigation = useMonthNavigation();
   const highlightProps = useHighlightRange();
 
   return (

--- a/frontend/src/components/DatePicker/DatePickerSelect.tsx
+++ b/frontend/src/components/DatePicker/DatePickerSelect.tsx
@@ -13,6 +13,9 @@ export interface DatePickerSelectProps extends CommonDatePickerProps {
   selectedDate: Date | null;
   handleDateSelect: (date: Date) => void;
 }
+
+// TODO: 리팩터링
+// 현재 커스텀 훅 계층 구조가 복잡하게 꼬여 있음.. 설계 다시 짜봐야 할 듯
 const DatePickerSelect = ({ 
   className, selectedDate, trigger, ...props 
 }: DatePickerSelectProps) => {
@@ -20,7 +23,10 @@ const DatePickerSelect = ({
   const ref = useClickOutside<HTMLDivElement>(() => setIsOpen(false));
 
   return (
-    <DatePickerSelectProvider selectedDate={selectedDate} {...props}>
+    <DatePickerSelectProvider
+      {...props}
+      selectedDate={selectedDate}
+    >
       <div className={containerStyle} ref={trigger ? ref : undefined}>
         {
           trigger && 

--- a/frontend/src/components/DatePicker/RootContainer.tsx
+++ b/frontend/src/components/DatePicker/RootContainer.tsx
@@ -1,16 +1,15 @@
-import type { PropsWithChildren, RefObject } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import clsx from '@/utils/clsx';
 
 import { rootContainerStyle } from './index.css';
 
 interface RootContainerProps extends PropsWithChildren {
-  ref?: RefObject<HTMLDivElement | null>;
   className?: string;
 }
 
-const RootContainer = ({ className, children, ref }: RootContainerProps) => (
-  <div className={clsx(className, rootContainerStyle)} ref={ref}>
+const RootContainer = ({ className, children }: RootContainerProps) => (
+  <div className={clsx(className, rootContainerStyle)}>
     {children}
   </div>
 );

--- a/frontend/src/components/DatePicker/Table/Highlight/index.css.ts
+++ b/frontend/src/components/DatePicker/Table/Highlight/index.css.ts
@@ -24,6 +24,10 @@ export const highlightBoxStyle = recipe({
         borderTopRightRadius: vars.radius[200],
         borderBottomRightRadius: vars.radius[200],        
       },
+      startAndEnd: {
+        backgroundColor: vars.color.Ref.Primary[50],
+        borderRadius: vars.radius[200],
+      },
     },
   },
 });

--- a/frontend/src/components/DatePicker/Table/Highlight/index.css.ts
+++ b/frontend/src/components/DatePicker/Table/Highlight/index.css.ts
@@ -53,6 +53,7 @@ export const highlightGapStyle = recipe({
         borderTopRightRadius: vars.radius[200],
         borderBottomRightRadius: vars.radius[200],
       },
+      startAndEnd: {},
     },
   }, 
 });

--- a/frontend/src/components/DatePicker/Table/Highlight/index.ts
+++ b/frontend/src/components/DatePicker/Table/Highlight/index.ts
@@ -3,7 +3,7 @@ import type { PropsWithChildren } from 'react';
 export * from './HighlightBox';
 export * from './HighlightGap';
 
-export type HighlightState = 'none' | 'startOfRange' | 'inRange' | 'endOfRange';
+export type HighlightState = 'none' | 'startOfRange' | 'inRange' | 'endOfRange' | 'startAndEnd';
 
 export interface HighlightRange {
   start: Date | null;

--- a/frontend/src/components/DatePicker/Table/Row.tsx
+++ b/frontend/src/components/DatePicker/Table/Row.tsx
@@ -32,8 +32,8 @@ const Row = ({ weekDates }: RowProps) => {
         // 마지막 셀 뒤에는 gap을 넣지 않음
         if (index === weekDates.length - 1) return cell;
         const gap = (
-          <HighlightGap 
-            highlightState={getGapHighlightState(highlightState)} 
+          <HighlightGap
+            highlightState={getHighlightGapState(highlightState)} 
             key={`gap-${day.getTime()}`}
           />
         );
@@ -46,7 +46,8 @@ const Row = ({ weekDates }: RowProps) => {
 const getHighlightState = (date: Date, highlightRange: HighlightRange): HighlightState => {
   const { start, end } = highlightRange;
   if (!start || !end) return 'none';
-  
+
+  if (isSameDate(start, end) && isSameDate(date, start)) return 'startAndEnd';
   if (isSameDate(date, start)) return 'startOfRange';
   if (isSameDate(date, end)) return 'endOfRange';
   if (date > start && date < end) return 'inRange';
@@ -55,7 +56,7 @@ const getHighlightState = (date: Date, highlightRange: HighlightRange): Highligh
 
 export default Row;
 
-const getGapHighlightState = (highlightState: HighlightState): HighlightState => {
+const getHighlightGapState = (highlightState: HighlightState): HighlightState => {
   if (highlightState === 'startOfRange' || highlightState === 'inRange') {
     return 'inRange';
   }

--- a/frontend/src/components/DatePicker/context/DatePickerRangeProvider.tsx
+++ b/frontend/src/components/DatePicker/context/DatePickerRangeProvider.tsx
@@ -37,7 +37,6 @@ const DatePickerRangeProvider = ({
       }}
     >
       {children}
-
     </DatePickerContext.Provider>
   );
 };

--- a/frontend/src/components/DatePicker/context/DatePickerSelectProvider.tsx
+++ b/frontend/src/components/DatePicker/context/DatePickerSelectProvider.tsx
@@ -13,17 +13,17 @@ const DatePickerSelectProvider = ({
   ...props
 }: DatePickerRangeProviderProps) => {
   const { highlightRange, onDateCellClick } = useDatePickerSelect(props);
-  const selectedDate = props.selectedDate;
-  const isDateSelected = (date: Date) => selectedDate ? isSameDate(date, selectedDate) : false;
+  const isDateSelected = (date: Date) => 
+    props.selectedDate ? isSameDate(date, props.selectedDate) : false;
 
   return (
     <DatePickerContext.Provider 
       value={{
+        ...props,
         calendarType: 'select',
         onDateCellClick,
         isDateSelected,
         highlightRange,
-        ...props,
       }}
     >
       {children}

--- a/frontend/src/features/discussion/ui/DiscussionForm/MeetingDateDropdowns.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionForm/MeetingDateDropdowns.tsx
@@ -1,24 +1,18 @@
+
 import DatePicker from '@/components/DatePicker';
 import Input from '@/components/Input';
 import { useMonthNavigation } from '@/hooks/useDatePicker/useMonthNavigation';
 import { isSameDate } from '@/utils/date';
 import { formatDateToBarString } from '@/utils/date/format';
 
+import type { DiscussionRequest } from '../../model';
 import { useFormContext } from './FormContext';
 
 const MeetingDateDropdowns = () => {
   const { formState, validationRef, setValidation, handleUpdateField } = useFormContext();
   const navigation = useMonthNavigation();
 
-  const validateDateRange = () => {
-    const today = new Date();
-    const dateRangeStart = new Date(formState.dateRangeStart);
-    if (!formState.dateRangeStart || !formState.dateRangeEnd) return false;
-    if (isSameDate(today, dateRangeStart)) return true;
-    return today < dateRangeStart;
-  };
-
-  setValidation('dateRangeStart', validateDateRange);
+  setValidation('dateRangeStart', () => validateDateRange(formState));
 
   return (
     <DatePicker.Range
@@ -45,6 +39,14 @@ const MeetingDateDropdowns = () => {
       }
     />
   );
+};
+
+const validateDateRange = (formState: DiscussionRequest) => {
+  const today = new Date();
+  const dateRangeStart = new Date(formState.dateRangeStart);
+  if (!formState.dateRangeStart || !formState.dateRangeEnd) return false;
+  if (isSameDate(today, dateRangeStart)) return true;
+  return today < dateRangeStart;
 };
 
 export default MeetingDateDropdowns;

--- a/frontend/src/features/my-calendar/ui/MyDatePicker/index.tsx
+++ b/frontend/src/features/my-calendar/ui/MyDatePicker/index.tsx
@@ -1,19 +1,16 @@
 import { useSharedCalendarContext } from '@/components/Calendar/context/SharedCalendarContext';
 import DatePicker from '@/components/DatePicker';
-import { useMonthNavigation } from '@/hooks/useDatePicker/useMonthNavigation';
 
 import { pickerStyle } from './index.css';
 
 export const MyDatePicker = () => {
   const calendar = useSharedCalendarContext();
-  const monthNavigation = useMonthNavigation();
   
   return (
     <DatePicker.Select
       className={pickerStyle}
       handleDateSelect={calendar.handleSelectDate}
-      selectedDate={calendar.selectedDate}
-      {...monthNavigation}
+      {...calendar}
     />
   );
 };

--- a/frontend/src/features/shared-schedule/ui/UpcomingSchedules/index.tsx
+++ b/frontend/src/features/shared-schedule/ui/UpcomingSchedules/index.tsx
@@ -2,21 +2,16 @@
 import { Flex } from '@/components/Flex';
 import { useCarouselControl } from '@/hooks/useCarousel';
 
-import { useUpcomingQuery } from '../../api/queries';
-import UpcomingFallback from '../Fallbacks/UpcomingFallback';
+import type { UpcomingSchedule } from '../../model';
 import ControlButtons from './ControlButton';
 import UpcomingCarousel from './UpcomingCarousel';
 
-const UpcomingSchedules = () => {
-  const { data, isPending } = useUpcomingQuery();
-  const schedules = data?.data ?? [];
-  
+const UpcomingSchedules = ({ schedules }: {
+  schedules: UpcomingSchedule[];
+}) => {
   const { offsetX, translateCarousel, canTranslateLeft, canTranslateRight } = useCarouselControl({ 
     totalCards: schedules.length,
   });
-
-  if (isPending) return <Flex height={380} width='full' />;
-  if (schedules.length === 0) return <UpcomingFallback />;
 
   return (
     // 최상단 Flex에 relative 주면 안 됨! (overflow hidden 때문에 뷰포트가 부모여야 함)

--- a/frontend/src/features/timeline-schedule/ui/TimelineContent/index.css.ts
+++ b/frontend/src/features/timeline-schedule/ui/TimelineContent/index.css.ts
@@ -10,9 +10,9 @@ export const containerStyle = style({
   height: '28.125rem',
 });
 
-export const overlayStyle = style({
+export const dimStyle = style({
   position: 'absolute',
-  left: -36,
+  // left: -36,
   width: '58.5rem',
   height: 100,
   backgroundColor: vars.color.Ref.Netural[500],
@@ -26,11 +26,12 @@ export const bodyContainerStyle = style({
   gap: vars.spacing[500],
   justifyContent: 'space-between',
   alignItems: 'flex-start',
+  borderBottomLeftRadius: vars.radius[400],
+  borderBottomRightRadius: vars.radius[400],
 
   position: 'relative',
   height: '23.25rem',
   overflowX: 'hidden',
-  overflowY: 'auto',
 });
 
 export const timelineHeaderStyle = style({

--- a/frontend/src/features/timeline-schedule/ui/TimelineContent/index.tsx
+++ b/frontend/src/features/timeline-schedule/ui/TimelineContent/index.tsx
@@ -12,9 +12,9 @@ import { getGridTimes, getRowTopOffset } from '../timelineHelper';
 import {
   bodyContainerStyle,
   containerStyle,
+  dimStyle,
   gridTimeContainerStyle,
   gridTimeTextStyle,
-  overlayStyle,
   timelineHeaderStyle,
 } from './index.css';
 import ParticipantList from './ParticipantList';
@@ -29,20 +29,14 @@ interface TimelineContentProps {
 const TimelineContent = (props: TimelineContentProps) => {
   const { gridTimes, gridStartOffset } = getGridTimes(props.conflictStart, props.conflictEnd);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const overlayRef = useRef<HTMLDivElement>(null);
-  // overlay의 posY를 스크롤과 동기화
-  const handleScroll = () => {
-    if (scrollRef.current && overlayRef.current) {
-      overlayRef.current.style.transform = `translateY(-${scrollRef.current.scrollTop}px)`;
-    }
-  };
+  const dimRef = useRef<HTMLDivElement>(null);
 
   return (
     <div className={containerStyle}>
       <TimelineHeader gridStartOffset={gridStartOffset} gridTimes={gridTimes} />
       <div
         className={bodyContainerStyle}
-        onScroll={handleScroll}
+        // onScroll={handleScroll}
         ref={scrollRef}
       >
         <ParticipantList {...props} />
@@ -52,17 +46,16 @@ const TimelineContent = (props: TimelineContentProps) => {
           gridTimes={gridTimes}
           participants={[...props.checkedParticipants, ...props.uncheckedParticipants]}
         />
+        {props.uncheckedParticipants.length > 0 && 
+        <div
+          className={dimStyle}
+          ref={dimRef}
+          style={{ 
+            top: getRowTopOffset(props.checkedParticipants.length),
+            height: getRowTopOffset(props.uncheckedParticipants.length), 
+          }}
+        />}
       </div>
-      {props.uncheckedParticipants.length > 0 && 
-      <div
-        className={overlayStyle}
-        ref={overlayRef}
-        style={{ 
-          top: getRowTopOffset(props.checkedParticipants.length) + 77,
-          // TODO: overlay height 정확히 계산하도록 리팩터링
-          height: getRowTopOffset(props.uncheckedParticipants.length) + 360, 
-        }}
-      />}
     </div>
   );
 };

--- a/frontend/src/hooks/useDatePicker/useDatePickerRange.ts
+++ b/frontend/src/hooks/useDatePicker/useDatePickerRange.ts
@@ -13,14 +13,22 @@ export const useDatePickerRange = ({
   setHighlightEnd,
 }: UseDatePickerRangeProps) => {
   const onDateCellClick = (date: Date) => {
+    const timeTrimmedDate = trimTime(date);
     const { start, end } = highlightRange;
-    if (!start) {
-      setHighlightStart(date);
+    // TODO: new Date(BAR_STYLE_DATE) 를 하면 BAR_STYLE_DATE를 UTC로 인식하여 +9시간이 되어버리는데, 이를 임시로 조치해 놓았음.
+    // 커스텀 DATE 객체 추가 후 리팩터링 필요
+    const [dateStart, dateEnd] = [
+      start ? trimTime(start) : null,
+      end ? trimTime(end) : null,
+    ];
+    
+    if (!dateStart) {
+      setHighlightStart(timeTrimmedDate);
       return;
     }
-    if (!end) {
-      if (date < start) setHighlightStart(date);
-      else setHighlightEnd(date);
+    if (!dateEnd) {
+      if (timeTrimmedDate < dateStart) setHighlightStart(timeTrimmedDate);
+      else setHighlightEnd(timeTrimmedDate);
       return;
     }
 
@@ -28,4 +36,10 @@ export const useDatePickerRange = ({
     setHighlightEnd(null);
   };
   return { onDateCellClick };
+};
+
+const trimTime = (date: Date) => {
+  const newDate = new Date(date);
+  newDate.setHours(0, 0, 0, 0);
+  return newDate;
 };

--- a/frontend/src/hooks/useDatePicker/useDatePickerSelect.ts
+++ b/frontend/src/hooks/useDatePicker/useDatePickerSelect.ts
@@ -3,7 +3,7 @@ import { formatDateToWeekDates, getDateParts } from '@/utils/date';
 import { getDaysInMonth } from '@/utils/date/calendar';
 
 interface UseDatePickerSelectProps {
-  baseDate?: Date;
+  baseDate: Date;
   selectedDate: Date | null;
   handleDateSelect: (date: Date) => void;
   gotoPrevMonth: () => void;

--- a/frontend/src/hooks/useSharedCalendar.ts
+++ b/frontend/src/hooks/useSharedCalendar.ts
@@ -3,12 +3,15 @@ import { useState } from 'react';
 import type { CalendarSharedInfo } from '@/components/Calendar/context/SharedCalendarContext';
 
 import { formatDateToWeekDates } from '../utils/date';
+import { useMonthNavigation } from './useDatePicker/useMonthNavigation';
 
 export const useSharedCalendar = (): CalendarSharedInfo => {
   const [selected, setSelected] = useState(new Date());
+  const { baseDate, setBaseDate, gotoPrevMonth, gotoNextMonth } = useMonthNavigation();
 
   const handleSelectDate = (date: Date) => {
     setSelected(date);
+    setBaseDate(new Date(date.getFullYear(), date.getMonth()));
   };
 
   return {
@@ -16,5 +19,8 @@ export const useSharedCalendar = (): CalendarSharedInfo => {
     selectedWeek: formatDateToWeekDates(selected),
     handleSelectDate,
     today: new Date(),
+    baseDate,
+    gotoPrevMonth,
+    gotoNextMonth,
   };
 };

--- a/frontend/src/pages/HomePage/UpcomingSection.tsx
+++ b/frontend/src/pages/HomePage/UpcomingSection.tsx
@@ -1,0 +1,43 @@
+
+import { useNavigate } from '@tanstack/react-router';
+
+import Button from '@/components/Button';
+import { Flex } from '@/components/Flex';
+import { Text } from '@/components/Text';
+import { useUpcomingQuery } from '@/features/shared-schedule/api/queries';
+import UpcomingFallback from '@/features/shared-schedule/ui/Fallbacks/UpcomingFallback';
+import UpcomingSchedules from '@/features/shared-schedule/ui/UpcomingSchedules';
+
+const UpcomingSection = () => {
+  const { data, isPending } = useUpcomingQuery();
+  const schedules = data?.data ?? [];
+  const navigate = useNavigate();
+
+  if (isPending) return <Flex height={380} width='full' />;
+  if (schedules.length === 0) return <UpcomingFallback />;
+  return  (
+    <Flex
+      direction='column'
+      gap={700}
+      justify='space-between'
+      width='full'
+    >
+      <Flex justify='space-between' width='full'>
+       
+        <Text typo='h2'>다가오는 일정</Text>
+        {schedules.length > 3 ? 
+          <Button
+            onClick={() => navigate({ to: '/upcoming-schedule' })}
+            style='borderless'
+          >
+            모두보기
+          </Button>          
+          : 
+          null}
+      </Flex>
+      <UpcomingSchedules schedules={schedules} />
+    </Flex>
+  );
+};
+
+export default UpcomingSection;

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -1,11 +1,6 @@
-import { useNavigate } from '@tanstack/react-router';
 
-import Button from '@/components/Button';
-import { Flex } from '@/components/Flex';
-import { Text } from '@/components/Text';
 import FinishedSchedules from '@/features/shared-schedule/ui/FinishedSchedules';
 import OngoingSchedules from '@/features/shared-schedule/ui/OngoingSchedules';
-import UpcomingSchedules from '@/features/shared-schedule/ui/UpcomingSchedules';
 
 import { containerStyle } from './index.css';
 import UpcomingSection from './UpcomingSection';

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -8,33 +8,14 @@ import OngoingSchedules from '@/features/shared-schedule/ui/OngoingSchedules';
 import UpcomingSchedules from '@/features/shared-schedule/ui/UpcomingSchedules';
 
 import { containerStyle } from './index.css';
+import UpcomingSection from './UpcomingSection';
 
-const HomePage = () => {
-  const navigate = useNavigate();
-
-  return (
-    <div className={containerStyle}>
-      <Flex
-        direction='column'
-        gap={700}
-        justify='space-between'
-        width='full'
-      >
-        <Flex justify='space-between' width='full'>
-          <Text typo='h2'>다가오는 일정</Text>
-          <Button
-            onClick={() => navigate({ to: '/upcoming-schedule' })}
-            style='borderless'
-          >
-            모두보기
-          </Button>
-        </Flex>
-        <UpcomingSchedules />
-      </Flex>
-      <OngoingSchedules />
-      <FinishedSchedules />
-    </div>
-  );
-};
+const HomePage = () => (
+  <div className={containerStyle}>
+    <UpcomingSection />
+    <OngoingSchedules />
+    <FinishedSchedules />
+  </div>
+);
 
 export default HomePage;


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 일정 조율 결과 세부 화면에서, 딤처리 레이아웃이 헤더를 덮는 문제 해결했습니다.
- 홈 화면의 다가오는 일정 섹션에서 카드가 3개 이하이면 모두보기 버튼을 표시하지 않도록 구현 수정했습니다.
- DatePicker.Range에서 당일 범위도 선택 가능하게 구현했습니다.
- DatePicker.Range에서 일정 범위 선택 완료되면 picker 꺼지게 하는건, 의견을 나누고 싶은 부분이 있어 보류해 두었습니다.
    - 저희 일정 조율 생성 Form에서 일정 조율 기간이 현 날짜로부터 일주일 범위로 초기화되어 있는데, 위 구현을 적용하게 되면 사용자가 기간을 재설정하기 위해 picker를 열었을 때 날짜를 선택하면 picker가 바로 꺼지게 됩니다.
    - 위 동작이 UX적으로 좋지 않을 것 같아서.. 이에 대해 의견을 나누고 싶어요. 개인적으로 전 picker가 꺼지지 않아도 괜찮을 것 같다는 입장입니다. 아니면 일정 범위를 처음에 아예 비워 놓아야 할 것 같아요
- 캘린더에서 날짜를 선택했을 때, DatePicker의 기준 달(month)이 그에 맞춰 변화하도록 구현했습니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
