### PR TITLE
[BE-Feat] 논의 참여 인증 실패 시 처리 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/DiscussionService.java
@@ -189,6 +189,7 @@ public class DiscussionService {
 
     public InvitationInfo getInvitationInfo(Long discussionId) {
         Discussion discussion = getDiscussionById(discussionId);
+        User currentUser = userService.getCurrentUser();
 
         return new InvitationInfo(
             discussionParticipantService.getHostNameByDiscussionId(discussionId),
@@ -199,7 +200,8 @@ public class DiscussionService {
             discussion.getTimeRangeEnd(),
             discussion.getDuration(),
             discussionParticipantService.isFull(discussionId),
-            discussion.getPassword() != null
+            discussion.getPassword() != null,
+            passwordCountService.getExpirationTime(currentUser.getId(), discussionId)
         );
     }
 

--- a/backend/src/main/java/endolphin/backend/domain/discussion/dto/InvitationInfo.java
+++ b/backend/src/main/java/endolphin/backend/domain/discussion/dto/InvitationInfo.java
@@ -1,6 +1,7 @@
 package endolphin.backend.domain.discussion.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record InvitationInfo(
@@ -12,7 +13,8 @@ public record InvitationInfo(
     LocalTime timeRangeEnd,
     Integer duration,
     Boolean isFull,
-    Boolean requirePassword
+    Boolean requirePassword,
+    LocalDateTime timeUnlocked
 ) {
 
 }

--- a/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
+++ b/backend/src/main/java/endolphin/backend/global/error/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     // Discussion
     DISCUSSION_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "Discussion not found"),
     DISCUSSION_NOT_ONGOING(HttpStatus.BAD_REQUEST, "D003", "Discussion not ongoing"),
-    TOO_MANY_FAILED_ATTEMPTS(HttpStatus.FORBIDDEN, "D004", "Too many failed attempts"),
+    TOO_MANY_FAILED_ATTEMPTS(HttpStatus.TOO_MANY_REQUESTS, "D004", "Too many failed attempts"),
     PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "D005", "Password required"),
 
     // PersonalEvent

--- a/backend/src/main/java/endolphin/backend/global/redis/PasswordCountService.java
+++ b/backend/src/main/java/endolphin/backend/global/redis/PasswordCountService.java
@@ -40,11 +40,14 @@ public class PasswordCountService {
 
     public LocalDateTime getExpirationTime(Long userId, Long discussionId) {
         String redisKey = "failedAttempts:" + discussionId + ":" + userId;
-        long remainingTime = redisStringTemplate.getExpire(redisKey, TimeUnit.SECONDS);
+        String countStr = redisStringTemplate.opsForValue().get(redisKey);
+        int failedAttemptsCount = countStr != null ? Integer.parseInt(countStr) : 0;
 
-        if (remainingTime < 0) {
+        if (failedAttemptsCount < MAX_FAILED_ATTEMPTS) {
             return null;
         }
+
+        long remainingTime = redisStringTemplate.getExpire(redisKey, TimeUnit.SECONDS);
 
         return TimeUtil.getNow().plusSeconds(remainingTime);
     }

--- a/backend/src/main/java/endolphin/backend/global/redis/PasswordCountService.java
+++ b/backend/src/main/java/endolphin/backend/global/redis/PasswordCountService.java
@@ -2,6 +2,8 @@ package endolphin.backend.global.redis;
 
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
+import endolphin.backend.global.util.TimeUtil;
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -34,5 +36,16 @@ public class PasswordCountService {
         redisStringTemplate.expire(redisKey, LOCKOUT_DURATION_MS, TimeUnit.MILLISECONDS);
 
         return updatedCount.intValue();
+    }
+
+    public LocalDateTime getExpirationTime(Long userId, Long discussionId) {
+        String redisKey = "failedAttempts:" + discussionId + ":" + userId;
+        long remainingTime = redisStringTemplate.getExpire(redisKey, TimeUnit.SECONDS);
+
+        if (remainingTime < 0) {
+            return null;
+        }
+
+        return TimeUtil.getNow().plusSeconds(remainingTime);
     }
 }

--- a/backend/src/main/java/endolphin/backend/global/redis/PasswordCountService.java
+++ b/backend/src/main/java/endolphin/backend/global/redis/PasswordCountService.java
@@ -1,7 +1,9 @@
 package endolphin.backend.global.redis;
 
+import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.global.error.exception.ApiException;
 import endolphin.backend.global.error.exception.ErrorCode;
+import endolphin.backend.global.security.PasswordEncoder;
 import endolphin.backend.global.util.TimeUtil;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
@@ -14,18 +16,22 @@ import org.springframework.stereotype.Component;
 public class PasswordCountService {
 
     private final StringRedisTemplate redisStringTemplate;
+    private final PasswordEncoder passwordEncoder;
 
-    private static final int MAX_FAILED_ATTEMPTS = 5;
+    public static final int MAX_FAILED_ATTEMPTS = 5;
     private static final long LOCKOUT_DURATION_MS = 5 * 60 * 1000;
 
-    public int increaseCount(Long userId, Long discussionId) {
-        String redisKey = "failedAttempts:" + discussionId + ":" + userId;
+    public int tryEnter(Long userId, Discussion discussion, String password) {
+        String redisKey = "failedAttempts:" + discussion.getId() + ":" + userId;
 
-        String countStr = redisStringTemplate.opsForValue().get(redisKey);
-        int failedAttemptsCount = countStr != null ? Integer.parseInt(countStr) : 0;
+        int failedAttemptsCount = getFailedCount(redisKey);
 
         if (failedAttemptsCount >= MAX_FAILED_ATTEMPTS) {
             throw new ApiException(ErrorCode.TOO_MANY_FAILED_ATTEMPTS);
+        }
+
+        if (discussion.getPassword() == null || checkPassword(discussion, password)) {
+            return 0;
         }
 
         Long updatedCount = redisStringTemplate.opsForValue().increment(redisKey);
@@ -40,15 +46,26 @@ public class PasswordCountService {
 
     public LocalDateTime getExpirationTime(Long userId, Long discussionId) {
         String redisKey = "failedAttempts:" + discussionId + ":" + userId;
-        String countStr = redisStringTemplate.opsForValue().get(redisKey);
-        int failedAttemptsCount = countStr != null ? Integer.parseInt(countStr) : 0;
 
-        if (failedAttemptsCount < MAX_FAILED_ATTEMPTS) {
+        if (getFailedCount(redisKey) < MAX_FAILED_ATTEMPTS) {
             return null;
         }
 
         long remainingTime = redisStringTemplate.getExpire(redisKey, TimeUnit.SECONDS);
 
         return TimeUtil.getNow().plusSeconds(remainingTime);
+    }
+
+    public int getFailedCount(String redisKey) {
+        String countStr = redisStringTemplate.opsForValue().get(redisKey);
+        return countStr != null ? Integer.parseInt(countStr) : 0;
+    }
+
+    private boolean checkPassword(Discussion discussion, String password) {
+        if (password == null || password.isBlank()) {
+            throw new ApiException(ErrorCode.PASSWORD_REQUIRED);
+        }
+
+        return passwordEncoder.matches(discussion.getId(), password, discussion.getPassword());
     }
 }

--- a/backend/src/main/java/endolphin/backend/global/security/JwtAuthFilter.java
+++ b/backend/src/main/java/endolphin/backend/global/security/JwtAuthFilter.java
@@ -69,10 +69,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             "/health"
         );
 
-        Pattern invitePattern = Pattern.compile("^/api/v1/discussion/\\d+/invite$");
-
         return "OPTIONS".equalsIgnoreCase(request.getMethod()) ||
-            excludedPaths.stream().anyMatch(path::startsWith) ||
-            invitePattern.matcher(path).matches();
+            excludedPaths.stream().anyMatch(path::startsWith);
     }
 }

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -410,6 +410,7 @@ public class DiscussionServiceTest {
         when(discussionParticipantService.getHostNameByDiscussionId(discussionId))
             .thenReturn("HostName");
         when(discussionParticipantService.isFull(discussionId)).thenReturn(true);
+        when(userService.getCurrentUser()).thenReturn(new User());
 
         InvitationInfo invitationInfo = discussionService.getInvitationInfo(discussionId);
 

--- a/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/domain/discussion/DiscussionServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,6 +21,7 @@ import endolphin.backend.domain.discussion.dto.DiscussionInfo;
 import endolphin.backend.domain.discussion.dto.DiscussionResponse;
 import endolphin.backend.domain.discussion.dto.InvitationInfo;
 import endolphin.backend.domain.discussion.dto.JoinDiscussionRequest;
+import endolphin.backend.domain.discussion.dto.JoinDiscussionResponse;
 import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.domain.discussion.enums.DiscussionStatus;
 import endolphin.backend.domain.discussion.enums.MeetingMethod;
@@ -577,6 +579,7 @@ public class DiscussionServiceTest {
         // 날짜 범위 검증 단계에서 예외가 발생하므로 다른 서비스들은 호출되지 않아야 함
         then(personalEventService).shouldHaveNoInteractions();
     }
+
     @DisplayName("비밀번호가 일치할 때 논의 참여 성공")
     @Test
     public void joinDiscussion_withCorrectPassword_returnsTrue() {
@@ -589,8 +592,7 @@ public class DiscussionServiceTest {
             .title("Test Discussion")
             .build();
         ReflectionTestUtils.setField(discussion, "discussionStatus", DiscussionStatus.ONGOING);
-        ReflectionTestUtils.setField(discussion, "id", 1L);
-
+        ReflectionTestUtils.setField(discussion, "id", discussionId);
         discussion.setPassword(encodedPassword);
 
         User currentUser = new User();
@@ -598,14 +600,11 @@ public class DiscussionServiceTest {
 
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
         when(userService.getCurrentUser()).thenReturn(currentUser);
-        when(passwordEncoder.matches(discussionId, correctPassword, encodedPassword)).thenReturn(
-            true);
+        when(passwordCountService.tryEnter(currentUser.getId(), discussion, correctPassword)).thenReturn(0);
 
-        // When
-        boolean result = discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(correctPassword)).isSuccess();
+        JoinDiscussionResponse response = discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(correctPassword));
 
-        // Then
-        assertThat(result).isTrue();
+        assertThat(response.isSuccess()).isTrue();
         verify(discussionParticipantService).addDiscussionParticipant(discussion, currentUser);
         verify(personalEventService).preprocessPersonalEvents(currentUser, discussion);
     }
@@ -622,29 +621,23 @@ public class DiscussionServiceTest {
             .title("Test Discussion")
             .build();
         ReflectionTestUtils.setField(discussion, "discussionStatus", DiscussionStatus.ONGOING);
-
+        ReflectionTestUtils.setField(discussion, "id", discussionId);
         discussion.setPassword(encodedPassword);
-
-        ReflectionTestUtils.setField(discussion, "id", 1L);
 
         User currentUser = new User();
         ReflectionTestUtils.setField(currentUser, "id", 1L);
 
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
         when(userService.getCurrentUser()).thenReturn(currentUser);
-        when(passwordEncoder.matches(discussionId, incorrectPassword, encodedPassword)).thenReturn(
-            false);
+        when(passwordCountService.tryEnter(currentUser.getId(), discussion, incorrectPassword)).thenReturn(1);
 
         // When
-        boolean result = discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(incorrectPassword)).isSuccess();
+        JoinDiscussionResponse response = discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(incorrectPassword));
 
-        // Then
-        assertThat(result).isFalse();
-        verify(passwordCountService).increaseCount(currentUser.getId(), discussionId);
-        verify(discussionParticipantService, org.mockito.Mockito.never()).addDiscussionParticipant(
-            any(), any());
-        verify(personalEventService, org.mockito.Mockito.never()).preprocessPersonalEvents(any(),
-            any());
+        assertThat(response.isSuccess()).isFalse();
+        verify(passwordCountService).tryEnter(currentUser.getId(), discussion, incorrectPassword);
+        verify(discussionParticipantService, never()).addDiscussionParticipant(any(), any());
+        verify(personalEventService, never()).preprocessPersonalEvents(any(), any());
     }
 
     @DisplayName("비밀번호가 없을 때 예외 발생")
@@ -656,15 +649,22 @@ public class DiscussionServiceTest {
             .title("Test Discussion")
             .build();
         ReflectionTestUtils.setField(discussion, "discussionStatus", DiscussionStatus.ONGOING);
-
         discussion.setPassword("encodedPassword123");
 
+        User currentUser = new User();
+        ReflectionTestUtils.setField(currentUser, "id", 1L);
+
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.of(discussion));
-        when(userService.getCurrentUser()).thenReturn(new User());
+        when(userService.getCurrentUser()).thenReturn(currentUser);
+
+        // 비밀번호가 null인 경우, passwordCountService.tryEnter가 예외를 던지도록 모킹
+        when(passwordCountService.tryEnter(currentUser.getId(), discussion, null))
+            .thenThrow(new ApiException(ErrorCode.PASSWORD_REQUIRED));
 
         // When & Then
-        assertThatThrownBy(() -> discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(null)))
-            .isInstanceOf(ApiException.class)
+        assertThatThrownBy(() ->
+            discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest(null))
+        ).isInstanceOf(ApiException.class)
             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_REQUIRED);
     }
 
@@ -676,10 +676,10 @@ public class DiscussionServiceTest {
         when(discussionRepository.findById(discussionId)).thenReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest("password123")))
-            .isInstanceOf(ApiException.class)
+        assertThatThrownBy(() ->
+            discussionService.joinDiscussion(discussionId, new JoinDiscussionRequest("password123"))
+        ).isInstanceOf(ApiException.class)
             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DISCUSSION_NOT_FOUND);
     }
-
 
 }

--- a/backend/src/test/java/endolphin/backend/global/redis/PasswordCountServiceTest.java
+++ b/backend/src/test/java/endolphin/backend/global/redis/PasswordCountServiceTest.java
@@ -5,21 +5,28 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import endolphin.backend.domain.discussion.entity.Discussion;
 import endolphin.backend.global.error.exception.ApiException;
+import endolphin.backend.global.security.PasswordEncoder;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class PasswordCountServiceTest {
 
     @Mock
     private StringRedisTemplate redisStringTemplate;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @Mock
     private ValueOperations<String, String> valueOperations;
@@ -30,7 +37,7 @@ public class PasswordCountServiceTest {
     public void setUp() {
         // StringRedisTemplate의 opsForValue() 호출 시 mock ValueOperations 반환
         when(redisStringTemplate.opsForValue()).thenReturn(valueOperations);
-        passwordCountService = new PasswordCountService(redisStringTemplate);
+        passwordCountService = new PasswordCountService(redisStringTemplate, passwordEncoder);
     }
 
     @Test
@@ -38,29 +45,36 @@ public class PasswordCountServiceTest {
         Long userId = 1L;
         Long discussionId = 1L;
         String redisKey = "failedAttempts:" + discussionId + ":" + userId;
+        Discussion discussion = new Discussion();
+        ReflectionTestUtils.setField(discussion, "id", discussionId);
+        ReflectionTestUtils.setField(discussion, "password", "password2");
 
         // 이전에 값이 없으면 null 반환 (즉, 첫 실패)
         when(valueOperations.get(redisKey)).thenReturn(null);
         // 증가 후 값으로 1 반환
         when(valueOperations.increment(redisKey)).thenReturn(1L);
 
-        passwordCountService.increaseCount(userId, discussionId);
+        passwordCountService.tryEnter(userId, discussion, "password");
 
         // 첫 실패시 expire가 설정되어야 함 (5분 = 5*60*1000 밀리초)
         verify(redisStringTemplate).expire(eq(redisKey), eq(5 * 60 * 1000L), eq(TimeUnit.MILLISECONDS));
     }
 
+    @DisplayName("첫 실패 후 성공")
     @Test
     public void testIncreaseCount_Success_SubsequentFailure() {
         Long userId = 2L;
         Long discussionId = 10L;
         String redisKey = "failedAttempts:" + discussionId + ":" + userId;
+        Discussion discussion = new Discussion();
+        ReflectionTestUtils.setField(discussion, "id", discussionId);
+        ReflectionTestUtils.setField(discussion, "password", "password");
 
         when(valueOperations.get(redisKey)).thenReturn("2");
 
-        when(valueOperations.increment(redisKey)).thenReturn(3L);
+        when(passwordEncoder.matches(discussionId, discussion.getPassword(), "password")).thenReturn(true);
 
-        passwordCountService.increaseCount(userId, discussionId);
+        passwordCountService.tryEnter(userId, discussion, "password");
     }
 
     @Test
@@ -69,10 +83,13 @@ public class PasswordCountServiceTest {
         Long discussionId = 20L;
         String redisKey = "failedAttempts:" + discussionId + ":" + userId;
 
+        Discussion discussion = new Discussion();
+        ReflectionTestUtils.setField(discussion, "id", discussionId);
+
         when(valueOperations.get(redisKey)).thenReturn("5");
 
         ApiException exception = assertThrows(ApiException.class, () ->
-            passwordCountService.increaseCount(userId, discussionId)
+            passwordCountService.tryEnter(userId, discussion, "password")
         );
 
     }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #176 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 초대장 정보 조회 시 이미 5회 실패한 유저라면 timeUnlocked를 함께 반환합니다.
- 5회 이상 실패 시 상태코드를 429 Too Many Requests로 수정했습니다.
- 5회 실패 이후 정상 비밀번호 입력 시 참여하지 못하도록 수정했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced invitation details now display an expiration timestamp and unlock time to provide clearer timing information for secure access.
  - Improved password handling during discussion joining, including tracking of failed attempts and password expiration.

- **Bug Fixes**
  - Updated error responses for excessive failed attempts to correctly indicate rate limiting, improving feedback accuracy.

- **Refactor**
  - Streamlined authentication filtering logic to simplify request processing and ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->