### PR TITLE
[BE-Feat] Ongoing discussion 정보에 time range, duration 추가

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -165,6 +165,8 @@ public class DiscussionParticipantService {
                 discussion.getTitle(),
                 discussion.getDateRangeStart(),
                 discussion.getDateRangeEnd(),
+                discussion.getTimeRangeStart(),
+                discussion.getTimeRangeEnd(),
                 TimeUtil.calculateTimeLeft(discussion.getDeadline()),
                 discussionPicturesMap.getOrDefault(discussion.getId(), Collections.emptyList())
             ))

--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionParticipantService.java
@@ -167,6 +167,7 @@ public class DiscussionParticipantService {
                 discussion.getDateRangeEnd(),
                 discussion.getTimeRangeStart(),
                 discussion.getTimeRangeEnd(),
+                discussion.getDuration(),
                 TimeUtil.calculateTimeLeft(discussion.getDeadline()),
                 discussionPicturesMap.getOrDefault(discussion.getId(), Collections.emptyList())
             ))

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussion.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussion.java
@@ -11,6 +11,7 @@ public record OngoingDiscussion(
     LocalDate dateRangeEnd,
     LocalTime timeRangeStart,
     LocalTime timeRangeEnd,
+    Integer duration,
     Long timeLeft,
     List<String> participantPictureUrls
 ) {

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussion.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/OngoingDiscussion.java
@@ -1,6 +1,7 @@
 package endolphin.backend.domain.discussion.dto;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 public record OngoingDiscussion(
@@ -8,6 +9,8 @@ public record OngoingDiscussion(
     String title,
     LocalDate dateRangeStart,
     LocalDate dateRangeEnd,
+    LocalTime timeRangeStart,
+    LocalTime timeRangeEnd,
     Long timeLeft,
     List<String> participantPictureUrls
 ) {


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 개인 일정 페이지 아코디언에서 추가적인 논의 정보가 필요하여 추가했습니다.
- time range start, time range end, duration을 함께 전달합니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
