### PR TITLE
[FE-Feat] 팝오버 인풋 수정 구현, 긴 일정 계산 오류 수정

### DIFF
--- a/frontend/src/features/my-calendar/api/hooks.ts
+++ b/frontend/src/features/my-calendar/api/hooks.ts
@@ -1,6 +1,6 @@
 import type { FormValues } from '@/hooks/useFormRef';
 
-import type { PersonalEventRequest } from '../model';
+import type { PersonalEventWithDateAndTime } from '../ui/SchedulePopover/PopoverContext';
 import { 
   usePersonalEventDeleteMutation, 
   usePersonalEventMutation, 
@@ -16,24 +16,27 @@ export const useSchedulePopover = ({
   setIsOpen: (isOpen: boolean) => void;
   reset?: () => void;
   scheduleId?: number;
-  valuesRef: { current: FormValues<PersonalEventRequest> };
+  valuesRef: { current: FormValues<PersonalEventWithDateAndTime> };
 }) => {
   const { mutate: createMutate } = usePersonalEventMutation();
   const { mutate: editMutate } = usePersonalEventUpdateMutation();
   const { mutate: deleteMutate } = usePersonalEventDeleteMutation();
-  
+  const createSchedule = () => {
+    const { startTime, startDate, endDate, endTime, ...values } = valuesRef.current;
+    const startDateTime = `${valuesRef.current.startDate}T${valuesRef.current.startTime}`;
+    const endDateTime = `${valuesRef.current.endDate}T${valuesRef.current.endTime}`;
+    return { ...values, startDateTime, endDateTime };
+  };
   const handleClickCreate = () => {
-    createMutate(valuesRef.current);
+    createMutate(createSchedule());
     reset?.();
     setIsOpen(false);
   };
-  
   const handleClickEdit = () => {
-    if (scheduleId) editMutate({ id: scheduleId, body: valuesRef.current });
+    if (scheduleId) editMutate({ id: scheduleId, body: createSchedule() });
     reset?.();
     setIsOpen(false);
   };
-  
   const handleClickDelete = () => {
     if (scheduleId) deleteMutate({
       id: scheduleId,
@@ -42,7 +45,6 @@ export const useSchedulePopover = ({
     reset?.();
     setIsOpen(false);
   };
-  
   return { handleClickCreate, handleClickEdit, handleClickDelete };
 };
   

--- a/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
+++ b/frontend/src/features/my-calendar/ui/CalendarCardList/index.tsx
@@ -16,6 +16,9 @@ const DefaultCard = (
 ) => {
   const { x: sx, y: sy } = calcPositionByDate(start);
   const { y: ey } = calcPositionByDate(end);
+  
+  if (sy === ey) return null;
+
   const height = ey - sy;
   return (
     <CalendarCard

--- a/frontend/src/features/my-calendar/ui/MyCalendar/CalendarDiscussionBox.tsx
+++ b/frontend/src/features/my-calendar/ui/MyCalendar/CalendarDiscussionBox.tsx
@@ -9,8 +9,7 @@ export const CalendarDiscussionBox = () => {
   const { selectedWeek } = useSharedCalendarContext();
   if (!selectedDateRange) return null;
  
-  const { start, end } = selectedDateRange;
-  const sizePosition = calcSizeByDate({ start, end }, selectedWeek);
+  const sizePosition = calcSizeByDate(selectedDateRange, selectedWeek);
 
   if (!sizePosition) return null;
   const { x, y, width, height } = sizePosition;

--- a/frontend/src/features/my-calendar/ui/OngoingDiscussion/OngoingCardList.tsx
+++ b/frontend/src/features/my-calendar/ui/OngoingDiscussion/OngoingCardList.tsx
@@ -1,11 +1,14 @@
 import { useSharedCalendarContext } from '@/components/Calendar/context/SharedCalendarContext';
+import { Text } from '@/components/Text';
 import { useOngoingQuery } from '@/features/shared-schedule/api/queries';
 import type { OngoingSchedule } from '@/features/shared-schedule/model';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useDiscussionContext } from '@/pages/MyCalendarPage/DiscussionContext';
 import { useTableContext } from '@/pages/MyCalendarPage/TableContext';
+import { vars } from '@/theme/index.css';
 import { parseTime, setTimeOnly } from '@/utils/date';
 
+import { emptyTextStyle } from './index.css';
 import { OngoingCardItem } from './OngoingCardItem';
 
 const formatDateTimeRange = (
@@ -18,6 +21,16 @@ const formatDateTimeRange = (
 
   return { start, end, sh, sm, eh, em };
 };
+
+const EmptyCard = () => (
+  <Text
+    className={emptyTextStyle}
+    color={vars.color.Ref.Netural[700]}
+    typo='b3M'
+  >
+    아직 조율 중인 일정이 없어요.
+  </Text>
+);
 
 export const OngoingCardList = () => {
   const { data, isPending } = useOngoingQuery(1, 2, 'ALL');
@@ -32,7 +45,6 @@ export const OngoingCardList = () => {
       reset();
       return;
     }
-    
     const { start, end, sh, sm, eh, em } = formatDateTimeRange(discussion);
     setSelectedId(discussion.discussionId);
     handleSelectDateRange(
@@ -47,6 +59,7 @@ export const OngoingCardList = () => {
   const cardRef = useClickOutside<HTMLDivElement>(()=>handleClickSelect(null));
 
   if (isPending || !data) return null;
+  if (!data.ongoingDiscussions.length) return <EmptyCard />;
 
   return data.ongoingDiscussions.map((discussion) => (
     <OngoingCardItem

--- a/frontend/src/features/my-calendar/ui/OngoingDiscussion/index.css.ts
+++ b/frontend/src/features/my-calendar/ui/OngoingDiscussion/index.css.ts
@@ -45,3 +45,7 @@ export const cardTextStyle = style({
   alignItems: 'center',
   gap: vars.spacing[200],
 });
+
+export const emptyTextStyle = style({
+  padding: `0 ${vars.spacing[400]}`,
+});

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/AdjustableCheckbox.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/AdjustableCheckbox.tsx
@@ -1,0 +1,20 @@
+import { Checkbox } from '@/components/Checkbox';
+
+import { usePopoverFormContext } from './PopoverContext';
+
+export const AdjustableCheckbox = () => {
+  const { valuesRef, handleChange } = usePopoverFormContext();
+  
+  return (
+    <Checkbox
+      defaultChecked={valuesRef.current.isAdjustable}
+      inputProps={{
+        name: 'isAdjustable',
+        onChange: (e) => handleChange({ name: 'isAdjustable', value: e.target.checked }),
+      }}
+      size='sm'
+    >
+      시간 조정 가능
+    </Checkbox>
+  );
+};

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/DateInput.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/DateInput.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+import DatePicker from '@/components/DatePicker';
+import Input from '@/components/Input';
+import { useMonthNavigation } from '@/hooks/useDatePicker/useMonthNavigation';
+import { formatDateToBarString } from '@/utils/date/format';
+
+import { usePopoverFormContext } from './PopoverContext';
+
+interface DateRange {
+  startDate: Date | null;
+  endDate: Date | null;
+}
+
+export const DateInput = () => {
+  const { valuesRef, handleChange } = usePopoverFormContext();
+  const startDate = new Date(valuesRef.current.startDate);
+  const endDate = new Date(valuesRef.current.endDate);
+  const [range, setRange] = useState<DateRange>({ startDate, endDate });
+  
+  const handleClickStartDate = (date: Date | null) => {
+    handleChange({ name: 'startDate', value: formatDateToBarString(date) });
+    setRange((prev) => ({ ...prev, startDate: date }));
+  };
+  const handleClickEndDate = (date: Date | null) => {
+    handleChange({ name: 'endDate', value: formatDateToBarString(date) });
+    setRange((prev) => ({ ...prev, endDate: date }));
+  };
+    
+  return (
+    <DatePicker.Range
+      {...useMonthNavigation(startDate)}
+      highlightRange={{ start: range.startDate, end: range.endDate }}
+      setHighlightEnd={handleClickEndDate}
+      setHighlightStart={handleClickStartDate}
+      trigger={
+        <Input.Multi
+          label='기간 설정'
+          separator='~'
+          type='select'
+        >
+          <Input.Multi.InputField value={formatDateToBarString(range.startDate)} />
+          <Input.Multi.InputField value={formatDateToBarString(range.endDate)} />
+        </Input.Multi>
+      }
+    />
+  );
+};

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/GoggleCalendarToggle.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/GoggleCalendarToggle.tsx
@@ -1,0 +1,17 @@
+import { Toggle } from '@/components/Toggle';
+
+import { usePopoverFormContext } from './PopoverContext';
+
+export const GoogleCalendarToggle = () => {
+  const { valuesRef, handleChange } = usePopoverFormContext();
+  
+  return (
+    <Toggle
+      defaultChecked={valuesRef.current.syncWithGoogleCalendar}
+      inputProps={{
+        name: 'syncWithGoogleCalendar',
+        onChange: (e) => handleChange({ name: 'syncWithGoogleCalendar', value: e.target.checked }),
+      }}
+    />
+  );
+};

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverButton.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverButton.tsx
@@ -1,32 +1,48 @@
 import Button from '@/components/Button';
 import { Flex } from '@/components/Flex';
 
-import type { PopoverType } from '../../model';
+import { useSchedulePopover } from '../../api/hooks';
 import { buttonStyle } from './index.css';
+import { usePopoverFormContext } from './PopoverContext';
+import type { SchedulePopoverBaseProps } from './type';
 
-interface PopoverButtonProps {
-  type: PopoverType;
-  onClickCreate: () => void;
-  onClickEdit: () => void;
-  onClickDelete: () => void;
-}
+export const PopoverButton = ({ type, setIsOpen, reset, scheduleId }: SchedulePopoverBaseProps)=> {
+  const { valuesRef, handleSubmit } = usePopoverFormContext();
+  const { handleClickCreate, handleClickEdit, handleClickDelete } = useSchedulePopover({
+    setIsOpen,
+    reset,
+    scheduleId,
+    valuesRef,
+  });
 
-export const PopoverButton = ({ type, ...handlers }: PopoverButtonProps)=>(
-  type === 'add' ? <Button className={buttonStyle} onClick={handlers.onClickCreate}>저장</Button> : (
-    <Flex
-      gap={100}
-      justify='flex-end'
-      width='100%'
-    >
+  return(
+    type === 'add' ? 
       <Button
-        className={buttonStyle}
-        onClick={handlers.onClickDelete}
-        style='weak'
-        variant='destructive'
+        className={buttonStyle} 
+        onClick={()=>handleSubmit(handleClickCreate)}
       >
-        삭제
-      </Button>
-      <Button className={buttonStyle} onClick={handlers.onClickEdit}>저장</Button>
-    </Flex>
-  )
-);
+        저장
+      </Button> : (
+        <Flex
+          gap={100}
+          justify='flex-end'
+          width='100%'
+        >
+          <Button
+            className={buttonStyle}
+            onClick={handleClickDelete}
+            style='weak'
+            variant='destructive'
+          >
+            삭제
+          </Button>
+          <Button 
+            className={buttonStyle}
+            onClick={()=>handleSubmit(handleClickEdit)}
+          >
+            저장
+          </Button>
+        </Flex>
+      )
+  );
+};

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverContext.ts
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverContext.ts
@@ -5,5 +5,13 @@ import { useSafeContext } from '@/hooks/useSafeContext';
 
 import type { PersonalEventRequest } from '../../model';
 
-export const PopoverFormContext = createContext<FormRef<PersonalEventRequest> | null>(null);
+export interface PersonalEventWithDateAndTime 
+  extends Omit<PersonalEventRequest, 'startDateTime' | 'endDateTime'> {
+  startDate: Date;
+  endDate: Date;
+  startTime: string;
+  endTime: string;
+}
+
+export const PopoverFormContext = createContext<FormRef<PersonalEventWithDateAndTime> | null>(null);
 export const usePopoverFormContext = () => useSafeContext(PopoverFormContext);

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverContext.ts
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+import type { FormRef } from '@/hooks/useFormRef';
+import { useSafeContext } from '@/hooks/useSafeContext';
+
+import type { PersonalEventRequest } from '../../model';
+
+export const PopoverFormContext = createContext<FormRef<PersonalEventRequest> | null>(null);
+export const usePopoverFormContext = () => useSafeContext(PopoverFormContext);

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
@@ -58,7 +58,7 @@ const DateInput = ({ valuesRef, handleChange }: FormRef<PersonalEventRequest>) =
   
   return (
     <DatePicker.Range
-      {...useMonthNavigation()}
+      {...useMonthNavigation(startDateTime)}
       highlightRange={{ start: range.startDateTime, end: range.endDateTime }}
       setHighlightEnd={handleClickEndDate}
       setHighlightStart={handleClickStartDate}

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
@@ -5,7 +5,8 @@ import { Text } from '@/components/Text';
 import { Toggle } from '@/components/Toggle';
 import type { FormRef } from '@/hooks/useFormRef';
 import { vars } from '@/theme/index.css';
-import { formatDateToTimeString } from '@/utils/date/format';
+import { parseTime, setTimeOnly } from '@/utils/date';
+import { formatDateToDateTimeString, formatDateToTimeString } from '@/utils/date/format';
 
 import type { PersonalEventRequest } from '../../model';
 import { cardStyle, inputStyle } from './index.css';
@@ -25,6 +26,40 @@ const AdjustableCheckbox = (
     시간 조정 가능
   </Checkbox>
 );
+
+const TimeInput = ({ valuesRef, handleChange }: FormRef<PersonalEventRequest>) => {
+  const startDateTime = new Date(valuesRef.current.startDateTime);
+  const endDateTime = new Date(valuesRef.current.endDateTime);
+
+  const formatValueTimeToDateTime = (date: Date, time: string) => {
+    const newDate = setTimeOnly(date, parseTime(time));
+    return formatDateToDateTimeString(newDate);
+  };
+
+  return (
+    <Input.Multi
+      borderPlacement='container'
+      label='시간 설정'
+      separator='~'
+      type='text'
+    >
+      <Input.Multi.InputField 
+        defaultValue={formatDateToTimeString(startDateTime)}
+        onChange={(e) => handleChange({ 
+          name: 'startDateTime', 
+          value: formatValueTimeToDateTime(startDateTime, e.target.value),
+        })}
+      />
+      <Input.Multi.InputField
+        defaultValue={formatDateToTimeString(endDateTime)}
+        onChange={(e) => handleChange({ 
+          name: 'endDateTime', 
+          value: formatValueTimeToDateTime(endDateTime, e.target.value),
+        })}
+      />
+    </Input.Multi>
+  ); 
+};
 
 const GoogleCalendarToggle = (
   { valuesRef, handleChange }: FormRef<PersonalEventRequest>,
@@ -52,21 +87,7 @@ export const PopoverForm = ({ valuesRef, handleChange }: FormRef<PersonalEventRe
         onChange={(e) => handleChange({ name: 'title', value: e.target.value })}
         placeholder='새 일정'
       />
-      <Input.Multi
-        borderPlacement='container'
-        label='시간 설정'
-        separator='~'
-        type='text'
-      >
-        <Input.Multi.InputField 
-          readOnly
-          value={formatDateToTimeString(new Date(valuesRef.current.startDateTime))}
-        />
-        <Input.Multi.InputField
-          readOnly
-          value={formatDateToTimeString(new Date(valuesRef.current.endDateTime))}
-        />
-      </Input.Multi>
+      <TimeInput handleChange={handleChange} valuesRef={valuesRef} />
       <AdjustableCheckbox handleChange={handleChange} valuesRef={valuesRef} />
     </Flex>
     <Flex className={cardStyle} justify='space-between'>

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
@@ -7,7 +7,6 @@ import Input from '@/components/Input';
 import { Text } from '@/components/Text';
 import { Toggle } from '@/components/Toggle';
 import { useMonthNavigation } from '@/hooks/useDatePicker/useMonthNavigation';
-import type { FormRef } from '@/hooks/useFormRef';
 import { vars } from '@/theme/index.css';
 import { parseTime, setDateOnly, setTimeOnly } from '@/utils/date';
 import { 
@@ -16,8 +15,8 @@ import {
   formatDateToTimeString, 
 } from '@/utils/date/format';
 
-import type { PersonalEventRequest } from '../../model';
 import { cardStyle, inputStyle } from './index.css';
+import { usePopoverFormContext } from './PopoverContext';
 
 interface DateRange {
   startDateTime: Date | null;
@@ -25,22 +24,25 @@ interface DateRange {
 }
 
 // TODO: Form Context 관리
-const AdjustableCheckbox = (
-  { valuesRef, handleChange }: FormRef<PersonalEventRequest>,
-) => (
-  <Checkbox
-    defaultChecked={valuesRef.current.isAdjustable}
-    inputProps={{
-      name: 'isAdjustable',
-      onChange: (e) => handleChange({ name: 'isAdjustable', value: e.target.checked }),
-    }}
-    size='sm'
-  >
-    시간 조정 가능
-  </Checkbox>
-);
+const AdjustableCheckbox = () => {
+  const { valuesRef, handleChange } = usePopoverFormContext();
 
-const DateInput = ({ valuesRef, handleChange }: FormRef<PersonalEventRequest>) => {
+  return (
+    <Checkbox
+      defaultChecked={valuesRef.current.isAdjustable}
+      inputProps={{
+        name: 'isAdjustable',
+        onChange: (e) => handleChange({ name: 'isAdjustable', value: e.target.checked }),
+      }}
+      size='sm'
+    >
+      시간 조정 가능
+    </Checkbox>
+  );
+};
+
+const DateInput = () => {
+  const { valuesRef, handleChange } = usePopoverFormContext();
   const startDateTime = new Date(valuesRef.current.startDateTime);
   const endDateTime = new Date(valuesRef.current.endDateTime);
   const [range, setRange] = useState<DateRange>({ startDateTime, endDateTime });
@@ -76,7 +78,8 @@ const DateInput = ({ valuesRef, handleChange }: FormRef<PersonalEventRequest>) =
   );
 };
 
-const TimeInput = ({ valuesRef, handleChange }: FormRef<PersonalEventRequest>) => {
+const TimeInput = () => {
+  const { valuesRef, handleChange } = usePopoverFormContext();
   const startDateTime = new Date(valuesRef.current.startDateTime);
   const endDateTime = new Date(valuesRef.current.endDateTime);
 
@@ -110,38 +113,45 @@ const TimeInput = ({ valuesRef, handleChange }: FormRef<PersonalEventRequest>) =
   ); 
 };
 
-const GoogleCalendarToggle = (
-  { valuesRef, handleChange }: FormRef<PersonalEventRequest>,
-) =>
-  <Toggle
-    defaultChecked={valuesRef.current.syncWithGoogleCalendar}
-    inputProps={{
-      name: 'syncWithGoogleCalendar',
-      onChange: (e) => handleChange({ name: 'syncWithGoogleCalendar', value: e.target.checked }),
-    }}
-  />;
+const GoogleCalendarToggle = () => {
+  const { valuesRef, handleChange } = usePopoverFormContext();
 
-export const PopoverForm = ({ valuesRef, handleChange }: FormRef<PersonalEventRequest>) => 
-  <>
-    <Flex
-      align='flex-end'
-      className={cardStyle}
-      direction='column'
-      gap={400}
-    >
-      <input
-        className={inputStyle}
-        defaultValue={valuesRef.current.title}
-        name='title'
-        onChange={(e) => handleChange({ name: 'title', value: e.target.value })}
-        placeholder='새 일정'
-      />
-      <DateInput handleChange={handleChange} valuesRef={valuesRef} />
-      <TimeInput handleChange={handleChange} valuesRef={valuesRef} />
-      <AdjustableCheckbox handleChange={handleChange} valuesRef={valuesRef} />
-    </Flex>
-    <Flex className={cardStyle} justify='space-between'>
-      <Text color={vars.color.Ref.Netural[600]} typo='caption'>구글 캘린더 연동</Text>
-      <GoogleCalendarToggle handleChange={handleChange} valuesRef={valuesRef} />
-    </Flex>
-  </>;
+  return (
+    <Toggle
+      defaultChecked={valuesRef.current.syncWithGoogleCalendar}
+      inputProps={{
+        name: 'syncWithGoogleCalendar',
+        onChange: (e) => handleChange({ name: 'syncWithGoogleCalendar', value: e.target.checked }),
+      }}
+    />
+  );
+};
+
+export const PopoverForm = () => { 
+  const { valuesRef, handleChange } = usePopoverFormContext();
+  return (
+    <>
+      <Flex
+        align='flex-end'
+        className={cardStyle}
+        direction='column'
+        gap={400}
+      >
+        <input
+          className={inputStyle}
+          defaultValue={valuesRef.current.title}
+          name='title'
+          onChange={(e) => handleChange({ name: 'title', value: e.target.value })}
+          placeholder='새 일정'
+        />
+        <DateInput />
+        <TimeInput />
+        <AdjustableCheckbox />
+      </Flex>
+      <Flex className={cardStyle} justify='space-between'>
+        <Text color={vars.color.Ref.Netural[600]} typo='caption'>구글 캘린더 연동</Text>
+        <GoogleCalendarToggle />
+      </Flex>
+    </>
+  );
+};

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/PopoverForm.tsx
@@ -1,131 +1,13 @@
-import { useState } from 'react';
-
-import { Checkbox } from '@/components/Checkbox';
-import DatePicker from '@/components/DatePicker';
 import { Flex } from '@/components/Flex';
-import Input from '@/components/Input';
 import { Text } from '@/components/Text';
-import { Toggle } from '@/components/Toggle';
-import { useMonthNavigation } from '@/hooks/useDatePicker/useMonthNavigation';
 import { vars } from '@/theme/index.css';
-import { parseTime, setDateOnly, setTimeOnly } from '@/utils/date';
-import { 
-  formatDateToBarString, 
-  formatDateToDateTimeString, 
-  formatDateToTimeString, 
-} from '@/utils/date/format';
 
+import { AdjustableCheckbox } from './AdjustableCheckbox';
+import { DateInput } from './DateInput';
+import { GoogleCalendarToggle } from './GoggleCalendarToggle';
 import { cardStyle, inputStyle } from './index.css';
 import { usePopoverFormContext } from './PopoverContext';
-
-interface DateRange {
-  startDateTime: Date | null;
-  endDateTime: Date | null;
-}
-
-// TODO: Form Context 관리
-const AdjustableCheckbox = () => {
-  const { valuesRef, handleChange } = usePopoverFormContext();
-
-  return (
-    <Checkbox
-      defaultChecked={valuesRef.current.isAdjustable}
-      inputProps={{
-        name: 'isAdjustable',
-        onChange: (e) => handleChange({ name: 'isAdjustable', value: e.target.checked }),
-      }}
-      size='sm'
-    >
-      시간 조정 가능
-    </Checkbox>
-  );
-};
-
-const DateInput = () => {
-  const { valuesRef, handleChange } = usePopoverFormContext();
-  const startDateTime = new Date(valuesRef.current.startDateTime);
-  const endDateTime = new Date(valuesRef.current.endDateTime);
-  const [range, setRange] = useState<DateRange>({ startDateTime, endDateTime });
-  const updateDate = (date: Date, newDate: Date | null) => 
-    formatDateToDateTimeString(setDateOnly(date, newDate));
-
-  const handleClickStartDate = (date: Date | null) => {
-    handleChange({ name: 'startDateTime', value: updateDate(startDateTime, date) });
-    setRange((prev) => ({ ...prev, startDateTime: date }));
-  };
-  const handleClickEndDate = (date: Date | null) => {
-    handleChange({ name: 'endDateTime', value: updateDate(endDateTime, date) });
-    setRange((prev) => ({ ...prev, endDateTime: date }));
-  };
-  
-  return (
-    <DatePicker.Range
-      {...useMonthNavigation(startDateTime)}
-      highlightRange={{ start: range.startDateTime, end: range.endDateTime }}
-      setHighlightEnd={handleClickEndDate}
-      setHighlightStart={handleClickStartDate}
-      trigger={
-        <Input.Multi
-          label='기간 설정'
-          separator='~'
-          type='select'
-        >
-          <Input.Multi.InputField value={formatDateToBarString(startDateTime)} />
-          <Input.Multi.InputField value={formatDateToBarString(endDateTime)} />
-        </Input.Multi>
-      }
-    />
-  );
-};
-
-const TimeInput = () => {
-  const { valuesRef, handleChange } = usePopoverFormContext();
-  const startDateTime = new Date(valuesRef.current.startDateTime);
-  const endDateTime = new Date(valuesRef.current.endDateTime);
-
-  const formatValueTimeToDateTime = (date: Date, time: string) => {
-    const newDate = setTimeOnly(date, parseTime(time));
-    return formatDateToDateTimeString(newDate);
-  };
-
-  return (
-    <Input.Multi
-      borderPlacement='container'
-      label='시간 설정'
-      separator='~'
-      type='text'
-    >
-      <Input.Multi.InputField 
-        defaultValue={formatDateToTimeString(startDateTime)}
-        onChange={(e) => handleChange({ 
-          name: 'startDateTime', 
-          value: formatValueTimeToDateTime(startDateTime, e.target.value),
-        })}
-      />
-      <Input.Multi.InputField
-        defaultValue={formatDateToTimeString(endDateTime)}
-        onChange={(e) => handleChange({ 
-          name: 'endDateTime', 
-          value: formatValueTimeToDateTime(endDateTime, e.target.value),
-        })}
-      />
-    </Input.Multi>
-  ); 
-};
-
-const GoogleCalendarToggle = () => {
-  const { valuesRef, handleChange } = usePopoverFormContext();
-
-  return (
-    <Toggle
-      defaultChecked={valuesRef.current.syncWithGoogleCalendar}
-      inputProps={{
-        name: 'syncWithGoogleCalendar',
-        onChange: (e) => handleChange({ name: 'syncWithGoogleCalendar', value: e.target.checked }),
-      }}
-    />
-  );
-};
+import { TimeInput } from './TimeInput';
 
 export const PopoverForm = () => { 
   const { valuesRef, handleChange } = usePopoverFormContext();

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/TimeInput.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/TimeInput.tsx
@@ -1,0 +1,44 @@
+import Input from '@/components/Input';
+import { isSameDate } from '@/utils/date';
+import { formatTimeStringToNumber } from '@/utils/date/format';
+
+import { usePopoverFormContext } from './PopoverContext';
+
+export const TimeInput = () => {
+  const { valuesRef, setValidation, errors, isValid, handleChange } = usePopoverFormContext();
+  
+  setValidation('startTime', () => {
+    const startTime = formatTimeStringToNumber(valuesRef.current.startTime);
+    const endTime = formatTimeStringToNumber(valuesRef.current.endTime);
+    if (isSameDate(new Date(valuesRef.current.startDate), new Date(valuesRef.current.endDate)) 
+        && startTime >= endTime) return '시작 시간은 종료 시간보다 빨라야 합니다.';
+    return null;
+  });
+  
+  return (
+    <Input.Multi
+      borderPlacement='container'
+      error={errors('startTime')}
+      isValid={isValid('startTime')}
+      label='시간 설정'
+      separator='~'
+      type='text'
+    >
+      <Input.Multi.InputField 
+        defaultValue={valuesRef.current.startTime}
+        onChange={(e) => handleChange({ 
+          name: 'startTime', 
+          value: e.target.value,
+        })}
+      />
+      <Input.Multi.InputField
+        defaultValue={valuesRef.current.endTime}
+        onChange={(e) => handleChange({ 
+          name: 'endTime', 
+          value: e.target.value,
+        })}
+      />
+    </Input.Multi>
+  ); 
+};
+  

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.css.ts
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.css.ts
@@ -4,7 +4,7 @@ import { font } from '@/theme/font';
 import { vars } from '@/theme/index.css';
 
 export const containerStyle = style({
-  width: 262,
+  width: 360,
 
   padding: vars.spacing[300],
 

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
@@ -1,10 +1,12 @@
 import { Flex } from '@/components/Flex';
 import { useFormRef } from '@/hooks/useFormRef';
+import { formatDateToTimeString } from '@/utils/date';
+import { formatDateToBarString } from '@/utils/date/format';
 import { calcPositionByDate } from '@/utils/date/position';
 
-import type { PersonalEventRequest } from '../../model';
 import { backgroundStyle, containerStyle } from './index.css';
 import { PopoverButton } from './PopoverButton';
+import type { PersonalEventWithDateAndTime } from './PopoverContext';
 import { PopoverFormContext } from './PopoverContext';
 import { PopoverForm } from './PopoverForm';
 import { Title } from './Title';
@@ -33,12 +35,15 @@ export const SchedulePopover = (
   { setIsOpen, reset, scheduleId, type, values, ...event }: SchedulePopoverProps,
 ) => {
   const startDate = new Date(event.startDateTime);
+  const endDate = new Date(event.endDateTime);
   const { x: sx } = calcPositionByDate(startDate);
 
   return(
-    <PopoverFormContext.Provider value={useFormRef<PersonalEventRequest>({
-      startDateTime: event.startDateTime,
-      endDateTime: event.endDateTime,
+    <PopoverFormContext.Provider value={useFormRef<PersonalEventWithDateAndTime>({
+      startTime: formatDateToTimeString(startDate),
+      endTime: formatDateToTimeString(endDate),
+      startDate: formatDateToBarString(startDate),
+      endDate: formatDateToBarString(endDate),
       ...initEvent(values),
     })}
     >

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
@@ -46,8 +46,8 @@ export const SchedulePopover = (
         className={containerStyle}
         style={{
           position: 'fixed',
-          left: `calc((100vw - 72px - 17.75rem) / 7 * ${sx + 1})`,
-          top: '50vh',
+          left: `calc((100vw - 72px - 17.75rem) / 7 * ${sx + 1} - 3rem)`,
+          top: '30vh',
         }}
       >
         <Title type={type} />

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/index.tsx
@@ -2,22 +2,13 @@ import { Flex } from '@/components/Flex';
 import { useFormRef } from '@/hooks/useFormRef';
 import { calcPositionByDate } from '@/utils/date/position';
 
-import { useSchedulePopover } from '../../api/hooks';
-import type { PersonalEventRequest, PopoverType } from '../../model';
+import type { PersonalEventRequest } from '../../model';
 import { backgroundStyle, containerStyle } from './index.css';
 import { PopoverButton } from './PopoverButton';
+import { PopoverFormContext } from './PopoverContext';
 import { PopoverForm } from './PopoverForm';
 import { Title } from './Title';
-
-type DefaultEvent = Omit<PersonalEventRequest, 'endDateTime' | 'startDateTime'>;
-
-interface SchedulePopoverProps extends Pick<PersonalEventRequest, 'endDateTime' | 'startDateTime'> {
-  scheduleId?: number;
-  values?: DefaultEvent;
-  setIsOpen: (isOpen: boolean) => void;
-  type: PopoverType;
-  reset?: () => void;
-}
+import type { DefaultEvent, SchedulePopoverProps } from './type';
 
 const initEvent = (values?: DefaultEvent): DefaultEvent => {
   if (values) return values;
@@ -43,19 +34,14 @@ export const SchedulePopover = (
 ) => {
   const startDate = new Date(event.startDateTime);
   const { x: sx } = calcPositionByDate(startDate);
-  const { valuesRef, handleChange } = useFormRef<PersonalEventRequest>({
-    startDateTime: event.startDateTime,
-    endDateTime: event.endDateTime,
-    ...initEvent(values),
-  });
-  const { handleClickCreate, handleClickEdit, handleClickDelete } = useSchedulePopover({
-    setIsOpen,
-    reset,
-    scheduleId,
-    valuesRef,
-  });
+
   return(
-    <>
+    <PopoverFormContext.Provider value={useFormRef<PersonalEventRequest>({
+      startDateTime: event.startDateTime,
+      endDateTime: event.endDateTime,
+      ...initEvent(values),
+    })}
+    >
       <dialog
         className={containerStyle}
         style={{
@@ -65,15 +51,15 @@ export const SchedulePopover = (
         }}
       >
         <Title type={type} />
-        <PopoverForm handleChange={handleChange} valuesRef={valuesRef} />
+        <PopoverForm />
         <PopoverButton
-          onClickCreate={handleClickCreate}
-          onClickDelete={handleClickDelete}
-          onClickEdit={handleClickEdit}
+          reset={reset}
+          scheduleId={scheduleId}
+          setIsOpen={setIsOpen}
           type={type}
         />
       </dialog>
       <Background reset={reset} setIsOpen={setIsOpen} />
-    </>
+    </PopoverFormContext.Provider>
   ); 
 };

--- a/frontend/src/features/my-calendar/ui/SchedulePopover/type.ts
+++ b/frontend/src/features/my-calendar/ui/SchedulePopover/type.ts
@@ -1,0 +1,14 @@
+import type { PersonalEventRequest, PopoverType } from '../../model';
+
+export type DefaultEvent = Omit<PersonalEventRequest, 'endDateTime' | 'startDateTime'>;
+
+export interface SchedulePopoverBaseProps {
+  scheduleId?: number;
+  values?: DefaultEvent;
+  setIsOpen: (isOpen: boolean) => void;
+  type: PopoverType;
+  reset?: () => void;
+}
+
+export type SchedulePopoverProps 
+  = SchedulePopoverBaseProps & Pick<PersonalEventRequest, 'endDateTime' | 'startDateTime'>;

--- a/frontend/src/hooks/useDatePicker/useDatePickerRange.ts
+++ b/frontend/src/hooks/useDatePicker/useDatePickerRange.ts
@@ -1,4 +1,3 @@
-
 import type { HighlightRange } from '@/components/DatePicker/Table/Highlight';
 
 interface UseDatePickerRangeProps {
@@ -21,7 +20,6 @@ export const useDatePickerRange = ({
       start ? trimTime(start) : null,
       end ? trimTime(end) : null,
     ];
-    
     if (!dateStart) {
       setHighlightStart(timeTrimmedDate);
       return;
@@ -31,7 +29,14 @@ export const useDatePickerRange = ({
       else setHighlightEnd(timeTrimmedDate);
       return;
     }
-
+    if (dateStart > timeTrimmedDate) {
+      setHighlightStart(timeTrimmedDate);
+      return;
+    }
+    if (dateEnd < timeTrimmedDate) {
+      setHighlightEnd(timeTrimmedDate);
+      return;
+    }
     setHighlightStart(null);
     setHighlightEnd(null);
   };

--- a/frontend/src/hooks/useFormRef.ts
+++ b/frontend/src/hooks/useFormRef.ts
@@ -8,14 +8,29 @@ export type ChangeEvent<T> = { name: keyof T; value: T[keyof T] };
 export interface FormRef<T> {
   valuesRef: { current: FormValues<T> };
   handleChange: ({ name, value }: ChangeEvent<T>) => void;
+  setValidation: (key: keyof T, validateFn: (value: T[keyof T]) => string | null) => void;
+  handleSubmit: (callback: () => void) => void;
 }
+
+export type Validation<T> = Record<keyof T, <K extends keyof T>(value: T[K]) => string | null>;
 
 export const useFormRef = <T>(initialValues: FormValues<T>): FormRef<T> => {
   const valuesRef = useRef<FormValues<T>>({ ...initialValues });
+  const validationRef = useRef<Validation<T>>({} as Validation<T>);
 
   const handleChange = ({ name, value }: ChangeEvent<T>) => {
     valuesRef.current[name] = value;
   };
 
-  return { valuesRef, handleChange };
+  const setValidation = (key: keyof T, validateFn: (value: T[keyof T]) => string | null) => {
+    validationRef.current[key] = validateFn;
+  };
+
+  const handleSubmit = (callback: () => void) => {
+    const isValid = Object.keys(validationRef.current)
+      .every((key) => !validationRef.current[key as keyof T](valuesRef.current[key as keyof T]));
+    if (isValid) callback();
+  };
+
+  return { valuesRef, handleChange, setValidation, handleSubmit };
 };

--- a/frontend/src/layout/Footer/index.css.ts
+++ b/frontend/src/layout/Footer/index.css.ts
@@ -5,4 +5,6 @@ export const footerContainerStyle = style({
   position: 'fixed',
   bottom: 0,
   left: 0,
+
+  pointerEvents: 'none',
 });

--- a/frontend/src/utils/date/date.ts
+++ b/frontend/src/utils/date/date.ts
@@ -275,7 +275,9 @@ export const isNextWeek = (start: Date, end: Date) => {
   return false;
 };
 
-export const setDateOnly = (baseDate: Date, newDate: Date) => {
+export const setDateOnly = (baseDate: Date, newDate: Date | null) => {
+  if (!newDate) return baseDate;
+
   const updatedDate = new Date(baseDate);
   updatedDate.setFullYear(newDate.getFullYear());
   updatedDate.setMonth(newDate.getMonth());

--- a/frontend/src/utils/date/format.ts
+++ b/frontend/src/utils/date/format.ts
@@ -1,4 +1,5 @@
 import { getDayDiff, getYearMonthDay } from './date';
+import type { Time } from './time';
 import { HOUR_IN_MINUTES } from './time';
 
 /**
@@ -116,4 +117,14 @@ export const formatTimeToDeadlineString = ({ days, hours, minutes }: {
   if (days !== 0) return `${Math.abs(days)}일`;
   if (hours !== 0) return `${Math.abs(hours)}시간`;
   return `${Math.abs(minutes)}분`;
+};
+
+export const formatTimeToString = (time: Time): string => {
+  const { hour, minute } = time;
+  return `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
+};
+
+export const formatTimeToNumber = (time: Time): number => {
+  const { hour, minute } = time;
+  return hour * HOUR_IN_MINUTES + minute;
 };

--- a/frontend/src/utils/date/position.ts
+++ b/frontend/src/utils/date/position.ts
@@ -1,6 +1,6 @@
 import { TIME_HEIGHT } from '@/constants/date';
 
-import { isNextWeek, setDateOnly } from './date';
+import { setDateOnly } from './date';
 
 interface DateRange {
   start: Date;
@@ -40,7 +40,7 @@ export const calcSizeByDate = ({ start, end }: DateRange, selectedWeek: Date[]) 
   const { x: sx, y: sy } = calcPositionByDate(startDate);
   const { x: ex, y: ey } = calcPositionByDate(endDate);
 
-  const dayDiff = isNextWeek(start, end) ? 7 - sx : ex - sx;
+  const dayDiff = ex - sx;
   const height = ey - sy;
 
   return { width: dayDiff + 1, height, x: sx, y: sy };

--- a/frontend/src/utils/date/position.ts
+++ b/frontend/src/utils/date/position.ts
@@ -1,6 +1,6 @@
 import { TIME_HEIGHT } from '@/constants/date';
 
-import { setDateOnly } from './date';
+import { getDateParts, setDateOnly } from './date';
 
 interface DateRange {
   start: Date;
@@ -29,10 +29,11 @@ export const calcPositionByDate = (date: Date | null) => {
  * @returns
  */
 export const calcSizeByDate = ({ start, end }: DateRange, selectedWeek: Date[]) => {
-  const firstDayOfWeek = selectedWeek[0];
-  const lastDayOfWeek = selectedWeek[6];
+  const { year: syear, month: sm, day: sd } = getDateParts(selectedWeek[0]);
+  const { year: eyear, month: em, day: ed } = getDateParts(selectedWeek[6]);
 
-  if (start > lastDayOfWeek || end < firstDayOfWeek) return null;
+  const firstDayOfWeek = new Date(syear, sm, sd, 0, 0, 0);
+  const lastDayOfWeek = new Date(eyear, em, ed, 23, 59, 59);
 
   const startDate = start > firstDayOfWeek ? start : setDateOnly(start, firstDayOfWeek);
   const endDate = end < lastDayOfWeek ? end : setDateOnly(end, lastDayOfWeek);

--- a/frontend/src/utils/date/time.ts
+++ b/frontend/src/utils/date/time.ts
@@ -73,21 +73,11 @@ export interface Time {
 
 export const parseTime = (timeStr: string): Time => {
   const parts = timeStr.trim().split(':');
-  if (parts.length < 2 || parts.length > 3) {
-    throw new Error('parseTime: Invalid time format');
-  }
 
   const [hourStr, minuteStr, secondStr = '0'] = parts;
   const hour = Number(hourStr);
   const minute = Number(minuteStr);
   const second = Number(secondStr);
-
-  if (isNaN(hour) || isNaN(minute) || isNaN(second)) {
-    throw new Error('parseTime: Invalid numeric values in time string');
-  }
-  if (hour < 0 || hour > 23) throw new Error('parseTime: Hour must be between 0 and 23');
-  if (minute < 0 || minute > 59) throw new Error('parseTime: Minute must be between 0 and 59');
-  if (second < 0 || second > 59) throw new Error('parseTime: Second must be between 0 and 59');
 
   return { hour, minute, second };
 };


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>

## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 이제 팝오버에서 일정을 수정할 수 있습니다.
- 조율 중인 일정이 없을 때 문구를 렌더링합니다.
- 일정 시작과 끝이 모두 12시인 경우 다음날로 넘겨서 렌더링하지 않습니다. (ex. 09:00-00:00 일정)
- 긴 일정의 마감 날짜 계산 오류를 수정합니다.

## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Calendar events with zero height are now hidden from view, ensuring a cleaner calendar display.
  - An informative empty state message appears when there are no ongoing discussions.
  - The scheduling popover has been enhanced to allow direct editing of time fields.
  - New validation and submission capabilities have been added to the form handling process.
  - New components for date and time input have been introduced, improving user interaction.
  - A toggle for syncing with Google Calendar has been added for better event management.

- **Bug Fixes**
  - Improved handling of time input when the hour is set to 24, preventing incorrect date transitions.

- **Style**
  - Added a new style for empty text, enhancing the visual feedback when no discussions are available.
  - The footer is now non-interactive, preventing mouse interactions.
  - Increased the width of the scheduling popover container for better layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->