### PR TITLE
[FE-Fix] 홈 화면 관련 버그 수정 및 UX 개선 반영

### DIFF
--- a/frontend/src/components/Pagination/index.tsx
+++ b/frontend/src/components/Pagination/index.tsx
@@ -26,6 +26,7 @@ const Pagination = ({
   const pages = getPaginationItems(currentPage, totalPages);
 
   return (
+    // totalPages > 1 &&
     <div className={clsx(paginationContainerStyle, className)}>
       {pages.map((item, index) => 
         <PaginationItem 

--- a/frontend/src/features/discussion/ui/DiscussionConfirmCard/index.tsx
+++ b/frontend/src/features/discussion/ui/DiscussionConfirmCard/index.tsx
@@ -46,12 +46,14 @@ const DiscussionConfirmCard = (
 
 const Buttons = () => (
   <>
-    {/* <Button
+    <Button
+      as={Link}
       size='xl'
       style='borderless'
+      to='/home'
     >
-      다시 일정 조율하기
-    </Button> */}
+      홈으로 가기
+    </Button>
     <Button
       as={Link}
       size='xl'

--- a/frontend/src/features/shared-schedule/model/finishedSchedules.ts
+++ b/frontend/src/features/shared-schedule/model/finishedSchedules.ts
@@ -9,9 +9,9 @@ const SharedEventDtoSchema = z.object({
 });
 
 const FinishedScheduleSchema = z.object({
-  id: z.number(),
+  discussionId: z.number(),
   title: z.string(),
-  meetingMethodOrLocation: z.string(),
+  meetingMethodOrLocation: z.union([z.string(), z.null()]),
   sharedEventDto: SharedEventDtoSchema,
   participantPictureUrls: z.array(z.string()),
 });

--- a/frontend/src/features/shared-schedule/ui/FinishedSchedules/FinishedScheduleList.tsx
+++ b/frontend/src/features/shared-schedule/ui/FinishedSchedules/FinishedScheduleList.tsx
@@ -25,16 +25,18 @@ const FinishedScheduleList = ({ baseYear }: FinishedScheduleListProps) => {
     <div className={scheduleListStyle} >
       <Flex
         direction='column'
+        height='100%'
         justify='flex-start'
         width='full'
       >
         {data.finishedDiscussions.map((schedule) => (
           <FinishedScheduleListItem
-            endDate={schedule.sharedEventDto.endDateTime}
-            key={schedule.id}
+            endDate={new Date(schedule.sharedEventDto.endDateTime)}
+            key={schedule.discussionId}
+            meetingPlace={schedule.meetingMethodOrLocation}
             participantImageUrls={schedule.participantPictureUrls}
             scheduleTitle={schedule.title}
-            startDate={schedule.sharedEventDto.startDateTime}
+            startDate={new Date(schedule.sharedEventDto.startDateTime)}
           />))}
       </Flex>
       <Pagination

--- a/frontend/src/features/shared-schedule/ui/FinishedSchedules/FinishedScheduleListItem.tsx
+++ b/frontend/src/features/shared-schedule/ui/FinishedSchedules/FinishedScheduleListItem.tsx
@@ -2,10 +2,9 @@ import Avatar from '@/components/Avatar';
 import { Flex } from '@/components/Flex';
 import { Text } from '@/components/Text';
 import { vars } from '@/theme/index.css';
-import { isSameDate } from '@/utils/date';
+import { getDateTimeRangeString } from '@/utils/date';
 
 import {
-  detailsContainerStyle,
   dotStyle,
   scheduleItemContainerStyle,
 } from './finishedScheduleListItem.css';
@@ -13,7 +12,7 @@ import {
 interface FinishedScheduleListItemProps {
   scheduleTitle: string;
   participantImageUrls: string[];
-  meetingPlace?: string;
+  meetingPlace?: string | null;
   startDate: Date;
   endDate: Date;
   onClick?: () => void;
@@ -41,7 +40,6 @@ const FinishedScheduleListItem = ({
     </Flex>
     <Flex
       align='center'
-      className={detailsContainerStyle}
       justify='space-between'
       width='full'
     >
@@ -54,22 +52,25 @@ const FinishedScheduleListItem = ({
   </Flex>
 );
 
-const MeetingPlace = ({ meetingPlace }: { meetingPlace?: string }) => (
-  meetingPlace && 
-  <>
-    <div className={dotStyle} />
-    <Text color={vars.color.Ref.Netural[600]} typo='b3R'>{meetingPlace}</Text>
-  </>
-);
-
 const MeetDate = ({ startDate, endDate }: { startDate: Date; endDate: Date }) => (
   <Text color={vars.color.Ref.Netural[600]} typo='b3R'>
-    {`${startDate.toLocaleDateString()} ~ `}
-    {isSameDate(startDate, endDate) ? 
-      endDate.toLocaleDateString()
-      :
-      endDate.toLocaleDateString().slice(5)}
+    {getDateTimeRangeString(startDate, endDate)}
   </Text>
 );
+
+const MeetingPlace = ({ meetingPlace }: { meetingPlace?: string | null }) => (
+  meetingPlace && 
+    <>
+      <div className={dotStyle} />
+      <Text color={vars.color.Ref.Netural[600]} typo='b3R'>{getMeetingPlace(meetingPlace)}</Text>
+    </>
+);
+
+const getMeetingPlace = (meetingPlace: string | null) => {
+  if (!meetingPlace) return null;
+  if (meetingPlace === 'OFFLINE') return '오프라인 모임';
+  if (meetingPlace === 'ONLINE') return '온라인 모임';
+  return meetingPlace;
+};
 
 export default FinishedScheduleListItem;

--- a/frontend/src/features/shared-schedule/ui/FinishedSchedules/finishedScheduleListItem.css.ts
+++ b/frontend/src/features/shared-schedule/ui/FinishedSchedules/finishedScheduleListItem.css.ts
@@ -9,13 +9,10 @@ export const scheduleItemContainerStyle = style({
   cursor: 'pointer',
 });
 
-export const detailsContainerStyle = style({
-  paddingLeft: 14,
-});
-
 export const dotStyle = style({
-  width: 8,
-  height: 8,
+  width: 3,
+  height: 3,
+  alignSelf: 'center',
   borderRadius: vars.radius['Max'],
   backgroundColor: vars.color.Ref.Netural[400],
 });

--- a/frontend/src/features/shared-schedule/ui/OngoingSchedules/OngoingScheduleList.tsx
+++ b/frontend/src/features/shared-schedule/ui/OngoingSchedules/OngoingScheduleList.tsx
@@ -57,16 +57,14 @@ const OngoingScheduleList = ({ segmentOption }: OngoingScheduleListProps) => {
           selectedIndex={selectedIndex}
           setSelectedIndex={setSelectedIndex}
         />
-        {data.totalPages > 1 && (
-          <Pagination
-            className={paginationStyle}
-            currentPage={currentPage}
-            onPageButtonHover={(page) =>
-              prefetchOngoingSchedules(queryClient, page, PAGE_SIZE, segmentOption.value )}
-            onPageChange={onPageChange}
-            totalPages={data.totalPages}
-          />
-        )}
+        <Pagination
+          className={paginationStyle}
+          currentPage={currentPage}
+          onPageButtonHover={(page) =>
+            prefetchOngoingSchedules(queryClient, page, PAGE_SIZE, segmentOption.value )}
+          onPageChange={onPageChange}
+          totalPages={data.totalPages}
+        />
       </Flex>
       <ScheduleContents discussionId={data.ongoingDiscussions[selectedIndex].discussionId} />
     </div>

--- a/frontend/src/features/shared-schedule/ui/OngoingSchedules/RecommendedSchedules.tsx
+++ b/frontend/src/features/shared-schedule/ui/OngoingSchedules/RecommendedSchedules.tsx
@@ -16,7 +16,11 @@ import { getHourDiff, getTimeParts, getTimeRangeString, getYearMonthDay } from '
 import { getDowString } from '@/utils/date/format';
 
 import { ONGOING_SCHEDULE_DETAIL_GC_TIME } from '../../api';
-import { recommendContainerStyle, recommendItemStyle } from './recommendedSchedules.css';
+import { 
+  noRecommendationTextWrapperStyle, 
+  recommendContainerStyle,
+  recommendItemStyle,
+} from './recommendedSchedules.css';
 
 const RecommendedSchedules = ({ discussion }: { 
   discussion: DiscussionResponse;
@@ -34,19 +38,25 @@ const RecommendedSchedules = ({ discussion }: {
     <Flex
       className={recommendContainerStyle}
       direction='column'
+      justify='flex-start'
       width='full'
     >
       <Text typo='t2'>추천 일정</Text>
-      {candidates.map((candidate, idx) => (
-        <RecommendedScheduleItem
-          adjustCount={candidate.usersForAdjust.length}
-          candidate={candidate}
-          discussionId={discussion.id}
-          endDTStr={candidate.endDateTime}
-          key={`${JSON.stringify(candidate)}-${idx}`}
-          startDTStr={candidate.startDateTime}
-        />
-      ))}
+      {
+        candidates.length === 0 ?
+          <NoRecommendationText />
+          :
+          candidates.map((candidate, idx) => (
+            <RecommendedScheduleItem
+              adjustCount={candidate.usersForAdjust.length}
+              candidate={candidate}
+              discussionId={discussion.id}
+              endDTStr={candidate.endDateTime}
+              key={`${JSON.stringify(candidate)}-${idx}`}
+              startDTStr={candidate.startDateTime}
+            />
+          ))
+      }
     </Flex>
   ); 
 };
@@ -95,6 +105,14 @@ const AvailableChip = ({ adjustCount }: { adjustCount: number }) => (
   >
     {adjustCount > 0 ? `조율 필요 ${adjustCount}` : '모두 가능'}
   </Chip>
+);
+
+const NoRecommendationText = () => (
+  <div className={noRecommendationTextWrapperStyle}>
+    <Text color={vars.color.Ref.Netural[600]} typo='t2'>
+      추천 가능한 일정이 없어요
+    </Text>
+  </div>
 );
 
 export default RecommendedSchedules;

--- a/frontend/src/features/shared-schedule/ui/OngoingSchedules/RecommendedSchedules.tsx
+++ b/frontend/src/features/shared-schedule/ui/OngoingSchedules/RecommendedSchedules.tsx
@@ -12,12 +12,12 @@ import type {
   DiscussionResponse,
 } from '@/features/discussion/model';
 import { vars } from '@/theme/index.css';
-import { getHourDiff, getTimeParts, getTimeRangeString, getYearMonthDay } from '@/utils/date';
+import { getTimeDiffString, getTimeParts, getTimeRangeString, getYearMonthDay } from '@/utils/date';
 import { getDowString } from '@/utils/date/format';
 
 import { ONGOING_SCHEDULE_DETAIL_GC_TIME } from '../../api';
-import { 
-  noRecommendationTextWrapperStyle, 
+import {
+  noRecommendationTextWrapperStyle,
   recommendContainerStyle,
   recommendItemStyle,
 } from './recommendedSchedules.css';
@@ -88,7 +88,7 @@ const RecommendedScheduleItem = ({
       <Flex direction='column' gap={100}>
         <Text typo='b2M'>{`${month}월 ${day}일 ${dow}요일`}</Text>
         <Text color={vars.color.Ref.Netural[700]} typo='b3R'>
-          {`${getTimeRangeString(startTime, endTime)} (${getHourDiff(startDT, endDT)}시간)`}
+          {`${getTimeRangeString(startTime, endTime)} (${getTimeDiffString(startDT, endDT)})`}
         </Text>
       </Flex >
       <AvailableChip adjustCount={adjustCount} />

--- a/frontend/src/features/shared-schedule/ui/OngoingSchedules/recommendedSchedules.css.ts
+++ b/frontend/src/features/shared-schedule/ui/OngoingSchedules/recommendedSchedules.css.ts
@@ -31,3 +31,11 @@ export const recommendItemStyle = style({
     },
   },
 });
+
+export const noRecommendationTextWrapperStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  height: '100%',
+});

--- a/frontend/src/features/shared-schedule/ui/UpcomingSchedules/ScheduleCard.tsx
+++ b/frontend/src/features/shared-schedule/ui/UpcomingSchedules/ScheduleCard.tsx
@@ -22,6 +22,7 @@ const ScheduleCard = ({ schedule, latest }: ScheduleCardProps) => (
     params={{ id: schedule.discussionId.toString() }}
     state={{ 
       upcomingScheduleDetail: {
+        title: schedule.title,
         startDateTime: schedule.sharedEventDto.startDateTime,
         endDateTime: schedule.sharedEventDto.endDateTime,
       },
@@ -33,29 +34,28 @@ const ScheduleCard = ({ schedule, latest }: ScheduleCardProps) => (
       direction='column'
       justify='space-between'
     >
-      <Flex direction='column' gap={300}>
-        <DdayChip endDateTime={new Date(schedule.sharedEventDto.endDateTime)} latest={latest} />
-        <Text typo='h3'>{schedule.title}</Text>
-        <Flex direction='column'>
-          <MeetingDateTimeInfo 
-            endDateTime={new Date(schedule.sharedEventDto.endDateTime)}
-            startDateTime={new Date(schedule.sharedEventDto.startDateTime)}
-          />
-          <Text color={vars.color.Ref.Netural[600]} typo='b2R'>
-            {schedule.meetingMethodOrLocation}
-          </Text>
-        </Flex>
-      </Flex>
-      <Flex
-        align='center'
-        justify='space-between'
-        width='full'
-      >
-        <Avatar imageUrls={schedule.participantPictureUrls} size='lg' />
-        <ChevronButton latest={latest} />
-      </Flex>
+      <ScheduleCardBody latest={latest} schedule={schedule} />
+      <ScheduleCardFooter latest={latest} schedule={schedule} />
     </Flex>
   </Link>
+);
+
+const ScheduleCardBody = ({ schedule, latest }: {
+  schedule: ScheduleCardProps['schedule']; latest: boolean; 
+}) => (
+  <Flex direction='column' gap={300}>
+    <DdayChip endDateTime={new Date(schedule.sharedEventDto.endDateTime)} latest={latest} />
+    <Text typo='h3'>{schedule.title}</Text>
+    <Flex direction='column'>
+      <MeetingDateTimeInfo 
+        endDateTime={new Date(schedule.sharedEventDto.endDateTime)}
+        startDateTime={new Date(schedule.sharedEventDto.startDateTime)}
+      />
+      <Text color={vars.color.Ref.Netural[600]} typo='b2R'>
+        {schedule.meetingMethodOrLocation}
+      </Text>
+    </Flex>
+  </Flex>
 );
 
 const DdayChip = ({ endDateTime, latest }: {
@@ -72,6 +72,19 @@ const DdayChip = ({ endDateTime, latest }: {
   </Chip>
 );
 
+const ScheduleCardFooter = ({ schedule, latest }: {
+  schedule: ScheduleCardProps['schedule']; latest: boolean; 
+}) => (
+  <Flex
+    align='center'
+    justify='space-between'
+    width='full'
+  >
+    <Avatar imageUrls={schedule.participantPictureUrls} size='lg' />
+    <ChevronButton latest={latest} />
+  </Flex>
+);
+
 const MeetingDateTimeInfo = ({ startDateTime, endDateTime }: {
   startDateTime: Date;
   endDateTime: Date;
@@ -81,8 +94,6 @@ const MeetingDateTimeInfo = ({ startDateTime, endDateTime }: {
   </Text>
 );
 
-export default ScheduleCard;
-
 const ChevronButton = ({ latest }: { latest: boolean }) => (
   <ChevronRight
     className={chevronButtonStyle({ latest })}
@@ -90,3 +101,5 @@ const ChevronButton = ({ latest }: { latest: boolean }) => (
     fill={vars.color.Ref.Netural[800]}
   />
 );
+
+export default ScheduleCard;

--- a/frontend/src/features/shared-schedule/ui/UpcomingSchedules/ScheduleCard.tsx
+++ b/frontend/src/features/shared-schedule/ui/UpcomingSchedules/ScheduleCard.tsx
@@ -18,33 +18,44 @@ interface ScheduleCardProps {
 }
 
 const ScheduleCard = ({ schedule, latest }: ScheduleCardProps) => (
-  <Flex
-    className={containerStyle({ latest })}
-    direction='column'
-    justify='space-between'
+  <Link
+    params={{ id: schedule.discussionId.toString() }}
+    state={{ 
+      upcomingScheduleDetail: {
+        startDateTime: schedule.sharedEventDto.startDateTime,
+        endDateTime: schedule.sharedEventDto.endDateTime,
+      },
+    }}
+    to='/upcoming-schedule/$id'
   >
-    <Flex direction='column' gap={300}>
-      <DdayChip endDateTime={new Date(schedule.sharedEventDto.endDateTime)} latest={latest} />
-      <Text typo='h3'>{schedule.title}</Text>
-      <Flex direction='column'>
-        <MeetingDateTimeInfo 
-          endDateTime={new Date(schedule.sharedEventDto.endDateTime)}
-          startDateTime={new Date(schedule.sharedEventDto.startDateTime)}
-        />
-        <Text color={vars.color.Ref.Netural[600]} typo='b2R'>
-          {schedule.meetingMethodOrLocation}
-        </Text>
+    <Flex
+      className={containerStyle({ latest })}
+      direction='column'
+      justify='space-between'
+    >
+      <Flex direction='column' gap={300}>
+        <DdayChip endDateTime={new Date(schedule.sharedEventDto.endDateTime)} latest={latest} />
+        <Text typo='h3'>{schedule.title}</Text>
+        <Flex direction='column'>
+          <MeetingDateTimeInfo 
+            endDateTime={new Date(schedule.sharedEventDto.endDateTime)}
+            startDateTime={new Date(schedule.sharedEventDto.startDateTime)}
+          />
+          <Text color={vars.color.Ref.Netural[600]} typo='b2R'>
+            {schedule.meetingMethodOrLocation}
+          </Text>
+        </Flex>
+      </Flex>
+      <Flex
+        align='center'
+        justify='space-between'
+        width='full'
+      >
+        <Avatar imageUrls={schedule.participantPictureUrls} size='lg' />
+        <ChevronButton latest={latest} />
       </Flex>
     </Flex>
-    <Flex
-      align='center'
-      justify='space-between'
-      width='full'
-    >
-      <Avatar imageUrls={schedule.participantPictureUrls} size='lg' />
-      <NavigateButton latest={latest} schedule={schedule} />
-    </Flex>
-  </Flex>
+  </Link>
 );
 
 const DdayChip = ({ endDateTime, latest }: {
@@ -72,25 +83,10 @@ const MeetingDateTimeInfo = ({ startDateTime, endDateTime }: {
 
 export default ScheduleCard;
 
-const NavigateButton = ({ latest, schedule }: {
-  latest: boolean; 
-  schedule: UpcomingSchedule;
-}) => (
-  <Link
+const ChevronButton = ({ latest }: { latest: boolean }) => (
+  <ChevronRight
     className={chevronButtonStyle({ latest })}
-    params={{ id: schedule.discussionId.toString() }}
-    state={{ 
-      upcomingScheduleDetail: {
-        startDateTime: schedule.sharedEventDto.startDateTime,
-        endDateTime: schedule.sharedEventDto.endDateTime,
-      },
-    }}
-    to='/upcoming-schedule/$id'
-  >
-    <ChevronRight
-      clickable
-      fill={vars.color.Ref.Netural[800]}
-      width={28}
-    />
-  </Link>
+    clickable
+    fill={vars.color.Ref.Netural[800]}
+  />
 );

--- a/frontend/src/features/shared-schedule/ui/UpcomingSchedules/UpcomingScheduleListItem.tsx
+++ b/frontend/src/features/shared-schedule/ui/UpcomingSchedules/UpcomingScheduleListItem.tsx
@@ -67,7 +67,11 @@ const Content = ({
       justify='flex-start'
     >
       <Text typo='t2'>{schedule.title}</Text>
-      <Chip color='black' style='weak'>
+      <Chip
+        color='black'
+        radius='max'
+        style='weak'
+      >
         {formatDateToDdayString(startDate)}
       </Chip>
     </Flex>

--- a/frontend/src/features/shared-schedule/ui/UpcomingSchedules/UpcomingScheduleListItem.tsx
+++ b/frontend/src/features/shared-schedule/ui/UpcomingSchedules/UpcomingScheduleListItem.tsx
@@ -33,6 +33,7 @@ const UpcomingScheduleListItem = ({
       params={{ id: schedule.discussionId.toString() }}
       state={{ 
         upcomingScheduleDetail: {
+          title: schedule.title,
           startDateTime: schedule.sharedEventDto.startDateTime,
           endDateTime: schedule.sharedEventDto.endDateTime,
         },

--- a/frontend/src/features/timeline-schedule/ui/TimelineContent/ChipAble.tsx
+++ b/frontend/src/features/timeline-schedule/ui/TimelineContent/ChipAble.tsx
@@ -3,7 +3,7 @@ import { Flex } from '@/components/Flex';
 import { Text } from '@/components/Text';
 import { vars } from '@/theme/index.css';
 
-import { chipAbleContainerStyle, dotStyle } from './chipAble.css';
+import { chipAbleContainerStyle } from './chipAble.css';
 
 export type ChipStatus = 'ADJUSTABLE' | 'FIXED' | 'OUT_OF_RANGE';
 
@@ -16,13 +16,13 @@ const ChipAble = ({ chipStatus }: { chipStatus: ChipStatus }) => {
       align='center'
       className={chipAbleContainerStyle({ isAdjustable })}
     >
-      <div className={dotStyle({ isAdjustable })} />
+      {/* <div className={dotStyle({ isAdjustable })} /> */}
       {isAdjustable ?
         <Text color={vars.color.Ref.Primary[500]} typo='caption'>조정 가능</Text>
         :
         <Text color={vars.color.Ref.Red[500]} typo='caption'>조정 불가능</Text>}
     </Flex>  
-  ); 
+  );
 };
 
 export default ChipAble;

--- a/frontend/src/features/timeline-schedule/ui/TimelineContent/ParticipantList.tsx
+++ b/frontend/src/features/timeline-schedule/ui/TimelineContent/ParticipantList.tsx
@@ -55,7 +55,9 @@ const ParticipantItem = ({ participant, isUncheckedParticipant }: {
         <Text typo='b2M'>{participant.name}</Text>
       </Flex>
       {!isConfirmedSchedule && !isUncheckedParticipant &&
-        <ChipAble chipStatus={chipStatus} />}
+      <Flex width={80}>
+        <ChipAble chipStatus={chipStatus} />
+      </Flex>}
     </Flex>
   );
 };

--- a/frontend/src/features/timeline-schedule/ui/TimelineContent/chipAble.css.ts
+++ b/frontend/src/features/timeline-schedule/ui/TimelineContent/chipAble.css.ts
@@ -6,7 +6,6 @@ export const chipAbleContainerStyle = recipe({
   base: {
     padding: `${vars.spacing[200]} ${vars.spacing[300]}`,
     borderRadius: vars.spacing[250],
-    gap: '0.375rem',
     flexShrink: 0,
   },
   variants: {

--- a/frontend/src/features/timeline-schedule/ui/TimelineContent/chipAble.css.ts
+++ b/frontend/src/features/timeline-schedule/ui/TimelineContent/chipAble.css.ts
@@ -7,6 +7,7 @@ export const chipAbleContainerStyle = recipe({
     padding: `${vars.spacing[200]} ${vars.spacing[300]}`,
     borderRadius: vars.spacing[250],
     gap: '0.375rem',
+    flexShrink: 0,
   },
   variants: {
     isAdjustable: {

--- a/frontend/src/features/timeline-schedule/ui/TimelineContent/participantList.css.ts
+++ b/frontend/src/features/timeline-schedule/ui/TimelineContent/participantList.css.ts
@@ -7,6 +7,5 @@ export const participantsContainerStyle = style({
 export const participantItemStyle = style({
   height: '4.25rem',
   width: '100%',
-  paddingRight: '1.0625rem',
   gap: '1.875rem',
 });

--- a/frontend/src/features/timeline-schedule/ui/TimelineContext.ts
+++ b/frontend/src/features/timeline-schedule/ui/TimelineContext.ts
@@ -3,7 +3,8 @@ import { createContext } from 'react';
 import { useSafeContext } from '@/hooks/useSafeContext';
 
 interface TimelineContextProps {
-  isConfirmedSchedule: boolean;  
+  isConfirmedSchedule: boolean;
+  handleGoBack: () => void;
 }
 
 export const TimelineContext = createContext<TimelineContextProps | null>(null);

--- a/frontend/src/features/timeline-schedule/ui/index.css.ts
+++ b/frontend/src/features/timeline-schedule/ui/index.css.ts
@@ -3,6 +3,8 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '@/theme/index.css';
 
 export const containerStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
   width: '58.5rem',
   // height: '40.5rem',
   

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -30,6 +30,14 @@ const router = createRouter({
   context: {
     queryClient,
   },
+  scrollRestoration: true,
+  scrollRestorationBehavior: 'smooth',
+  getScrollRestorationKey: (location) => {
+    const paths = ['/home'];
+    return paths.includes(location.pathname)
+      ? location.pathname
+      : location.state.key!;
+  },
 });
 
 declare module '@tanstack/react-router' {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -31,7 +31,7 @@ const router = createRouter({
     queryClient,
   },
   scrollRestoration: true,
-  scrollRestorationBehavior: 'smooth',
+  scrollRestorationBehavior: 'instant',
   getScrollRestorationKey: (location) => {
     const paths = ['/home'];
     return paths.includes(location.pathname)

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -52,6 +52,7 @@ declare module '@tanstack/react-router' {
       selectedParticipantIds?: number[];
     };
     upcomingScheduleDetail?: {
+      title: string;
       startDateTime: string;
       endDateTime: string;
     };

--- a/frontend/src/pages/UpcomingScheduleDetailPage/index.tsx
+++ b/frontend/src/pages/UpcomingScheduleDetailPage/index.tsx
@@ -1,38 +1,56 @@
 import { useParams } from '@tanstack/react-router';
 
+import { Chip } from '@/components/Chip';
+import { Flex } from '@/components/Flex';
+import { Text } from '@/components/Text';
 import TimelineScheduleModal from '@/features/timeline-schedule/ui';
+import { formatDateToDdayString } from '@/utils/date/format';
 
 import Header from './Header';
 import { backdropStyle } from './index.css';
 
-const UpcomingScheduleDetailPage = (candidate: {
+interface ScheduleInfo {
+  title: string;
   startDateTime: string;
   endDateTime: string;
-  selectedParticipantIds?: number[];
-}) => {
+};
+
+const UpcomingScheduleDetailPage = (scheduleInfo: ScheduleInfo) => {
   const { id } = useParams({ from: '/_main/upcoming-schedule/$id' });
-  const [start, end] = [new Date(candidate.startDateTime), new Date(candidate.endDateTime)];
-  
+  const start = new Date(scheduleInfo.startDateTime);
+  const end = new Date(scheduleInfo.endDateTime);
+
   return (
     <>
       <div className={backdropStyle} />
       <TimelineScheduleModal
         discussionId={Number(id)}
         isConfirmedSchedule={true}
-        {...candidate}
+        {...scheduleInfo}
       >
         <TimelineScheduleModal.TopBar>
-
+          <TopBarContent end={end} scheduleInfo={scheduleInfo} />
         </TimelineScheduleModal.TopBar>
         <TimelineScheduleModal.Header>
-          <Header
-            endDateTime={end}
-            startDateTime={start}
-          />
+          <Header endDateTime={end} startDateTime={start} />
         </TimelineScheduleModal.Header>
       </TimelineScheduleModal>
     </>
-  ); 
+  );
 };
+
+const TopBarContent = ({ scheduleInfo, end }: { scheduleInfo: ScheduleInfo; end: Date }) => (
+  <Flex align='center' gap={200}>
+    <Text typo='t1'>{scheduleInfo.title}</Text>
+    <Chip
+      color='coolGray'
+      radius='max'
+      size='md'
+      style='weak'
+    >
+      {formatDateToDdayString(end)}
+    </Chip>
+  </Flex>
+);
 
 export default UpcomingScheduleDetailPage;

--- a/frontend/src/pages/UpcomingScheduleDetailPage/index.tsx
+++ b/frontend/src/pages/UpcomingScheduleDetailPage/index.tsx
@@ -12,7 +12,7 @@ const UpcomingScheduleDetailPage = (candidate: {
 }) => {
   const { id } = useParams({ from: '/_main/upcoming-schedule/$id' });
   const [start, end] = [new Date(candidate.startDateTime), new Date(candidate.endDateTime)];
-
+  
   return (
     <>
       <div className={backdropStyle} />
@@ -21,7 +21,9 @@ const UpcomingScheduleDetailPage = (candidate: {
         isConfirmedSchedule={true}
         {...candidate}
       >
-        <TimelineScheduleModal.TopBar></TimelineScheduleModal.TopBar>
+        <TimelineScheduleModal.TopBar>
+
+        </TimelineScheduleModal.TopBar>
         <TimelineScheduleModal.Header>
           <Header
             endDateTime={end}

--- a/frontend/src/utils/date/date.ts
+++ b/frontend/src/utils/date/date.ts
@@ -242,9 +242,11 @@ export const getDateTimeRangeString = (start: Date, end: Date): string => {
   return `${startMonth}월 ${startDay}일 ${startTime} ~ ${endMonth}월 ${endDay}일 ${endTime}`;
 };
 
-export const getDday = (date: Date): number => {
+export const getDayDiff = (date: Date): number => {
   const today = new Date();
-  const diff = date.getTime() - today.getTime();
+  const todayDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const targetDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const diff = targetDate.getTime() - todayDate.getTime();
   return Math.floor(diff / DAY_IN_MILLISECONDS);
 };
 

--- a/frontend/src/utils/date/format.ts
+++ b/frontend/src/utils/date/format.ts
@@ -113,7 +113,7 @@ export const formatTimeToDeadlineString = ({ days, hours, minutes }: {
   hours: number;
   minutes: number;
 }): string => {
-  if (days !== 0) return `${days}일`;
-  if (hours !== 0) return `${hours}시간`;
-  return `${minutes}분`;
+  if (days !== 0) return `${Math.abs(days)}일`;
+  if (hours !== 0) return `${Math.abs(hours)}시간`;
+  return `${Math.abs(minutes)}분`;
 };

--- a/frontend/src/utils/date/format.ts
+++ b/frontend/src/utils/date/format.ts
@@ -1,5 +1,5 @@
 import { getDday, getYearMonthDay } from './date';
-import { HOUR } from './time';
+import { HOUR_IN_MINUTES } from './time';
 
 /**
  * 날짜 객체를 YY-MM-DD 형식의 문자열로 변환합니다.
@@ -42,8 +42,8 @@ export const formatDateToTimeString = (date: Date | null): string => {
 };
 
 export const formatMinutesToTimeString = (minutes: number): string => {
-  const hours = Math.floor(minutes / HOUR);
-  const restMinutes = (minutes % HOUR);
+  const hours = Math.floor(minutes / HOUR_IN_MINUTES);
+  const restMinutes = (minutes % HOUR_IN_MINUTES);
   const minutesString = restMinutes ? ` ${restMinutes.toString().padStart(2, '0')}분` : '';
   const amOrPm = hours >= 12 ? '오후' : '오전';
 
@@ -53,16 +53,16 @@ export const formatMinutesToTimeString = (minutes: number): string => {
 };
 
 export const formatNumberToTimeString = (number: number): string => {
-  const hours = Math.floor(number / HOUR).toString()
+  const hours = Math.floor(number / HOUR_IN_MINUTES).toString()
     .padStart(2, '0');
-  const minutes = (number % HOUR).toString().padStart(2, '0');
+  const minutes = (number % HOUR_IN_MINUTES).toString().padStart(2, '0');
 
   return `${hours}:${minutes}`;
 };
 
 export const formatTimeStringToNumber = (timeString: string): number => {
   const [hours, minutes] = timeString.split(':');
-  return Number(hours) * HOUR + Number(minutes);
+  return Number(hours) * HOUR_IN_MINUTES + Number(minutes);
 };
 
 export const formatDateToString = (date: Date | null): string => {
@@ -72,8 +72,8 @@ export const formatDateToString = (date: Date | null): string => {
 };
 
 export const formatMinutesToTimeDuration = (minutes: number): string => {
-  const hours = Math.floor(minutes / HOUR);
-  const restMinutes = (minutes % HOUR);
+  const hours = Math.floor(minutes / HOUR_IN_MINUTES);
+  const restMinutes = (minutes % HOUR_IN_MINUTES);
 
   if (hours === 0) return `${restMinutes}분`;
   if (restMinutes === 0) return `${hours}시간`;

--- a/frontend/src/utils/date/format.ts
+++ b/frontend/src/utils/date/format.ts
@@ -1,4 +1,4 @@
-import { getDday, getYearMonthDay } from './date';
+import { getDayDiff, getYearMonthDay } from './date';
 import { HOUR_IN_MINUTES } from './time';
 
 /**
@@ -98,7 +98,7 @@ export const formatTimeStringToLocaleString = (timeString: string): string => {
 };
 
 export const formatDateToDdayString = (date: Date): string => {
-  const diffDays = getDday(date);
+  const diffDays = getDayDiff(date);
 
   if (diffDays === 0) return 'D-Day';
   if (diffDays > 0) return `D-${diffDays}`;

--- a/frontend/src/utils/date/time.ts
+++ b/frontend/src/utils/date/time.ts
@@ -1,4 +1,4 @@
-export const HOUR = 60;
+export const HOUR_IN_MINUTES = 60;
 export const HOUR_IN_MILLISECONDS = 1000 * 60 * 60;
 export const MINUTE_IN_MILLISECONDS = 60000;
 
@@ -13,14 +13,19 @@ export const formatDateToTimeString = (date: Date | null): string => {
   return `${hours}:${minutes}`;
 };
 
-export const getTimeRangeString = (startTime: Time, endTime: Time): string => {
-  const { hour: startHour, minute: startMinute } = startTime;
-  const { hour: endHour, minute: endMinute } = endTime;
+export const getTimeRangeString = (startDate: Time, endDate: Time): string => {
+  const convertTime = (time: Time): string => {
+    const { hour, minute } = time;
+    const period = hour >= 12 ? '오후' : '오전';
+    const hour12 = hour % 12 || 12;
+    const paddedMinutes = minute.toString().padStart(2, '0');
+    return minute === 0 ? `${period} ${hour12}시` : `${period} ${hour12}시 ${paddedMinutes}분`;
+  };
+
+  const startTime = convertTime(startDate);
+  const endTime = convertTime(endDate);
   
-  const format = (hour: number, minute: number) => 
-    minute === 0 ? `${hour}시` : `${hour}시 ${minute}분`;
-  
-  return `${format(startHour, startMinute)} ~ ${format(endHour, endMinute)}`;
+  return `${startTime} ~ ${endTime}`;
 };
 
 export const getMinuteDiff = (startTime: Date, endTime: Date): number => { 
@@ -29,12 +34,28 @@ export const getMinuteDiff = (startTime: Date, endTime: Date): number => {
   return Math.floor(diff / MINUTE_IN_MILLISECONDS);
 };
 
-export const getHourDiff = (startTime: Date, endTime: Date, ignoreDateDiff = true): number => {
-  if (ignoreDateDiff) {
-    return endTime.getHours() - startTime.getHours();
-  } 
-  const diffMilliseconds = endTime.getTime() - startTime.getTime();
-  return Math.floor(diffMilliseconds / HOUR_IN_MILLISECONDS);
+export const getTimeDiffString = (
+  startTime: Date,
+  endTime: Date,
+  ignoreDateDiff = true,
+): string => {
+  const getTotalMinutes = (date: Date): number =>
+    date.getHours() * HOUR_IN_MINUTES + date.getMinutes();
+
+  const totalMinutes = ignoreDateDiff
+    ? getTotalMinutes(endTime) - getTotalMinutes(startTime)
+    : Math.floor((endTime.getTime() - startTime.getTime()) / MINUTE_IN_MILLISECONDS);
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  const formattedHours = hours > 0 ? `${hours}시간` : '';
+  const formattedMinutes = minutes > 0 ? `${minutes}분` : '';
+
+  // 빈 문자열 제거
+  const timeParts = [formattedHours, formattedMinutes].filter(Boolean);
+
+  return timeParts.join(' ') || '0분';
 };
 
 export const getTimeParts = (date: Date): Time => {


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 홈 화면에 scroll restoration을 적용했습니다. (홈 화면의 스크롤 위치를 기억해 두었다가, 다른 페이지에서 라우팅 시 스크롤 위치 복원)
    - 현재 scroll restoration 동작을 `smooth`로 해 두었는데, 스크롤이 부드럽게 이동하는 게 좋을까요, 아니면 바로 고정되는 게 좋을까요? 일단 지인이 보기에 부드럽게 이동하는 게 더 정성들인?ㅋㅋ 느낌이라는 의견을 줘서 `smooth`로 설정해 두었습니다.
- 지난 일정이 출력되지 않는 문제를 해결했습니다. zod 스키마 검증 문제였습니다. (또 너야)
- 후보 일정 디테일 화면에서, 조정 가능 여부를 나타내는 Chip이 줄바꿈되지 않도록 css 수정했습니다.
- 홈 화면의 추천 일정에서, 미팅 duration을 잘못 계산하던 문제를 수정했습니다.
- 일정 확정 완료 화면에 '홈 화면으로' 버튼을 추가했습니다.
- 다가오는 일정 카드 (큰 카드) 전체를 클릭할 수 있게 변경했습니다.
- 다가오는 일정에 표시되는 D-Day 계산 오류를 수정했습니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a “Go to Home” button on the discussion confirmation card.
	- Added a clear message when no schedule recommendations are available.
	- Upcoming schedule cards now act as clickable links for easier navigation.
	- Enhanced scroll behavior creates smoother transitions.

- **UI/Style Enhancements**
	- Updated visual cues in schedule displays, including improved indicators and chip styling.
	- Refined meeting location labels for better clarity.

- **Refactor**
	- Streamlined date and time formatting for more accurate scheduling details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->