### PR TITLE
[BE-Feat] ONGOING 논의 종료 시 비트맵 데이터 삭제 로직 추가

### DIFF
--- a/backend/src/test/java/endolphin/backend/global/scheduler/DiscussionStatusSchedulerTest.java
+++ b/backend/src/test/java/endolphin/backend/global/scheduler/DiscussionStatusSchedulerTest.java
@@ -12,16 +12,19 @@ import endolphin.backend.domain.shared_event.SharedEventService;
 import endolphin.backend.domain.shared_event.dto.SharedEventDto;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
+import endolphin.backend.global.redis.DiscussionBitmapService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class DiscussionStatusSchedulerTest {
@@ -31,6 +34,9 @@ public class DiscussionStatusSchedulerTest {
 
     @Mock
     private SharedEventService sharedEventService;
+
+    @Mock
+    private DiscussionBitmapService discussionBitmapService;
 
     @InjectMocks
     private DiscussionStatusScheduler scheduler;
@@ -51,6 +57,11 @@ public class DiscussionStatusSchedulerTest {
             .location("Room 1")
             .build();
         discussion.setDiscussionStatus(DiscussionStatus.ONGOING);
+        ReflectionTestUtils.setField(discussion, "id", 1L);
+
+        when(discussionBitmapService.deleteDiscussionBitmapsUsingScan(any(Long.class)))
+            .thenReturn(CompletableFuture.completedFuture(null));
+
 
         discussion = scheduler.updateStatus(discussion, today);
 
@@ -124,6 +135,7 @@ public class DiscussionStatusSchedulerTest {
             .location("Room 1")
             .build();
         discussion1.setDiscussionStatus(DiscussionStatus.UPCOMING);
+        ReflectionTestUtils.setField(discussion1, "id", 1L);
 
         Discussion discussion2 = Discussion.builder()
             .title("Discussion 2")
@@ -137,6 +149,10 @@ public class DiscussionStatusSchedulerTest {
             .location("Room 2")
             .build();
         discussion2.setDiscussionStatus(DiscussionStatus.ONGOING);
+        ReflectionTestUtils.setField(discussion2, "id", 2L);
+
+        when(discussionBitmapService.deleteDiscussionBitmapsUsingScan(any(Long.class)))
+            .thenReturn(CompletableFuture.completedFuture(null));
 
         when(discussionRepository.findByDiscussionStatusNot(DiscussionStatus.FINISHED)).thenReturn(List.of(discussion1, discussion2));
 


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 기존 ONGOING discussion이 finished로 변경될 때 비트맵 데이터 삭제가 이루어지고 있지 않아 추가했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Discussions now trigger an automatic cleanup process when marked as finished.
- **Tests**
	- Enhanced test coverage to verify the cleanup process during discussion status updates.
- **Style**
	- Minor formatting improvements for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->