### PR TITLE
[BE-Fix] 구글에서 반영된 일정이 항상 조정 불가능으로 되는 버그 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -243,7 +243,7 @@ public class PersonalEventService {
             .ifPresentOrElse(personalEvent -> {
                     changedDates.add(personalEvent.getStartTime().toLocalDate());
                     changedDates.add(personalEvent.getEndTime().toLocalDate());
-                    updatePersonalEvent(PersonalEventRequest.of(googleEvent), personalEvent, user,
+                    updatePersonalEvent(PersonalEventRequest.of(googleEvent, personalEvent), personalEvent, user,
                         discussions);
                 },
                 () -> {

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/PersonalEventService.java
@@ -243,8 +243,9 @@ public class PersonalEventService {
             .ifPresentOrElse(personalEvent -> {
                     changedDates.add(personalEvent.getStartTime().toLocalDate());
                     changedDates.add(personalEvent.getEndTime().toLocalDate());
-                    updatePersonalEvent(PersonalEventRequest.of(googleEvent, personalEvent), personalEvent, user,
-                        discussions);
+                    updatePersonalEvent(
+                        PersonalEventRequest.of(googleEvent, personalEvent.getIsAdjustable()),
+                        personalEvent, user, discussions);
                 },
                 () -> {
                     PersonalEvent personalEvent =

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/dto/PersonalEventRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/dto/PersonalEventRequest.java
@@ -15,12 +15,12 @@ public record PersonalEventRequest(
     Boolean syncWithGoogleCalendar
 ) {
 
-    public static PersonalEventRequest of(GoogleEvent googleEvent, PersonalEvent personalEvent) {
+    public static PersonalEventRequest of(GoogleEvent googleEvent, boolean isAdjustable) {
         return new PersonalEventRequest(
             googleEvent.summary(),
             googleEvent.startDateTime(),
             googleEvent.endDateTime(),
-            personalEvent.getIsAdjustable(),
+            isAdjustable,
             false
         );
     }

--- a/backend/src/main/java/endolphin/backend/domain/personal_event/dto/PersonalEventRequest.java
+++ b/backend/src/main/java/endolphin/backend/domain/personal_event/dto/PersonalEventRequest.java
@@ -1,5 +1,6 @@
 package endolphin.backend.domain.personal_event.dto;
 
+import endolphin.backend.domain.personal_event.entity.PersonalEvent;
 import endolphin.backend.global.google.dto.GoogleEvent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -14,12 +15,12 @@ public record PersonalEventRequest(
     Boolean syncWithGoogleCalendar
 ) {
 
-    public static PersonalEventRequest of(GoogleEvent googleEvent) {
+    public static PersonalEventRequest of(GoogleEvent googleEvent, PersonalEvent personalEvent) {
         return new PersonalEventRequest(
             googleEvent.summary(),
             googleEvent.startDateTime(),
             googleEvent.endDateTime(),
-            false,
+            personalEvent.getIsAdjustable(),
             false
         );
     }


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #137 

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
구글에서 가져오는 일정이 항상 조정 불가능으로 되는 버그 수정했습니다.
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the process for updating personal events by leveraging additional event context, allowing for more accurate handling of the `isAdjustable` attribute during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->