### PR TITLE
[BE-Fix] 토큰 재할당 뒤 적용이 되지 않던 버그 수정

### DIFF
--- a/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
+++ b/backend/src/main/java/endolphin/backend/global/google/GoogleCalendarService.java
@@ -116,7 +116,6 @@ public class GoogleCalendarService {
         String eventUrl = String.format(googleCalendarUrl.updateUrl(),
             personalEvent.getCalendarId(), personalEvent.getGoogleEventId());
         User user = personalEvent.getUser();
-        String token = user.getAccessToken();
 
         GoogleEventRequest body = GoogleEventRequest.of(personalEvent,
             personalEvent.getGoogleEventId());
@@ -125,7 +124,7 @@ public class GoogleCalendarService {
             () -> {
                 restClient.put()
                     .uri(eventUrl)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + user.getAccessToken())
                     .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     .body(body)
                     .exchange((request, response) -> {
@@ -151,13 +150,12 @@ public class GoogleCalendarService {
         String eventUrl = String.format(googleCalendarUrl.updateUrl(),
             personalEvent.getCalendarId(), personalEvent.getGoogleEventId());
         User user = personalEvent.getUser();
-        String token = user.getAccessToken();
 
         retryExecutor.executeCalendarApiWithRetry(
             () -> {
                 restClient.delete()
                     .uri(eventUrl)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + user.getAccessToken())
                     .exchange((request, response) -> {
                         if (response.getStatusCode().is2xxSuccessful()) {
                             return Optional.empty();
@@ -261,13 +259,12 @@ public class GoogleCalendarService {
     }
 
     public GoogleCalendarDto getPrimaryCalendar(User user) {
-        String accessToken = user.getAccessToken();
 
         return retryExecutor.executeCalendarApiWithRetry(
             () -> {
                 GoogleCalendarDto result = restClient.get()
                     .uri(googleCalendarUrl.primaryCalendarUrl())
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + user.getAccessToken())
                     .exchange((request, response) -> {
                         if (response.getStatusCode().is2xxSuccessful()) {
                             return response.bodyTo(GoogleCalendarDto.class);


### PR DESCRIPTION
<!-- 제목 템플릿
[파트명-Feat] [파트명-Refactor] [파트명-Fix] [파트명-Chore] [파트명-Remove]
-->
## #️⃣ 연관된 이슈>
- #308 
## 📝 작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
자바 람다식에서 지역변수를 사용하면 캡쳐 시점의 값으로 고정하기 때문에 token 대신 user.getAccessToken()을 사용해서 변경된 토큰을 사용할 수 있도록 수정
## 🙏 여기는 꼭 봐주세요! > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Optimized the calendar synchronization process for seamless and reliable service, maintaining the same functionality while paving the way for smoother future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->